### PR TITLE
Add jsoniter-derivation with some goodies

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -108,8 +108,11 @@ Common issues when writing cross-compiled macros — one-line summaries below, f
 - **Path-dependent types in `Expr.quote`** — fails on Scala 2; use `LambdaBuilder` or runtime type witness
 - **Macro-internal types leak** — `??`, `Expr_??` inside `Expr.quote` cause reification failures; extract to `val` before quote
 - **`Array` needs `ClassTag`** — use `List` and `::` instead of `Array` in `Expr.quote`
-- **`Expr.upcast` only widens** — use `.asInstanceOf` inside `Expr.quote` for narrowing
+- **`Expr.upcast` only widens** — use `.asInstanceOf` inside `Expr.quote` for narrowing; also needs `Type[A]` in scope for the source type
 - **Macro methods need concrete types** — don't wrap macro calls in generic helpers
+- **Sibling `Expr.splice` isolation (Scala 3)** — each `Expr.splice` in an `Expr.quote` gets its own `Quotes` context; types/exprs can't be shared between sibling splices. For combined codecs, pre-derive with `LambdaBuilder` in one `runSafe` call
+- **`IsMap`/`IsCollection` path-dependent types** — `import isMap.{Key, Value, CtorResult}` before `Expr.quote` to bring `Type` instances into scope
+- **`ValDefsCache` wrapping scope** — `vals.toValDefs.use` must wrap the outermost expression containing all references, not individual sub-expressions
 
 Hearth source is at `../hearth/` when documentation is insufficient. See
 `docs/contributing/hearth-documentation-skill.md` § "Hearth source as reference" for key files.
@@ -130,6 +133,8 @@ When implementing or modifying type class derivation macros, follow:
 Use `FastShowPrettyMacrosImpl.scala` as the reference for **encoder-style** derivation (reading fields).
 Use `circe-derivation/DecoderMacrosImpl.scala` as the reference for **decoder-style** derivation
 (constructing types from decoded data).
+Use `jsoniter-derivation/CodecMacrosImpl.scala` as the reference for **combined codec derivation**
+(encoder + decoder in one type class, `LambdaBuilder` pattern for Scala 3 cross-splice safety).
 
 ### Other guides in `type-class-derivation-skill.md`
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,96 +1,43 @@
 # AGENTS
 
-This file guides coding agents working in this repository.
-
 ## Project Overview
 
-**Kindlings** provides type classes (re)implemented with [Hearth](https://github.com/MateuszKubuszok/hearth/) to kick-off the ecosystem. Each module demonstrates how to use Hearth's macro-agnostic APIs to implement cross-compiled (Scala 2.13 + 3) type class derivation.
+**Kindlings** provides type classes (re)implemented with [Hearth](https://github.com/MateuszKubuszok/hearth/) to kick-off the ecosystem — cross-compiled (Scala 2.13 + 3) type class derivation using Hearth's macro-agnostic APIs.
 
-- **Language**: Scala (pure Scala library)
-- **Scala Versions**: 2.13.18, 3.7.4
-- **Platforms**: JVM, Scala.js, Scala Native
-- **Build Tool**: SBT (but see restrictions below)
-- **License**: Apache 2.0
+- **Scala Versions**: 2.13.18, 3.7.4 | **Platforms**: JVM, Scala.js, Scala Native | **Build Tool**: SBT
 
-## Using MCP for compilation context
+## MCP — Always verify APIs via MCP before using them
 
-This project has Metals MCP available at `.metals/mcp.json` as **`kindlings-metals`**. Use MCP to:
-- Query available definitions, types, and symbols before writing code
-- Validate that APIs you're about to use actually exist (prevents hallucinations)
-- Check compilation errors before running sbt
-
-**Always verify APIs via MCP before using them.** If MCP reports issues with your code, fix them before running sbt to avoid long feedback loops and context pollution.
+Metals MCP at `.metals/mcp.json` (`kindlings-metals`). Query definitions/types/symbols, check compilation errors before running sbt. Fix MCP issues before running sbt to avoid long feedback loops.
 
 ## Global Rules
 
- - **Always use `sbt --client`** — never run bare `sbt` without `--client`. Starting sbt without `--client`
-   launches a new JVM every time, which is extremely expensive and kills the feedback loop. `sbt --client`
-   connects to a running sbt server instead.
-
- - **Redirect sbt output to a temporary file** when running long compilation/test cycles — this avoids
-   re-running the same expensive command just to inspect a different part of the output:
-   ```bash
-   sbt --client "fastShowPretty/clean ; test-jvm-2_13" 2>&1 | tee /tmp/sbt-output.txt
-   ```
-   Then use `grep`, `tail`, `head`, etc. on `/tmp/sbt-output.txt` to inspect results. Only re-run
-   sbt if code was actually modified.
-
- - Only run `sbt compile` or `sbt test` after MCP shows no compilation issues
-
- - **Do not modify `dev.properties`** — it's primarily used by the developer to focus on one platform
-   in their IDE.
-
- - **Do not add yourself as co-author** — when making commits, agents should not add themselves
-   (e.g. `Co-Authored-By: Claude ...`) to commit messages. Only the human author and Happy
-   attribution should appear.
+ - **Always use `sbt --client`** — never bare `sbt`. Connects to running server instead of launching new JVM.
+ - **Redirect sbt output**: `sbt --client "module/clean ; test-jvm-2_13" 2>&1 | tee /tmp/sbt-output.txt`
+   Then inspect with `grep`/`tail`/`head`. Only re-run sbt if code was modified.
+ - Only run `sbt compile`/`sbt test` after MCP shows no compilation issues.
+ - **Do not modify `dev.properties`** — used by the developer for IDE platform focus.
+ - **Do not add yourself as co-author** — no `Co-Authored-By: Claude ...` in commits.
 
 ### Project matrix structure
 
-This project uses **sbt-projectmatrix** (not sbt-crossproject). Scala version is determined by project name suffix, not by `++` commands.
+Uses **sbt-projectmatrix** (not sbt-crossproject). **Do NOT use** `++` version switching or `scalaCrossVersion`.
 
-**Do NOT use:**
-- `++2.13.18`, `++3.7.4` or any `++` version switching
-- `scalaCrossVersion` settings
-- Any cross-building commands from sbt-crossproject
-
-**Project naming convention:**
-- No suffix = Scala 2.13 JVM (e.g., `fastShowPretty`)
-- `3` suffix = Scala 3 JVM (e.g., `fastShowPretty3`)
-- `JS` suffix = Scala 2.13 JS (e.g., `fastShowPrettyJS`)
-- `JS3` suffix = Scala 3 JS (e.g., `fastShowPrettyJS3`)
-- `Native` suffix = Scala 2.13 Native (e.g., `fastShowPrettyNative`)
-- `Native3` suffix = Scala 3 Native (e.g., `fastShowPrettyNative3`)
+**Naming**: no suffix = Scala 2.13 JVM, `3` = Scala 3 JVM, `JS`/`JS3` = Scala.js, `Native`/`Native3` = Scala Native.
+Example: `fastShowPretty` (2.13 JVM), `fastShowPretty3` (3 JVM), `fastShowPrettyJS3` (3 JS).
 
 ### Test aliases
 
-| Command | What it does |
-|---|---|
-| `sbt --client test-jvm-2_13` | Test Scala 2.13 on JVM |
-| `sbt --client test-jvm-3` | Test Scala 3 on JVM |
-| `sbt --client test-js-3` | Test Scala 3 on Scala.js |
-| `sbt --client test-js-2_13` | Test Scala 2.13 on Scala.js |
-| `sbt --client test-native-3` | Test Scala 3 on Scala Native |
-| `sbt --client test-native-2_13` | Test Scala 2.13 on Scala Native |
+| `test-jvm-2_13` | `test-jvm-3` | `test-js-2_13` | `test-js-3` | `test-native-2_13` | `test-native-3` |
+|---|---|---|---|---|---|
 
-**JVM-only by default** — unless debugging a platform-specific failure, run tests only on JVM
-platforms (`test-jvm-2_13`, `test-jvm-3`). JS and Native builds are slow and the sbt server
-can run out of memory on Native builds. CI covers all platforms.
+**JVM-only by default** — JS/Native are slow (Native can OOM). CI covers all platforms.
 
 ## Incremental Compilation Gotchas
 
- - **Always clean after macro changes** — incremental compilation does NOT re-expand macros when their
-   implementation changes. You WILL get stale results if you skip cleaning.
-
- - **Clean the specific module before testing:**
-   ```bash
-   sbt --client "fastShowPretty/clean ; fastShowPretty3/clean ; test-jvm-2_13 ; test-jvm-3"
-   ```
-
- - **Nuclear option** (if behavior seems wrong despite clean):
-   ```bash
-   sbt --client clean
-   sbt --client "test-jvm-2_13 ; test-jvm-3"
-   ```
+ - **Always clean after macro changes** — incremental compilation does NOT re-expand macros.
+ - Clean specific module: `sbt --client "module/clean ; module3/clean ; test-jvm-2_13 ; test-jvm-3"`
+ - Nuclear option: `sbt --client clean` then `sbt --client "test-jvm-2_13 ; test-jvm-3"`
 
 ## Cross-Quotes and Macro-Agnostic APIs
 
@@ -102,20 +49,19 @@ Code uses `Expr`, `Type`, etc. from **Hearth's API**, NOT `scala.quoted.Expr` or
 
 ## Cross-Compilation Pitfalls
 
-Common issues when writing cross-compiled macros — one-line summaries below, full details in
-`docs/contributing/type-class-derivation-skill.md` § "Cross-compilation pitfalls":
+Full details in `docs/contributing/type-class-derivation-skill.md` § "Cross-compilation pitfalls":
 
 - **Path-dependent types in `Expr.quote`** — fails on Scala 2; use `LambdaBuilder` or runtime type witness
 - **Macro-internal types leak** — `??`, `Expr_??` inside `Expr.quote` cause reification failures; extract to `val` before quote
 - **`Array` needs `ClassTag`** — use `List` and `::` instead of `Array` in `Expr.quote`
-- **`Expr.upcast` only widens** — use `.asInstanceOf` inside `Expr.quote` for narrowing; also needs `Type[A]` in scope for the source type
+- **`Expr.upcast` only widens** — use `.asInstanceOf` inside `Expr.quote` for narrowing; also needs `Type[A]` in scope
 - **Macro methods need concrete types** — don't wrap macro calls in generic helpers
-- **Sibling `Expr.splice` isolation (Scala 3)** — each `Expr.splice` in an `Expr.quote` gets its own `Quotes` context; types/exprs can't be shared between sibling splices. For combined codecs, pre-derive with `LambdaBuilder` in one `runSafe` call
-- **`IsMap`/`IsCollection` path-dependent types** — `import isMap.{Key, Value, CtorResult}` before `Expr.quote` to bring `Type` instances into scope
-- **`ValDefsCache` wrapping scope** — `vals.toValDefs.use` must wrap the outermost expression containing all references, not individual sub-expressions
+- **Sibling `Expr.splice` isolation (Scala 3)** — each splice gets its own `Quotes`; pre-derive with `LambdaBuilder` in one `runSafe` call
+- **`IsMap`/`IsCollection` path-dependent types** — `import isMap.{Key, Value, CtorResult}` before `Expr.quote`
+- **`ValDefsCache` wrapping scope** — `vals.toValDefs.use` must wrap the outermost expression containing all references
 
-Hearth source is at `../hearth/` when documentation is insufficient. See
-`docs/contributing/hearth-documentation-skill.md` § "Hearth source as reference" for key files.
+Hearth source is at `../hearth/` when documentation is insufficient.
+See `docs/contributing/hearth-documentation-skill.md` § "Hearth source as reference" for key files.
 
 ## Hearth documentation and API reference
 
@@ -125,29 +71,21 @@ Hearth source is at `../hearth/` when documentation is insufficient. See
 
 ## Skills routing
 
-### Type class derivation
+### Type class derivation — follow `docs/contributing/type-class-derivation-skill.md`
 
-When implementing or modifying type class derivation macros, follow:
-**`docs/contributing/type-class-derivation-skill.md`**
+- `FastShowPrettyMacrosImpl.scala` — reference for **encoder-style** derivation (reading fields)
+- `circe-derivation/DecoderMacrosImpl.scala` — reference for **decoder-style** derivation (constructing types)
+- `jsoniter-derivation/CodecMacrosImpl.scala` — reference for **combined codec** (encoder + decoder, `LambdaBuilder` pattern)
 
-Use `FastShowPrettyMacrosImpl.scala` as the reference for **encoder-style** derivation (reading fields).
-Use `circe-derivation/DecoderMacrosImpl.scala` as the reference for **decoder-style** derivation
-(constructing types from decoded data).
-Use `jsoniter-derivation/CodecMacrosImpl.scala` as the reference for **combined codec derivation**
-(encoder + decoder in one type class, `LambdaBuilder` pattern for Scala 3 cross-splice safety).
-
-### Other guides in `type-class-derivation-skill.md`
-
-- **"Implementing a new module"** — build config, 3-layer file structure, testing patterns
-- **"Debugging derivation"** — debug logger import and scalac option for compile-time logs
-- **"Syncing from Hearth"** — adaptation checklist for syncing from hearth's demo modules
+Also in `type-class-derivation-skill.md`: "Implementing a new module", "Debugging derivation", "Syncing from Hearth".
 
 ### Fixing a bug
 
-1. Write a failing test that reproduces the bug
-2. Clean the affected modules (incremental compilation does not re-expand macros)
-3. Verify the test fails as expected
-4. Apply the fix in the appropriate layer (runtime utils, macro impl, or bridge)
-5. Clean again and verify all tests pass
-6. Cross-platform verification (if relevant): `sbt --client "test-js-3 ; test-native-3"`
+1. Write a failing test reproducing the bug
+2. Clean affected modules (incremental compilation does not re-expand macros)
+3. Verify the test fails, apply fix, clean again, verify all tests pass
+4. Cross-platform if relevant: `sbt --client "test-js-3 ; test-native-3"`
 
+### Finishing work in a worktree
+
+When done with a worktree, suggest `sbt --client shutdown` to free memory — each worktree gets its own SBT server that persists after the worktree is removed.

--- a/build.sbt
+++ b/build.sbt
@@ -26,7 +26,7 @@ val versions = new {
   // Dependencies.
   val circe = "0.14.15"
   val hearth = "0.2.0-229-g36ee579-SNAPSHOT"
-  val jsoniterScala = "2.30.2"
+  val jsoniterScala = "2.38.9"
   val kindProjector = "0.13.4"
   val munit = "1.2.1"
   val scalacheck = "1.19.0"

--- a/docs/contributing/hearth-api-knowledge.md
+++ b/docs/contributing/hearth-api-knowledge.md
@@ -58,15 +58,24 @@ Living cache of hearth API signatures used in kindlings. **Always verify with `k
 | API | Signature | Description |
 |-----|-----------|-------------|
 | `LambdaBuilder.of1[A]` | `(name: String): LambdaBuilder1[A]` | 1-arg lambda builder |
+| `LambdaBuilder.of2[A, B]` | `(name1: String, name2: String): LambdaBuilder2[A, B]` | 2-arg lambda builder |
+| `LambdaBuilder.of3[A, B, C]` | `(name1: String, name2: String, name3: String): LambdaBuilder3[A, B, C]` | 3-arg lambda builder |
 | `builder.traverse` | `(f: Expr[A] => MIO[Expr[B]]): MIO[Built1[A, B]]` | Build with MIO body |
 | `builder.buildWith` | `(f: Expr[A] => Expr[B]): Expr[A => B]` | Build with pure body |
 | `built.build[B]` | `: Expr[A => B]` | Finalize lambda |
 | `ValDefBuilder.ofLazy[T]` | `(name: String): ValDefBuilder` | `lazy val` builder |
 | `ValDefBuilder.ofDef1[A, B]` | `(name: String, argName: String): ValDefBuilder` | `def` with 1 arg |
+| `ValDefBuilder.ofDef2[A, B, C]` | `(name: String, argName1: String, argName2: String): ValDefBuilder` | `def` with 2 args |
+| `ValDefBuilder.ofDef3[A, B, C, D]` | `(name: String, a1: String, a2: String, a3: String): ValDefBuilder` | `def` with 3 args |
 | `ValDefsCache.mlocal` | `: MLocal[ValDefsCache]` | Create cache storage |
 | `cache.get0Ary[T]` | `(key: String): MIO[Option[Expr[T]]]` | Get cached value |
 | `cache.get1Ary[A, B]` | `(key: String): MIO[Option[Expr[A] => Expr[B]]]` | Get cached function |
+| `cache.get2Ary[A, B, C]` | `(key: String): MIO[Option[(Expr[A], Expr[B]) => Expr[C]]]` | Get cached 2-arg function |
+| `cache.get3Ary[A, B, C, D]` | `(key: String): MIO[Option[(Expr[A], Expr[B], Expr[C]) => Expr[D]]]` | Get cached 3-arg function |
 | `cache.buildCachedWith` | `(key: String, builder: ValDefBuilder)(body: ...): MIO[...]` | Build and cache |
+| `cache.forwardDeclare` | `(key: String, builder: ValDefBuilder): MIO[Unit]` | Forward-declare for recursion |
+| `cache.get` | `: MIO[ValDefsCache]` | Extract accumulated cached defs |
+| `vals.toValDefs.use` | `(f: ... => Expr[A]): Expr[A]` | Wrap expr in cached val defs block |
 
 ## Data model introspection
 
@@ -105,6 +114,9 @@ Living cache of hearth API signatures used in kindlings. **Always verify with `k
 | Path-dependent types in `Expr.quote` | `import param.tpe.Underlying as F; Expr.quote { x.asInstanceOf[F] }` fails on Scala 2 | Use `LambdaBuilder.of1[F]` or runtime type witness |
 | Macro-internal types leak | `??`, `Expr_??` inside `Expr.quote` causes reification failures on Scala 2 | Extract to `val` before `Expr.quote` |
 | `Array` needs `ClassTag` | `Array.empty[T]` inside `Expr.quote` fails on Scala 2 | Use `List.empty[T]` and `::` |
-| `upcast` only widens | `expr.upcast[B]` requires `A <:< B` | Use `.asInstanceOf` for narrowing |
+| `upcast` only widens | `expr.upcast[B]` requires `A <:< B`; also needs `Type[A]` in scope | Use `.asInstanceOf` for narrowing |
 | Raw quotes in `LambdaBuilder` | `'{ }` captures wrong `Quotes` on Scala 3 | Use `Expr.quote`/`Expr.splice` |
 | Generic macro wrapper | `def helper[A](v: A)` calling macro sees abstract `A` | Call macros with concrete types |
+| Sibling splice isolation | Each `Expr.splice` in an `Expr.quote` gets its own `Quotes` context on Scala 3; types/exprs can't be shared between sibling splices | Derive everything in one `runSafe`, use `LambdaBuilder` to package as function `Expr`s, then splice references only |
+| `IsMap`/`IsCollection` types need import | `isMap.Key`, `isMap.Value`, `isMap.CtorResult` need `Type` in scope | `import isMap.{Key, Value, CtorResult}` before `Expr.quote` |
+| `toValDefs.use` wrapping scope | Wrapping individual lambdas with all cached defs causes unused-method warnings | Wrap the outermost expression that contains all references |

--- a/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecCompanionCompat.scala
+++ b/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecCompanionCompat.scala
@@ -1,6 +1,6 @@
 package hearth.kindlings.jsoniterderivation
 
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReaderException, JsonValueCodec}
 import scala.language.experimental.macros
 
 private[jsoniterderivation] trait KindlingsJsonValueCodecCompanionCompat {
@@ -11,4 +11,10 @@ private[jsoniterderivation] trait KindlingsJsonValueCodecCompanionCompat {
 
   implicit def derived[A](implicit config: JsoniterConfig): KindlingsJsonValueCodec[A] =
     macro internal.compiletime.CodecMacros.deriveKindlingsCodecImpl[A]
+
+  def writeToString[A](value: A)(implicit config: JsoniterConfig): String =
+    macro internal.compiletime.CodecMacros.deriveInlineWriteToStringImpl[A]
+
+  def readFromString[A](json: String)(implicit config: JsoniterConfig): Either[JsonReaderException, A] =
+    macro internal.compiletime.CodecMacros.deriveInlineReadFromStringImpl[A]
 }

--- a/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecCompanionCompat.scala
+++ b/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecCompanionCompat.scala
@@ -1,0 +1,14 @@
+package hearth.kindlings.jsoniterderivation
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import scala.language.experimental.macros
+
+private[jsoniterderivation] trait KindlingsJsonValueCodecCompanionCompat {
+  this: KindlingsJsonValueCodec.type =>
+
+  def derive[A](implicit config: JsoniterConfig): JsonValueCodec[A] =
+    macro internal.compiletime.CodecMacros.deriveCodecImpl[A]
+
+  implicit def derived[A](implicit config: JsoniterConfig): KindlingsJsonValueCodec[A] =
+    macro internal.compiletime.CodecMacros.deriveKindlingsCodecImpl[A]
+}

--- a/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacros.scala
+++ b/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacros.scala
@@ -1,0 +1,19 @@
+package hearth.kindlings.jsoniterderivation
+package internal.compiletime
+
+import hearth.MacroCommonsScala2
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import scala.reflect.macros.blackbox
+
+final private[jsoniterderivation] class CodecMacros(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with CodecMacrosImpl {
+
+  def deriveCodecImpl[A: c.WeakTypeTag](
+      config: c.Expr[JsoniterConfig]
+  ): c.Expr[JsonValueCodec[A]] = deriveCodecTypeClass[A](config).asInstanceOf[c.Expr[JsonValueCodec[A]]]
+
+  def deriveKindlingsCodecImpl[A: c.WeakTypeTag](
+      config: c.Expr[JsoniterConfig]
+  ): c.Expr[KindlingsJsonValueCodec[A]] = deriveCodecTypeClass[A](config)
+}

--- a/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacros.scala
+++ b/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacros.scala
@@ -2,7 +2,7 @@ package hearth.kindlings.jsoniterderivation
 package internal.compiletime
 
 import hearth.MacroCommonsScala2
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReaderException, JsonValueCodec}
 import scala.reflect.macros.blackbox
 
 final private[jsoniterderivation] class CodecMacros(val c: blackbox.Context)
@@ -16,4 +16,36 @@ final private[jsoniterderivation] class CodecMacros(val c: blackbox.Context)
   def deriveKindlingsCodecImpl[A: c.WeakTypeTag](
       config: c.Expr[JsoniterConfig]
   ): c.Expr[KindlingsJsonValueCodec[A]] = deriveCodecTypeClass[A](config)
+
+  def deriveInlineWriteToStringImpl[A: c.WeakTypeTag](
+      value: c.Expr[A]
+  )(config: c.Expr[JsoniterConfig]): c.Expr[String] =
+    deriveInlineWriteToString[A](value, config)
+
+  def deriveInlineReadFromStringImpl[A: c.WeakTypeTag](
+      json: c.Expr[String]
+  )(config: c.Expr[JsoniterConfig]): c.Expr[Either[JsonReaderException, A]] =
+    deriveInlineReadFromString[A](json, config)
+
+  @scala.annotation.nowarn("msg=unchecked")
+  def deriveInlineWriteToStringOpsImpl[A: c.WeakTypeTag](
+      config: c.Expr[JsoniterConfig]
+  ): c.Expr[String] = {
+    val value = c.Expr[A](c.prefix.tree match {
+      case c.universe.Apply(_, List(arg)) => arg
+      case other                          => c.abort(c.enclosingPosition, s"Unexpected prefix: $other")
+    })
+    deriveInlineWriteToString[A](value, config)
+  }
+
+  @scala.annotation.nowarn("msg=unchecked")
+  def deriveInlineReadFromStringOpsImpl[A: c.WeakTypeTag](
+      config: c.Expr[JsoniterConfig]
+  ): c.Expr[Either[JsonReaderException, A]] = {
+    val json = c.Expr[String](c.prefix.tree match {
+      case c.universe.Apply(_, List(arg)) => arg
+      case other                          => c.abort(c.enclosingPosition, s"Unexpected prefix: $other")
+    })
+    deriveInlineReadFromString[A](json, config)
+  }
 }

--- a/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/syntax.scala
+++ b/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/syntax.scala
@@ -1,0 +1,17 @@
+package hearth.kindlings.jsoniterderivation
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
+import scala.language.experimental.macros
+
+object syntax {
+
+  implicit class JsoniterWriteOps[A](private val value: A) extends AnyVal {
+    def toJsonString(implicit config: JsoniterConfig): String =
+      macro internal.compiletime.CodecMacros.deriveInlineWriteToStringOpsImpl[A]
+  }
+
+  implicit class JsoniterReadOps(private val json: String) extends AnyVal {
+    def fromJsonString[A](implicit config: JsoniterConfig): Either[JsonReaderException, A] =
+      macro internal.compiletime.CodecMacros.deriveInlineReadFromStringOpsImpl[A]
+  }
+}

--- a/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecCompanionCompat.scala
+++ b/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecCompanionCompat.scala
@@ -1,0 +1,15 @@
+package hearth.kindlings.jsoniterderivation
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+
+private[jsoniterderivation] trait KindlingsJsonValueCodecCompanionCompat {
+  this: KindlingsJsonValueCodec.type =>
+
+  inline def derive[A](using config: JsoniterConfig): JsonValueCodec[A] = ${
+    internal.compiletime.CodecMacros.deriveCodecImpl[A]('config)
+  }
+
+  inline given derived[A](using config: JsoniterConfig): KindlingsJsonValueCodec[A] = ${
+    internal.compiletime.CodecMacros.deriveKindlingsCodecImpl[A]('config)
+  }
+}

--- a/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecCompanionCompat.scala
+++ b/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecCompanionCompat.scala
@@ -1,6 +1,6 @@
 package hearth.kindlings.jsoniterderivation
 
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReaderException, JsonValueCodec}
 
 private[jsoniterderivation] trait KindlingsJsonValueCodecCompanionCompat {
   this: KindlingsJsonValueCodec.type =>
@@ -11,5 +11,13 @@ private[jsoniterderivation] trait KindlingsJsonValueCodecCompanionCompat {
 
   inline given derived[A](using config: JsoniterConfig): KindlingsJsonValueCodec[A] = ${
     internal.compiletime.CodecMacros.deriveKindlingsCodecImpl[A]('config)
+  }
+
+  inline def writeToString[A](inline value: A)(using config: JsoniterConfig): String = ${
+    internal.compiletime.CodecMacros.deriveInlineWriteToStringImpl[A]('value, 'config)
+  }
+
+  inline def readFromString[A](json: String)(using config: JsoniterConfig): Either[JsonReaderException, A] = ${
+    internal.compiletime.CodecMacros.deriveInlineReadFromStringImpl[A]('json, 'config)
   }
 }

--- a/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacros.scala
+++ b/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacros.scala
@@ -2,7 +2,7 @@ package hearth.kindlings.jsoniterderivation
 package internal.compiletime
 
 import hearth.MacroCommonsScala3
-import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReaderException, JsonValueCodec}
 import scala.quoted.*
 
 final private[jsoniterderivation] class CodecMacros(q: Quotes) extends MacroCommonsScala3(using q), CodecMacrosImpl
@@ -17,4 +17,16 @@ private[jsoniterderivation] object CodecMacros {
       config: Expr[JsoniterConfig]
   )(using q: Quotes): Expr[KindlingsJsonValueCodec[A]] =
     new CodecMacros(q).deriveCodecTypeClass[A](config)
+
+  def deriveInlineWriteToStringImpl[A: Type](
+      value: Expr[A],
+      config: Expr[JsoniterConfig]
+  )(using q: Quotes): Expr[String] =
+    new CodecMacros(q).deriveInlineWriteToString[A](value, config)
+
+  def deriveInlineReadFromStringImpl[A: Type](
+      json: Expr[String],
+      config: Expr[JsoniterConfig]
+  )(using q: Quotes): Expr[Either[JsonReaderException, A]] =
+    new CodecMacros(q).deriveInlineReadFromString[A](json, config)
 }

--- a/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacros.scala
+++ b/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacros.scala
@@ -1,0 +1,20 @@
+package hearth.kindlings.jsoniterderivation
+package internal.compiletime
+
+import hearth.MacroCommonsScala3
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+import scala.quoted.*
+
+final private[jsoniterderivation] class CodecMacros(q: Quotes) extends MacroCommonsScala3(using q), CodecMacrosImpl
+private[jsoniterderivation] object CodecMacros {
+
+  def deriveCodecImpl[A: Type](
+      config: Expr[JsoniterConfig]
+  )(using q: Quotes): Expr[JsonValueCodec[A]] =
+    new CodecMacros(q).deriveCodecTypeClass[A](config)
+
+  def deriveKindlingsCodecImpl[A: Type](
+      config: Expr[JsoniterConfig]
+  )(using q: Quotes): Expr[KindlingsJsonValueCodec[A]] =
+    new CodecMacros(q).deriveCodecTypeClass[A](config)
+}

--- a/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/syntax.scala
+++ b/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/syntax.scala
@@ -1,0 +1,18 @@
+package hearth.kindlings.jsoniterderivation
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException
+
+object syntax {
+
+  extension [A](value: A) {
+    inline def toJsonString(using config: JsoniterConfig): String = ${
+      internal.compiletime.CodecMacros.deriveInlineWriteToStringImpl[A]('value, 'config)
+    }
+  }
+
+  extension (json: String) {
+    inline def fromJsonString[A](using config: JsoniterConfig): Either[JsonReaderException, A] = ${
+      internal.compiletime.CodecMacros.deriveInlineReadFromStringImpl[A]('json, 'config)
+    }
+  }
+}

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/JsonValueCodecExtensions.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/JsonValueCodecExtensions.scala
@@ -1,0 +1,40 @@
+package hearth.kindlings.jsoniterderivation
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonValueCodec, JsonWriter}
+
+object JsonValueCodecExtensions {
+
+  implicit class JsonValueCodecOps[A](private val codec: JsonValueCodec[A]) extends AnyVal {
+
+    def map[B](f: A => B)(g: B => A): JsonValueCodec[B] =
+      new JsonValueCodec[B] {
+        val nullValue: B = {
+          val a = codec.nullValue
+          if (a == null) null.asInstanceOf[B] else f(a)
+        }
+        def decodeValue(in: JsonReader, default: B): B = f(codec.decodeValue(in, codec.nullValue))
+        def encodeValue(x: B, out: JsonWriter): Unit = codec.encodeValue(g(x), out)
+      }
+
+    def mapDecode[B](f: A => Either[String, B])(g: B => A): JsonValueCodec[B] =
+      new JsonValueCodec[B] {
+        val nullValue: B = {
+          val a = codec.nullValue
+          if (a == null) null.asInstanceOf[B]
+          else
+            f(a) match {
+              case Right(b) => b
+              case Left(_)  => null.asInstanceOf[B]
+            }
+        }
+        def decodeValue(in: JsonReader, default: B): B = {
+          val a = codec.decodeValue(in, codec.nullValue)
+          f(a) match {
+            case Right(b)  => b
+            case Left(msg) => in.decodeError(msg)
+          }
+        }
+        def encodeValue(x: B, out: JsonWriter): Unit = codec.encodeValue(g(x), out)
+      }
+  }
+}

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/JsoniterConfig.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/JsoniterConfig.scala
@@ -1,0 +1,74 @@
+package hearth.kindlings.jsoniterderivation
+
+final case class JsoniterConfig(
+    fieldNameMapper: String => String = identity,
+    adtLeafClassNameMapper: String => String = identity,
+    discriminatorFieldName: Option[String] = None,
+    skipUnexpectedFields: Boolean = true
+) {
+
+  def withFieldNameMapper(f: String => String): JsoniterConfig = copy(fieldNameMapper = f)
+  def withAdtLeafClassNameMapper(f: String => String): JsoniterConfig = copy(adtLeafClassNameMapper = f)
+  def withSnakeCaseFieldNames: JsoniterConfig = copy(fieldNameMapper = JsoniterConfig.snakeCase)
+  def withKebabCaseFieldNames: JsoniterConfig = copy(fieldNameMapper = JsoniterConfig.kebabCase)
+  def withPascalCaseFieldNames: JsoniterConfig = copy(fieldNameMapper = JsoniterConfig.pascalCase)
+  def withScreamingSnakeCaseFieldNames: JsoniterConfig =
+    copy(fieldNameMapper = JsoniterConfig.screamingSnakeCase)
+  def withSnakeCaseAdtLeafClassNames: JsoniterConfig =
+    copy(adtLeafClassNameMapper = JsoniterConfig.snakeCase)
+  def withKebabCaseAdtLeafClassNames: JsoniterConfig =
+    copy(adtLeafClassNameMapper = JsoniterConfig.kebabCase)
+  def withDiscriminator(field: String): JsoniterConfig = copy(discriminatorFieldName = Some(field))
+  def withSkipUnexpectedFields(skip: Boolean): JsoniterConfig = copy(skipUnexpectedFields = skip)
+}
+object JsoniterConfig {
+
+  implicit val default: JsoniterConfig = JsoniterConfig()
+
+  private[jsoniterderivation] val snakeCase: String => String = { s =>
+    val sb = new StringBuilder
+    var i = 0
+    while (i < s.length) {
+      val c = s.charAt(i)
+      if (c.isUpper) {
+        if (i > 0) sb.append('_')
+        sb.append(c.toLower)
+      } else sb.append(c)
+      i += 1
+    }
+    sb.toString
+  }
+
+  private[jsoniterderivation] val kebabCase: String => String = { s =>
+    val sb = new StringBuilder
+    var i = 0
+    while (i < s.length) {
+      val c = s.charAt(i)
+      if (c.isUpper) {
+        if (i > 0) sb.append('-')
+        sb.append(c.toLower)
+      } else sb.append(c)
+      i += 1
+    }
+    sb.toString
+  }
+
+  private[jsoniterderivation] val pascalCase: String => String = { s =>
+    if (s.isEmpty) s
+    else s.charAt(0).toUpper.toString + s.substring(1)
+  }
+
+  private[jsoniterderivation] val screamingSnakeCase: String => String = { s =>
+    val sb = new StringBuilder
+    var i = 0
+    while (i < s.length) {
+      val c = s.charAt(i)
+      if (c.isUpper) {
+        if (i > 0) sb.append('_')
+        sb.append(c)
+      } else sb.append(c.toUpper)
+      i += 1
+    }
+    sb.toString
+  }
+}

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodec.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodec.scala
@@ -1,0 +1,15 @@
+package hearth.kindlings.jsoniterderivation
+
+import com.github.plokhotnyuk.jsoniter_scala.core.JsonValueCodec
+
+trait KindlingsJsonValueCodec[A] extends JsonValueCodec[A]
+object KindlingsJsonValueCodec extends KindlingsJsonValueCodecCompanionCompat {
+
+  /** Special type - if its implicit is in scope then macros will log the derivation process.
+    *
+    * @see
+    *   [[hearth.kindlings.jsoniterderivation.debug.logDerivationForKindlingsJsonValueCodec]] for details
+    */
+  sealed trait LogDerivation
+  object LogDerivation extends LogDerivation
+}

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/debug/package.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/debug/package.scala
@@ -1,0 +1,13 @@
+package hearth.kindlings.jsoniterderivation
+
+// $COVERAGE-OFF$
+package object debug {
+
+  /** Import [[KindlingsJsonValueCodec.LogDerivation]] in the scope to preview how the codec derivation is done.
+    *
+    * Put outside of [[KindlingsJsonValueCodec]] companion to prevent the implicit from being summoned automatically!
+    */
+  implicit val logDerivationForKindlingsJsonValueCodec: KindlingsJsonValueCodec.LogDerivation =
+    KindlingsJsonValueCodec.LogDerivation
+}
+// $COVERAGE-ON$

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -1,0 +1,1572 @@
+package hearth.kindlings.jsoniterderivation.internal.compiletime
+
+import hearth.MacroCommons
+import hearth.fp.data.NonEmptyList
+import hearth.fp.effect.*
+import hearth.fp.syntax.*
+import hearth.std.*
+
+import hearth.kindlings.jsoniterderivation.{JsoniterConfig, KindlingsJsonValueCodec}
+import hearth.kindlings.jsoniterderivation.internal.runtime.JsoniterDerivationUtils
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonValueCodec, JsonWriter}
+
+trait CodecMacrosImpl { this: MacroCommons & StdExtensions =>
+
+  // Entrypoints
+
+  /** Derive a combined JsonValueCodec for type A.
+    *
+    * To avoid Scala 3 cross-splice staging issues, all derivation (encode, decode, nullValue) is performed in a single
+    * MIO.scoped/runSafe call using LambdaBuilder. The resulting function expressions are then spliced into the final
+    * Expr.quote without creating new expressions inside sibling splices.
+    */
+  @scala.annotation.nowarn("msg=is never used")
+  def deriveCodecTypeClass[A: Type](configExpr: Expr[JsoniterConfig]): Expr[KindlingsJsonValueCodec[A]] = {
+    implicit val CodecA: Type[JsonValueCodec[A]] = CTypes.JsonValueCodec[A]
+    implicit val KindlingsCodecA: Type[KindlingsJsonValueCodec[A]] = CTypes.KindlingsJsonValueCodec[A]
+    implicit val ConfigT: Type[JsoniterConfig] = CTypes.JsoniterConfig
+    implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+    implicit val JsonWriterT: Type[JsonWriter] = CTypes.JsonWriter
+    implicit val UnitT: Type[Unit] = CTypes.Unit
+
+    deriveCodecFromCtxAndAdaptForEntrypoint[A, KindlingsJsonValueCodec[A]]("KindlingsJsonValueCodec.derived") {
+      case (encodeFnExpr, decodeFnExpr, nullValueExpr) =>
+        Expr.quote {
+          new KindlingsJsonValueCodec[A] {
+            private val _encode = Expr.splice(encodeFnExpr)
+            private val _decode = Expr.splice(decodeFnExpr)
+            def nullValue: A = Expr.splice(nullValueExpr)
+            def decodeValue(in: JsonReader, default: A): A = {
+              val _ = default
+              _decode(in, Expr.splice(configExpr))
+            }
+            def encodeValue(x: A, out: JsonWriter): Unit = _encode(x, out, Expr.splice(configExpr))
+          }
+        }
+    }
+  }
+
+  // Handles logging, error reporting and prepending "cached" defs and vals to the result.
+
+  def deriveCodecFromCtxAndAdaptForEntrypoint[A: Type, Out: Type](macroName: String)(
+      provideCtxAndAdapt: (
+          Expr[(A, JsonWriter, JsoniterConfig) => Unit],
+          Expr[(JsonReader, JsoniterConfig) => A],
+          Expr[A]
+      ) => Expr[Out]
+  ): Expr[Out] = Log
+    .namedScope(
+      s"Deriving codec for ${Type[A].prettyPrint} at: ${Environment.currentPosition.prettyPrint}"
+    ) {
+      implicit val ConfigT: Type[JsoniterConfig] = CTypes.JsoniterConfig
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+      implicit val JsonWriterT: Type[JsonWriter] = CTypes.JsonWriter
+      implicit val UnitT: Type[Unit] = CTypes.Unit
+
+      // All derivation in a single MIO.scoped / runSafe to avoid cross-splice issues in Scala 3.
+      // The cross-quotes plugin gives each Expr.splice within an Expr.quote its own nested Quotes
+      // context. Expressions created in one splice can't be used in a sibling splice.
+      // By deriving encode, decode, and nullValue as pre-built Expr values in a single runSafe call,
+      // we ensure no expressions leak between splices in the final Expr.quote.
+      MIO.scoped { runSafe =>
+        val cache = ValDefsCache.mlocal
+        val selfType: Option[??] = Some(Type[A].as_??)
+
+        val (encLambdaRaw, decLambdaRaw, nullValueExpr, vals) = runSafe {
+          for {
+            _ <- Environment.loadStandardExtensions().toMIO(allowFailures = false)
+
+            // Derive encoder as (A, JsonWriter, JsoniterConfig) => Unit via LambdaBuilder
+            encLambdaRaw <- LambdaBuilder
+              .of3[A, JsonWriter, JsoniterConfig]("value", "writer", "config")
+              .traverse { case (valueExpr, writerExpr, cfgExpr) =>
+                deriveEncoderRecursively[A](using EncoderCtx.from(valueExpr, writerExpr, cfgExpr, cache, selfType))
+              }
+              .map(_.build[Unit])
+
+            // Derive decoder as (JsonReader, JsoniterConfig) => A via LambdaBuilder
+            decLambdaRaw <- LambdaBuilder
+              .of2[JsonReader, JsoniterConfig]("reader", "config")
+              .traverse { case (readerExpr, cfgExpr) =>
+                deriveDecoderRecursively[A](using DecoderCtx.from(readerExpr, cfgExpr, cache, selfType))
+              }
+              .map(_.build[A])
+
+            // Derive null value
+            nullVal <- deriveNullValue[A]
+
+            // Extract all cached val defs (encoder + decoder share the same cache,
+            // using different keys: "cached-encode-method" vs "cached-decode-method")
+            vals <- cache.get
+          } yield (encLambdaRaw, decLambdaRaw, nullVal, vals)
+        }
+
+        // Wrap cached val defs around the entire result expression, so both lambdas
+        // share the same definitions without duplication or unused-method warnings.
+        val resultExpr = provideCtxAndAdapt(encLambdaRaw, decLambdaRaw, nullValueExpr)
+        vals.toValDefs.use(_ => resultExpr)
+      }
+    }
+    .flatTap { result =>
+      Log.info(s"Derived final codec result: ${result.prettyPrint}")
+    }
+    .runToExprOrFail(
+      macroName,
+      infoRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
+      errorRendering = RenderFrom(Log.Level.Info)
+    ) { (errorLogs, errors) =>
+      val errorsRendered = errors
+        .map { e =>
+          e.getMessage.split("\n").toList match {
+            case head :: tail => (("  - " + head) :: tail.map("    " + _)).mkString("\n")
+            case _            => "  - " + e.getMessage
+          }
+        }
+        .mkString("\n")
+      val hint =
+        "Enable debug logging with: import hearth.kindlings.jsoniterderivation.debug.logDerivationForKindlingsJsonValueCodec or scalac option -Xmacro-settings:jsoniterDerivation.logDerivation=true"
+      if (errorLogs.nonEmpty)
+        s"""Macro derivation failed with the following errors:
+           |$errorsRendered
+           |and the following logs:
+           |$errorLogs
+           |$hint""".stripMargin
+      else
+        s"""Macro derivation failed with the following errors:
+           |$errorsRendered
+           |$hint""".stripMargin
+    }
+
+  def shouldWeLogCodecDerivation: Boolean = {
+    implicit val LogDerivation: Type[KindlingsJsonValueCodec.LogDerivation] = CTypes.CodecLogDerivation
+    def logDerivationImported = Expr.summonImplicit[KindlingsJsonValueCodec.LogDerivation].isDefined
+
+    def logDerivationSetGlobally = (for {
+      data <- Environment.typedSettings.toOption
+      jsoniterDerivation <- data.get("jsoniterDerivation")
+      shouldLog <- jsoniterDerivation.get("logDerivation").flatMap(_.asBoolean)
+    } yield shouldLog).getOrElse(false)
+
+    logDerivationImported || logDerivationSetGlobally
+  }
+
+  // Null value derivation
+
+  @scala.annotation.nowarn("msg=is never used")
+  def deriveNullValue[A: Type]: MIO[Expr[A]] = MIO.pure {
+    if (Type[A] <:< Type.of[AnyRef]) Expr.quote(null.asInstanceOf[A])
+    else if (Type[A] =:= Type.of[Boolean]) Expr.quote(false.asInstanceOf[A])
+    else if (Type[A] =:= Type.of[Byte]) Expr.quote(0.toByte.asInstanceOf[A])
+    else if (Type[A] =:= Type.of[Short]) Expr.quote(0.toShort.asInstanceOf[A])
+    else if (Type[A] =:= Type.of[Int]) Expr.quote(0.asInstanceOf[A])
+    else if (Type[A] =:= Type.of[Long]) Expr.quote(0L.asInstanceOf[A])
+    else if (Type[A] =:= Type.of[Float]) Expr.quote(0.0f.asInstanceOf[A])
+    else if (Type[A] =:= Type.of[Double]) Expr.quote(0.0.asInstanceOf[A])
+    else if (Type[A] =:= Type.of[Char]) Expr.quote('\u0000'.asInstanceOf[A])
+    else Expr.quote(null.asInstanceOf[A])
+  }
+
+  // Encoder Context
+
+  final case class EncoderCtx[A](
+      tpe: Type[A],
+      value: Expr[A],
+      writer: Expr[JsonWriter],
+      config: Expr[JsoniterConfig],
+      cache: MLocal[ValDefsCache],
+      derivedType: Option[??]
+  ) {
+
+    def nest[B: Type](newValue: Expr[B]): EncoderCtx[B] = copy[B](
+      tpe = Type[B],
+      value = newValue
+    )
+
+    def nestInCache(
+        newValue: Expr[A],
+        newWriter: Expr[JsonWriter],
+        newConfig: Expr[JsoniterConfig]
+    ): EncoderCtx[A] = copy(
+      value = newValue,
+      writer = newWriter,
+      config = newConfig
+    )
+
+    def getInstance[B: Type]: MIO[Option[Expr[JsonValueCodec[B]]]] = {
+      implicit val CodecB: Type[JsonValueCodec[B]] = CTypes.JsonValueCodec[B]
+      cache.get0Ary[JsonValueCodec[B]]("cached-codec-instance")
+    }
+    def setInstance[B: Type](instance: Expr[JsonValueCodec[B]]): MIO[Unit] = {
+      implicit val CodecB: Type[JsonValueCodec[B]] = CTypes.JsonValueCodec[B]
+      cache.buildCachedWith(
+        "cached-codec-instance",
+        ValDefBuilder.ofLazy[JsonValueCodec[B]](s"codec_${Type[B].shortName}")
+      )(_ => instance)
+    }
+
+    def getHelper[B: Type]: MIO[Option[(Expr[B], Expr[JsonWriter], Expr[JsoniterConfig]) => Expr[Unit]]] = {
+      implicit val UnitT: Type[Unit] = CTypes.Unit
+      implicit val JsonWriterT: Type[JsonWriter] = CTypes.JsonWriter
+      implicit val ConfigT: Type[JsoniterConfig] = CTypes.JsoniterConfig
+      cache.get3Ary[B, JsonWriter, JsoniterConfig, Unit]("cached-encode-method")
+    }
+    def setHelper[B: Type](
+        helper: (Expr[B], Expr[JsonWriter], Expr[JsoniterConfig]) => MIO[Expr[Unit]]
+    ): MIO[Unit] = {
+      implicit val UnitT: Type[Unit] = CTypes.Unit
+      implicit val JsonWriterT: Type[JsonWriter] = CTypes.JsonWriter
+      implicit val ConfigT: Type[JsoniterConfig] = CTypes.JsoniterConfig
+      val defBuilder =
+        ValDefBuilder.ofDef3[B, JsonWriter, JsoniterConfig, Unit](s"encode_${Type[B].shortName}")
+      for {
+        _ <- cache.forwardDeclare("cached-encode-method", defBuilder)
+        _ <- MIO.scoped { runSafe =>
+          runSafe(cache.buildCachedWith("cached-encode-method", defBuilder) { case (_, (value, writer, config)) =>
+            runSafe(helper(value, writer, config))
+          })
+        }
+      } yield ()
+    }
+
+    override def toString: String =
+      s"encode[${tpe.prettyPrint}](value = ${value.prettyPrint}, writer = ${writer.prettyPrint}, config = ${config.prettyPrint})"
+  }
+  object EncoderCtx {
+
+    def from[A: Type](
+        value: Expr[A],
+        writer: Expr[JsonWriter],
+        config: Expr[JsoniterConfig],
+        cache: MLocal[ValDefsCache],
+        derivedType: Option[??]
+    ): EncoderCtx[A] = EncoderCtx(
+      tpe = Type[A],
+      value = value,
+      writer = writer,
+      config = config,
+      cache = cache,
+      derivedType = derivedType
+    )
+  }
+
+  def ectx[A](implicit A: EncoderCtx[A]): EncoderCtx[A] = A
+
+  implicit def currentEncoderValueType[A: EncoderCtx]: Type[A] = ectx.tpe
+
+  abstract class EncoderDerivationRule(val name: String) extends Rule {
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]]
+  }
+
+  // Encoder derivation
+
+  def deriveEncoderRecursively[A: EncoderCtx]: MIO[Expr[Unit]] =
+    Log
+      .namedScope(s"Deriving encoder for type ${Type[A].prettyPrint}") {
+        Rules(
+          EncUseCachedDefWhenAvailableRule,
+          EncUseImplicitWhenAvailableRule,
+          EncHandleAsBuiltInRule,
+          EncHandleAsValueTypeRule,
+          EncHandleAsOptionRule,
+          EncHandleAsMapRule,
+          EncHandleAsCollectionRule,
+          EncHandleAsCaseClassRule,
+          EncHandleAsEnumRule
+        )(_[A]).flatMap {
+          case Right(result) =>
+            Log.info(s"Derived encoder for ${Type[A].prettyPrint}: ${result.prettyPrint}") >>
+              MIO.pure(result)
+          case Left(reasons) =>
+            val reasonsStrings = reasons.toListMap
+              .removed(EncUseCachedDefWhenAvailableRule)
+              .view
+              .map { case (rule, reasons) =>
+                if (reasons.isEmpty) s"The rule ${rule.name} was not applicable"
+                else
+                  s" - The rule ${rule.name} was not applicable, for the following reasons: ${reasons.mkString(", ")}"
+              }
+              .toList
+            Log.info(s"Failed to derive encoder for ${Type[A].prettyPrint}:\n${reasonsStrings.mkString("\n")}") >>
+              MIO.fail(CodecDerivationError.UnsupportedType(Type[A].prettyPrint, reasonsStrings))
+        }
+      }
+
+  // Encoder Rules
+
+  object EncUseCachedDefWhenAvailableRule extends EncoderDerivationRule("use cached def when available") {
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to use cached encoder for ${Type[A].prettyPrint}") >>
+        ectx.getInstance[A].flatMap {
+          case Some(instance) => callCachedInstance[A](instance)
+          case None           =>
+            ectx.getHelper[A].flatMap {
+              case Some(helperCall) => callCachedHelper[A](helperCall)
+              case None             => yieldUnsupported[A]
+            }
+        }
+
+    private def callCachedInstance[A: EncoderCtx](
+        instance: Expr[JsonValueCodec[A]]
+    ): MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Found cached codec instance for ${Type[A].prettyPrint}") >> MIO.pure(Rule.matched(Expr.quote {
+        Expr.splice(instance).encodeValue(Expr.splice(ectx.value), Expr.splice(ectx.writer))
+      }))
+
+    private def callCachedHelper[A: EncoderCtx](
+        helperCall: (Expr[A], Expr[JsonWriter], Expr[JsoniterConfig]) => Expr[Unit]
+    ): MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Found cached encoder helper for ${Type[A].prettyPrint}") >> MIO.pure(
+        Rule.matched(helperCall(ectx.value, ectx.writer, ectx.config))
+      )
+
+    private def yieldUnsupported[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} does not have a cached encoder"))
+  }
+
+  object EncUseImplicitWhenAvailableRule extends EncoderDerivationRule("use implicit when available") {
+
+    lazy val ignoredImplicits: Seq[UntypedMethod] = {
+      val ours = Type.of[KindlingsJsonValueCodec.type].methods.collect {
+        case method if method.value.name == "derived" => method.value.asUntyped
+      }
+      ours
+    }
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to use implicit JsonValueCodec for ${Type[A].prettyPrint}") >> {
+        if (ectx.derivedType.exists(_.Underlying =:= Type[A]))
+          MIO.pure(
+            Rule.yielded(s"The type ${Type[A].prettyPrint} is the type being derived, skipping implicit search")
+          )
+        else
+          CTypes.JsonValueCodec[A].summonExprIgnoring(ignoredImplicits*).toEither match {
+            case Right(instanceExpr) => cacheAndUse[A](instanceExpr)
+            case Left(reason)        => yieldUnsupported[A](reason)
+          }
+      }
+
+    private def cacheAndUse[A: EncoderCtx](
+        instanceExpr: Expr[JsonValueCodec[A]]
+    ): MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Found implicit codec ${instanceExpr.prettyPrint}, using directly") >>
+        MIO.pure(Rule.matched(Expr.quote {
+          Expr.splice(instanceExpr).encodeValue(Expr.splice(ectx.value), Expr.splice(ectx.writer))
+        }))
+
+    private def yieldUnsupported[A: EncoderCtx](reason: String): MIO[Rule.Applicability[Expr[Unit]]] =
+      MIO.pure(
+        Rule.yielded(
+          s"The type ${Type[A].prettyPrint} does not have an implicit JsonValueCodec instance: $reason"
+        )
+      )
+  }
+
+  @scala.annotation.nowarn("msg=is never used")
+  object EncHandleAsBuiltInRule extends EncoderDerivationRule("handle as built-in type") {
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a built-in type") >> {
+        val writer = ectx.writer
+        val value = ectx.value
+
+        val result: Option[Expr[Unit]] =
+          if (Type[A] =:= Type.of[Int])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[Int])))
+          else if (Type[A] =:= Type.of[Long])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[Long])))
+          else if (Type[A] =:= Type.of[Double])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[Double])))
+          else if (Type[A] =:= Type.of[Float])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[Float])))
+          else if (Type[A] =:= Type.of[Boolean])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[Boolean])))
+          else if (Type[A] =:= Type.of[String])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[String])))
+          else if (Type[A] =:= Type.of[Byte])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[Byte])))
+          else if (Type[A] =:= Type.of[Short])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[Short])))
+          else if (Type[A] =:= Type.of[Char])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[Char].toString)))
+          else if (Type[A] =:= Type.of[BigDecimal])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[BigDecimal])))
+          else if (Type[A] =:= Type.of[BigInt])
+            Some(Expr.quote(Expr.splice(writer).writeVal(Expr.splice(value).asInstanceOf[BigInt])))
+          else
+            None
+
+        MIO.pure(result match {
+          case Some(expr) => Rule.matched(expr)
+          case None       => Rule.yielded(s"The type ${Type[A].prettyPrint} is not a built-in type")
+        })
+      }
+  }
+
+  object EncHandleAsValueTypeRule extends EncoderDerivationRule("handle as value type when possible") {
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
+        Type[A] match {
+          case IsValueType(isValueType) =>
+            import isValueType.Underlying as Inner
+            val unwrappedExpr = isValueType.value.unwrap(ectx.value)
+            for {
+              innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
+            } yield Rule.matched(innerResult)
+
+          case _ =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+        }
+      }
+  }
+
+  object EncHandleAsOptionRule extends EncoderDerivationRule("handle as Option when possible") {
+    implicit val UnitT: Type[Unit] = CTypes.Unit
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as Option") >> {
+        Type[A] match {
+          case IsOption(isOption) =>
+            import isOption.Underlying as Inner
+            LambdaBuilder
+              .of1[Inner]("inner")
+              .traverse { innerExpr =>
+                deriveEncoderRecursively[Inner](using ectx.nest(innerExpr))
+              }
+              .map { builder =>
+                val lambda = builder.build[Unit]
+                Rule.matched(
+                  isOption.value.fold[Unit](ectx.value)(
+                    onEmpty = Expr.quote(Expr.splice(ectx.writer).writeNull()),
+                    onSome = innerExpr =>
+                      Expr.quote {
+                        Expr.splice(lambda).apply(Expr.splice(innerExpr))
+                      }
+                  )
+                )
+              }
+
+          case _ =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not an Option"))
+        }
+      }
+  }
+
+  @scala.annotation.nowarn("msg=Infinite loop")
+  object EncHandleAsMapRule extends EncoderDerivationRule("handle as map when possible") {
+    implicit val UnitT: Type[Unit] = CTypes.Unit
+    implicit val StringT: Type[String] = CTypes.String
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a map") >> {
+        Type[A] match {
+          case IsMap(isMap) =>
+            import isMap.Underlying as Pair
+            deriveMapEntries[A, Pair](isMap.value)
+
+          case _ =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a map"))
+        }
+      }
+
+    private def deriveMapEntries[A: EncoderCtx, Pair: Type](
+        isMap: IsMapOf[A, Pair]
+    ): MIO[Rule.Applicability[Expr[Unit]]] = {
+      import isMap.{Key, Value}
+      if (!(Key <:< Type[String]))
+        MIO.pure(Rule.yielded(s"Map key type ${Key.prettyPrint} is not String"))
+      else {
+        LambdaBuilder
+          .of1[Value]("mapValue")
+          .traverse { valueExpr =>
+            deriveEncoderRecursively[Value](using ectx.nest(valueExpr))
+          }
+          .map { builder =>
+            val valueLambda = builder.build[Unit]
+            val iterableExpr = isMap.asIterable(ectx.value)
+            Rule.matched(Expr.quote {
+              JsoniterDerivationUtils.writeMapStringKeyed[Value](
+                Expr.splice(ectx.writer),
+                Expr.splice(iterableExpr).asInstanceOf[Iterable[(String, Value)]],
+                Expr.splice(valueLambda)
+              )
+            })
+          }
+      }
+    }
+  }
+
+  object EncHandleAsCollectionRule extends EncoderDerivationRule("handle as collection when possible") {
+    implicit val UnitT: Type[Unit] = CTypes.Unit
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+        Type[A] match {
+          case IsCollection(isCollection) =>
+            import isCollection.Underlying as Item
+            LambdaBuilder
+              .of1[Item]("item")
+              .traverse { itemExpr =>
+                deriveEncoderRecursively[Item](using ectx.nest(itemExpr))
+              }
+              .map { builder =>
+                val lambda = builder.build[Unit]
+                val iterableExpr = isCollection.value.asIterable(ectx.value)
+                Rule.matched(Expr.quote {
+                  JsoniterDerivationUtils.writeArray[Item](
+                    Expr.splice(ectx.writer),
+                    Expr.splice(iterableExpr),
+                    Expr.splice(lambda)
+                  )
+                })
+              }
+
+          case _ =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+        }
+      }
+  }
+
+  object EncHandleAsCaseClassRule extends EncoderDerivationRule("handle as case class when possible") {
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a case class") >> {
+        CaseClass.parse[A] match {
+          case Some(caseClass) =>
+            for {
+              _ <- ectx.setHelper[A] { (value, writer, config) =>
+                encodeCaseClassFields[A](caseClass)(using ectx.nestInCache(value, writer, config))
+              }
+              result <- ectx.getHelper[A].flatMap {
+                case Some(helperCall) => MIO.pure(Rule.matched(helperCall(ectx.value, ectx.writer, ectx.config)))
+                case None             => MIO.pure(Rule.yielded(s"Failed to build helper for ${Type[A].prettyPrint}"))
+              }
+            } yield result
+
+          case None =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a case class"))
+        }
+      }
+
+    /** Encode only the key-value field pairs (no writeObjectStart/writeObjectEnd). */
+    @scala.annotation.nowarn("msg=is never used")
+    private[compiletime] def encodeCaseClassFieldsOnly[A: EncoderCtx](
+        caseClass: CaseClass[A]
+    ): MIO[Expr[Unit]] = {
+      implicit val StringT: Type[String] = CTypes.String
+      implicit val JsonWriterT: Type[JsonWriter] = CTypes.JsonWriter
+      implicit val UnitT: Type[Unit] = CTypes.Unit
+
+      val fields = caseClass.caseFieldValuesAt(ectx.value).toList
+
+      NonEmptyList.fromList(fields) match {
+        case Some(nonEmptyFields) =>
+          nonEmptyFields
+            .parTraverse { case (fieldName, fieldValue) =>
+              import fieldValue.{Underlying as Field, value as fieldExpr}
+              Log.namedScope(s"Encoding field ${ectx.value.prettyPrint}.$fieldName: ${Type[Field].prettyPrint}") {
+                deriveEncoderRecursively[Field](using ectx.nest(fieldExpr)).map { fieldEnc =>
+                  (fieldName, fieldEnc)
+                }
+              }
+            }
+            .map { fieldPairs =>
+              fieldPairs.toList
+                .map { case (fieldName, fieldEnc) =>
+                  Expr.quote {
+                    Expr
+                      .splice(ectx.writer)
+                      .writeKey(Expr.splice(ectx.config).fieldNameMapper(Expr.splice(Expr(fieldName))))
+                    Expr.splice(fieldEnc)
+                  }
+                }
+                .foldLeft(Expr.quote(()): Expr[Unit]) { (acc, field) =>
+                  Expr.quote {
+                    Expr.splice(acc)
+                    Expr.splice(field)
+                  }
+                }
+            }
+
+        case None =>
+          MIO.pure(Expr.quote(()): Expr[Unit])
+      }
+    }
+
+    /** Encode a full JSON object: writeObjectStart + fields + writeObjectEnd. */
+    @scala.annotation.nowarn("msg=is never used")
+    private def encodeCaseClassFields[A: EncoderCtx](
+        caseClass: CaseClass[A]
+    ): MIO[Expr[Unit]] =
+      encodeCaseClassFieldsOnly(caseClass).map { fieldsExpr =>
+        Expr.quote {
+          Expr.splice(ectx.writer).writeObjectStart()
+          Expr.splice(fieldsExpr)
+          Expr.splice(ectx.writer).writeObjectEnd()
+        }
+      }
+  }
+
+  object EncHandleAsEnumRule extends EncoderDerivationRule("handle as enum when possible") {
+
+    def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as an enum") >> {
+        Enum.parse[A] match {
+          case Some(enumm) =>
+            for {
+              _ <- ectx.setHelper[A] { (value, writer, config) =>
+                encodeEnumCases[A](enumm)(using ectx.nestInCache(value, writer, config))
+              }
+              result <- ectx.getHelper[A].flatMap {
+                case Some(helperCall) => MIO.pure(Rule.matched(helperCall(ectx.value, ectx.writer, ectx.config)))
+                case None             => MIO.pure(Rule.yielded(s"Failed to build helper for ${Type[A].prettyPrint}"))
+              }
+            } yield result
+          case None =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not an enum"))
+        }
+      }
+
+    @scala.annotation.nowarn("msg=is never used")
+    private def encodeEnumCases[A: EncoderCtx](
+        enumm: Enum[A]
+    ): MIO[Expr[Unit]] = {
+      implicit val UnitT: Type[Unit] = CTypes.Unit
+      implicit val JsonWriterT: Type[JsonWriter] = CTypes.JsonWriter
+      implicit val StringT: Type[String] = CTypes.String
+
+      enumm
+        .parMatchOn[MIO, Unit](ectx.value) { matched =>
+          import matched.{value as enumCaseValue, Underlying as EnumCase}
+          Log.namedScope(s"Encoding enum case ${enumCaseValue.prettyPrint}: ${EnumCase.prettyPrint}") {
+            val caseName = Type[EnumCase].shortName
+
+            // For discriminator mode, we need fields-only encoding to avoid double wrapping.
+            // Parse child as case class to get field-level access.
+            val fieldsOnlyMIO: MIO[Expr[Unit]] = CaseClass.parse[EnumCase] match {
+              case Some(caseClass) =>
+                EncHandleAsCaseClassRule.encodeCaseClassFieldsOnly[EnumCase](caseClass)(using ectx.nest(enumCaseValue))
+              case None =>
+                // Not a case class (e.g. case object) — no fields
+                MIO.pure(Expr.quote(()): Expr[Unit])
+            }
+
+            // Also derive the full encoding for wrapper mode
+            val fullEncMIO: MIO[Expr[Unit]] =
+              deriveEncoderRecursively[EnumCase](using ectx.nest(enumCaseValue))
+
+            for {
+              fieldsOnly <- fieldsOnlyMIO
+              fullEnc <- fullEncMIO
+            } yield Expr.quote {
+              val name = Expr.splice(ectx.config).adtLeafClassNameMapper(Expr.splice(Expr(caseName)))
+              Expr.splice(ectx.config).discriminatorFieldName match {
+                case Some(discriminatorField) =>
+                  Expr.splice(ectx.writer).writeObjectStart()
+                  Expr.splice(ectx.writer).writeKey(discriminatorField)
+                  Expr.splice(ectx.writer).writeVal(name)
+                  Expr.splice(fieldsOnly)
+                  Expr.splice(ectx.writer).writeObjectEnd()
+                case None =>
+                  JsoniterDerivationUtils.writeWrapped(Expr.splice(ectx.writer), name) {
+                    Expr.splice(fullEnc)
+                  }
+              }
+            }
+          }
+        }
+        .flatMap {
+          case Some(result) => MIO.pure(result)
+          case None         =>
+            MIO.fail(new RuntimeException(s"The type ${Type[A].prettyPrint} does not have any children!"))
+        }
+    }
+  }
+
+  // Decoder Context
+
+  final case class DecoderCtx[A](
+      tpe: Type[A],
+      reader: Expr[JsonReader],
+      config: Expr[JsoniterConfig],
+      cache: MLocal[ValDefsCache],
+      derivedType: Option[??]
+  ) {
+
+    def nest[B: Type](newReader: Expr[JsonReader]): DecoderCtx[B] = copy[B](
+      tpe = Type[B],
+      reader = newReader
+    )
+
+    def nestInCache(
+        newReader: Expr[JsonReader],
+        newConfig: Expr[JsoniterConfig]
+    ): DecoderCtx[A] = copy(
+      reader = newReader,
+      config = newConfig
+    )
+
+    def getInstance[B: Type]: MIO[Option[Expr[JsonValueCodec[B]]]] = {
+      implicit val CodecB: Type[JsonValueCodec[B]] = CTypes.JsonValueCodec[B]
+      cache.get0Ary[JsonValueCodec[B]]("cached-codec-instance")
+    }
+    def setInstance[B: Type](instance: Expr[JsonValueCodec[B]]): MIO[Unit] = {
+      implicit val CodecB: Type[JsonValueCodec[B]] = CTypes.JsonValueCodec[B]
+      cache.buildCachedWith(
+        "cached-codec-instance",
+        ValDefBuilder.ofLazy[JsonValueCodec[B]](s"codec_${Type[B].shortName}")
+      )(_ => instance)
+    }
+
+    def getHelper[B: Type]: MIO[Option[(Expr[JsonReader], Expr[JsoniterConfig]) => Expr[B]]] = {
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+      implicit val ConfigT: Type[JsoniterConfig] = CTypes.JsoniterConfig
+      cache.get2Ary[JsonReader, JsoniterConfig, B]("cached-decode-method")
+    }
+    def setHelper[B: Type](
+        helper: (Expr[JsonReader], Expr[JsoniterConfig]) => MIO[Expr[B]]
+    ): MIO[Unit] = {
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+      implicit val ConfigT: Type[JsoniterConfig] = CTypes.JsoniterConfig
+      val defBuilder =
+        ValDefBuilder.ofDef2[JsonReader, JsoniterConfig, B](s"decode_${Type[B].shortName}")
+      for {
+        _ <- cache.forwardDeclare("cached-decode-method", defBuilder)
+        _ <- MIO.scoped { runSafe =>
+          runSafe(cache.buildCachedWith("cached-decode-method", defBuilder) { case (_, (reader, config)) =>
+            runSafe(helper(reader, config))
+          })
+        }
+      } yield ()
+    }
+
+    override def toString: String =
+      s"decode[${tpe.prettyPrint}](reader = ${reader.prettyPrint}, config = ${config.prettyPrint})"
+  }
+  object DecoderCtx {
+
+    def from[A: Type](
+        reader: Expr[JsonReader],
+        config: Expr[JsoniterConfig],
+        cache: MLocal[ValDefsCache],
+        derivedType: Option[??]
+    ): DecoderCtx[A] = DecoderCtx(
+      tpe = Type[A],
+      reader = reader,
+      config = config,
+      cache = cache,
+      derivedType = derivedType
+    )
+  }
+
+  def dctx[A](implicit A: DecoderCtx[A]): DecoderCtx[A] = A
+
+  implicit def currentDecoderValueType[A: DecoderCtx]: Type[A] = dctx.tpe
+
+  abstract class DecoderDerivationRule(val name: String) extends Rule {
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]]
+  }
+
+  // Decoder derivation
+
+  def deriveDecoderRecursively[A: DecoderCtx]: MIO[Expr[A]] =
+    Log
+      .namedScope(s"Deriving decoder for type ${Type[A].prettyPrint}") {
+        Rules(
+          DecUseCachedDefWhenAvailableRule,
+          DecUseImplicitWhenAvailableRule,
+          DecHandleAsBuiltInRule,
+          DecHandleAsValueTypeRule,
+          DecHandleAsOptionRule,
+          DecHandleAsMapRule,
+          DecHandleAsCollectionRule,
+          DecHandleAsCaseClassRule,
+          DecHandleAsEnumRule
+        )(_[A]).flatMap {
+          case Right(result) =>
+            Log.info(s"Derived decoder for ${Type[A].prettyPrint}: ${result.prettyPrint}") >>
+              MIO.pure(result)
+          case Left(reasons) =>
+            val reasonsStrings = reasons.toListMap
+              .removed(DecUseCachedDefWhenAvailableRule)
+              .view
+              .map { case (rule, reasons) =>
+                if (reasons.isEmpty) s"The rule ${rule.name} was not applicable"
+                else
+                  s" - The rule ${rule.name} was not applicable, for the following reasons: ${reasons.mkString(", ")}"
+              }
+              .toList
+            Log.info(s"Failed to derive decoder for ${Type[A].prettyPrint}:\n${reasonsStrings.mkString("\n")}") >>
+              MIO.fail(CodecDerivationError.UnsupportedType(Type[A].prettyPrint, reasonsStrings))
+        }
+      }
+
+  // Decoder Rules
+
+  object DecUseCachedDefWhenAvailableRule extends DecoderDerivationRule("use cached def when available") {
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to use cached decoder for ${Type[A].prettyPrint}") >>
+        dctx.getInstance[A].flatMap {
+          case Some(instance) => callCachedInstance[A](instance)
+          case None           =>
+            dctx.getHelper[A].flatMap {
+              case Some(helperCall) => callCachedHelper[A](helperCall)
+              case None             => yieldUnsupported[A]
+            }
+        }
+
+    private def callCachedInstance[A: DecoderCtx](
+        instance: Expr[JsonValueCodec[A]]
+    ): MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Found cached codec instance for ${Type[A].prettyPrint}") >> MIO.pure(
+        Rule.matched(Expr.quote {
+          Expr.splice(instance).decodeValue(Expr.splice(dctx.reader), Expr.splice(instance).nullValue)
+        })
+      )
+
+    private def callCachedHelper[A: DecoderCtx](
+        helperCall: (Expr[JsonReader], Expr[JsoniterConfig]) => Expr[A]
+    ): MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Found cached decoder helper for ${Type[A].prettyPrint}") >> MIO.pure(
+        Rule.matched(helperCall(dctx.reader, dctx.config))
+      )
+
+    private def yieldUnsupported[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} does not have a cached decoder"))
+  }
+
+  object DecUseImplicitWhenAvailableRule extends DecoderDerivationRule("use implicit when available") {
+
+    lazy val ignoredImplicits: Seq[UntypedMethod] = {
+      val ours = Type.of[KindlingsJsonValueCodec.type].methods.collect {
+        case method if method.value.name == "derived" => method.value.asUntyped
+      }
+      ours
+    }
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to use implicit JsonValueCodec for ${Type[A].prettyPrint}") >> {
+        if (dctx.derivedType.exists(_.Underlying =:= Type[A]))
+          MIO.pure(
+            Rule.yielded(s"The type ${Type[A].prettyPrint} is the type being derived, skipping implicit search")
+          )
+        else
+          CTypes.JsonValueCodec[A].summonExprIgnoring(ignoredImplicits*).toEither match {
+            case Right(instanceExpr) => cacheAndUse[A](instanceExpr)
+            case Left(reason)        => yieldUnsupported[A](reason)
+          }
+      }
+
+    private def cacheAndUse[A: DecoderCtx](
+        instanceExpr: Expr[JsonValueCodec[A]]
+    ): MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Found implicit codec ${instanceExpr.prettyPrint}, using directly") >>
+        MIO.pure(Rule.matched(Expr.quote {
+          Expr.splice(instanceExpr).decodeValue(Expr.splice(dctx.reader), Expr.splice(instanceExpr).nullValue)
+        }))
+
+    private def yieldUnsupported[A: DecoderCtx](
+        reason: String
+    ): MIO[Rule.Applicability[Expr[A]]] =
+      MIO.pure(
+        Rule.yielded(
+          s"The type ${Type[A].prettyPrint} does not have an implicit JsonValueCodec instance: $reason"
+        )
+      )
+  }
+
+  @scala.annotation.nowarn("msg=is never used")
+  object DecHandleAsBuiltInRule extends DecoderDerivationRule("handle as built-in type") {
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a built-in type") >> {
+        val reader = dctx.reader
+
+        val result: Option[Expr[A]] =
+          if (Type[A] =:= Type.of[Int])
+            Some(Expr.quote(Expr.splice(reader).readInt().asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[Long])
+            Some(Expr.quote(Expr.splice(reader).readLong().asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[Double])
+            Some(Expr.quote(Expr.splice(reader).readDouble().asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[Float])
+            Some(Expr.quote(Expr.splice(reader).readFloat().asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[Boolean])
+            Some(Expr.quote(Expr.splice(reader).readBoolean().asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[String])
+            Some(Expr.quote(Expr.splice(reader).readString(null).asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[Byte])
+            Some(Expr.quote(Expr.splice(reader).readByte().asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[Short])
+            Some(Expr.quote(Expr.splice(reader).readShort().asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[Char])
+            Some(Expr.quote(Expr.splice(reader).readChar().asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[BigDecimal])
+            Some(Expr.quote(Expr.splice(reader).readBigDecimal(null).asInstanceOf[A]))
+          else if (Type[A] =:= Type.of[BigInt])
+            Some(Expr.quote(Expr.splice(reader).readBigInt(null).asInstanceOf[A]))
+          else
+            None
+
+        MIO.pure(result match {
+          case Some(expr) => Rule.matched(expr)
+          case None       => Rule.yielded(s"The type ${Type[A].prettyPrint} is not a built-in type")
+        })
+      }
+  }
+
+  object DecHandleAsValueTypeRule extends DecoderDerivationRule("handle as value type when possible") {
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
+        Type[A] match {
+          case IsValueType(isValueType) =>
+            import isValueType.Underlying as Inner
+
+            // Build wrap lambda outside quotes to avoid staging issues with wrap.Result type
+            LambdaBuilder
+              .of1[Inner]("inner")
+              .traverse { innerExpr =>
+                MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
+              }
+              .flatMap { builder =>
+                val wrapLambda = builder.build[A]
+                // Try implicit first, fall back to recursive derivation (includes built-in types)
+                CTypes
+                  .JsonValueCodec[Inner]
+                  .summonExprIgnoring(DecUseImplicitWhenAvailableRule.ignoredImplicits*)
+                  .toEither match {
+                  case Right(innerCodec) =>
+                    MIO.pure(Rule.matched(Expr.quote {
+                      Expr
+                        .splice(wrapLambda)
+                        .apply(
+                          Expr
+                            .splice(innerCodec)
+                            .decodeValue(Expr.splice(dctx.reader), Expr.splice(innerCodec).nullValue)
+                        )
+                    }))
+                  case Left(_) =>
+                    // No implicit — derive via recursive rules (includes built-in types)
+                    deriveDecoderRecursively[Inner](using dctx.nest[Inner](dctx.reader)).map { innerDecoded =>
+                      Rule.matched(Expr.quote {
+                        Expr.splice(wrapLambda).apply(Expr.splice(innerDecoded))
+                      })
+                    }
+                }
+              }
+
+          case _ =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+        }
+      }
+  }
+
+  object DecHandleAsOptionRule extends DecoderDerivationRule("handle as Option when possible") {
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as Option") >> {
+        Type[A] match {
+          case IsOption(isOption) =>
+            import isOption.Underlying as Inner
+            implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+
+            LambdaBuilder
+              .of1[JsonReader]("innerReader")
+              .traverse { innerReaderExpr =>
+                deriveDecoderRecursively[Inner](using dctx.nest[Inner](innerReaderExpr))
+              }
+              .map { builder =>
+                val decodeFn = builder.build[Inner]
+                Rule.matched(Expr.quote {
+                  JsoniterDerivationUtils
+                    .readOption(Expr.splice(dctx.reader))(Expr.splice(decodeFn))
+                    .asInstanceOf[A]
+                })
+              }
+
+          case _ =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not an Option"))
+        }
+      }
+  }
+
+  @scala.annotation.nowarn("msg=Infinite loop")
+  object DecHandleAsMapRule extends DecoderDerivationRule("handle as map when possible") {
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a map") >> {
+        Type[A] match {
+          case IsMap(isMap) =>
+            import isMap.Underlying as Pair
+            decodeMapEntries[A, Pair](isMap.value)
+          case _ =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a map"))
+        }
+      }
+
+    private def decodeMapEntries[A: DecoderCtx, Pair: Type](
+        isMap: IsMapOf[A, Pair]
+    ): MIO[Rule.Applicability[Expr[A]]] = {
+      import isMap.{Key, Value, CtorResult}
+      implicit val StringT: Type[String] = CTypes.String
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+
+      if (!(Key <:< Type[String]))
+        MIO.pure(Rule.yielded(s"Map key type ${Key.prettyPrint} is not String"))
+      else {
+        LambdaBuilder
+          .of1[JsonReader]("valueReader")
+          .traverse { valueReaderExpr =>
+            deriveDecoderRecursively[Value](using dctx.nest[Value](valueReaderExpr))
+          }
+          .map { builder =>
+            val decodeFn = builder.build[Value]
+            val factoryExpr = isMap.factory
+            Rule.matched(Expr.quote {
+              JsoniterDerivationUtils
+                .readMap[Value, A](
+                  Expr.splice(dctx.reader),
+                  Expr.splice(decodeFn),
+                  Expr.splice(factoryExpr).asInstanceOf[scala.collection.Factory[(String, Value), A]]
+                )
+                .asInstanceOf[A]
+            })
+          }
+      }
+    }
+  }
+
+  object DecHandleAsCollectionRule extends DecoderDerivationRule("handle as collection when possible") {
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+        Type[A] match {
+          case IsCollection(isCollection) =>
+            import isCollection.Underlying as Item
+            import isCollection.value.CtorResult
+            implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+
+            LambdaBuilder
+              .of1[JsonReader]("itemReader")
+              .traverse { itemReaderExpr =>
+                deriveDecoderRecursively[Item](using dctx.nest[Item](itemReaderExpr))
+              }
+              .map { builder =>
+                val decodeFn = builder.build[Item]
+                val factoryExpr = isCollection.value.factory
+                Rule.matched(Expr.quote {
+                  JsoniterDerivationUtils
+                    .readCollection[Item, A](
+                      Expr.splice(dctx.reader),
+                      Expr.splice(decodeFn),
+                      Expr.splice(factoryExpr).asInstanceOf[scala.collection.Factory[Item, A]]
+                    )
+                    .asInstanceOf[A]
+                })
+              }
+
+          case _ =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+        }
+      }
+  }
+
+  object DecHandleAsCaseClassRule extends DecoderDerivationRule("handle as case class when possible") {
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a case class") >> {
+        CaseClass.parse[A] match {
+          case Some(caseClass) =>
+            for {
+              _ <- dctx.setHelper[A] { (reader, config) =>
+                decodeCaseClassFields[A](caseClass)(using dctx.nestInCache(reader, config))
+              }
+              result <- dctx.getHelper[A].flatMap {
+                case Some(helperCall) =>
+                  MIO.pure(Rule.matched(helperCall(dctx.reader, dctx.config)))
+                case None =>
+                  MIO.pure(Rule.yielded(s"Failed to build helper for ${Type[A].prettyPrint}"))
+              }
+            } yield result
+
+          case None =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a case class"))
+        }
+      }
+
+    @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
+    private def decodeCaseClassFields[A: DecoderCtx](
+        caseClass: CaseClass[A]
+    ): MIO[Expr[A]] = {
+      implicit val StringT: Type[String] = CTypes.String
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+
+      val constructor = caseClass.primaryConstructor
+      val fieldsList = constructor.parameters.flatten.toList
+
+      NonEmptyList.fromList(fieldsList) match {
+        case None =>
+          // Zero-parameter case class: construct directly
+          caseClass
+            .construct[MIO](new CaseClass.ConstructField[MIO] {
+              def apply(field: Parameter): MIO[Expr[field.tpe.Underlying]] =
+                MIO.fail(
+                  new RuntimeException(s"Unexpected parameter in zero-argument case class ${Type[A].prettyPrint}")
+                )
+            })
+            .flatMap {
+              case Some(expr) =>
+                // Still need to read the empty object from the reader
+                MIO.pure(Expr.quote {
+                  JsoniterDerivationUtils.readEmptyObject(Expr.splice(dctx.reader))
+                  Expr.splice(expr)
+                })
+              case None =>
+                MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}"))
+            }
+
+        case Some(fields) =>
+          implicit val AnyT: Type[Any] = CTypes.Any
+          implicit val ArrayAnyT: Type[Array[Any]] = CTypes.ArrayAny
+
+          // Step 1: For each field, derive a decoder (implicit or recursive) and build
+          // decode + accessor expressions. Uses unsafeCast with the decoder as type witness
+          // to avoid path-dependent type aliases in Expr.quote (Scala 2 compatibility).
+          fields
+            .parTraverse { case (fieldName, param) =>
+              import param.tpe.Underlying as Field
+              Log.namedScope(s"Deriving decoder for field $fieldName: ${Type[Field].prettyPrint}") {
+                deriveFieldDecoder[Field].map { decodeFn =>
+                  // Build an erased version of the decode function for the dispatch
+                  val decodeFnErased: Expr[JsonReader => Any] = Expr.quote { (r: JsonReader) =>
+                    Expr.splice(decodeFn).apply(r).asInstanceOf[Any]
+                  }
+                  val makeAccessor: Expr[Array[Any]] => (String, Expr_??) = { arrExpr =>
+                    val typedExpr = Expr.quote {
+                      JsoniterDerivationUtils.unsafeCast(
+                        Expr.splice(arrExpr)(Expr.splice(Expr(param.index))),
+                        Expr.splice(decodeFn)
+                      )
+                    }
+                    (fieldName, typedExpr.as_??)
+                  }
+                  (fieldName, param.index, decodeFnErased, makeAccessor)
+                }
+              }
+            }
+            .flatMap { fieldData =>
+              val fieldDataList = fieldData.toList
+
+              // Step 2: Build the constructor lambda using LambdaBuilder + primaryConstructor
+              LambdaBuilder
+                .of1[Array[Any]]("decodedValues")
+                .traverse { decodedValuesExpr =>
+                  val fieldMap: Map[String, Expr_??] =
+                    fieldDataList.map(_._4(decodedValuesExpr)).toMap
+                  caseClass.primaryConstructor(fieldMap) match {
+                    case Right(constructExpr) => MIO.pure(constructExpr)
+                    case Left(error)          =>
+                      MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
+                  }
+                }
+                .map { builder =>
+                  val constructLambda = builder.build[A]
+
+                  // Step 3: Build the field dispatch - if-else chain matching mapped field names.
+                  // Uses the erased decode functions (JsonReader => Any) to avoid path-dependent types.
+                  val fieldMappings = fieldDataList.map { case (name, index, decodeFnErased, _) =>
+                    (name, index, decodeFnErased)
+                  }
+
+                  Expr.quote {
+                    JsoniterDerivationUtils.readObject[A](
+                      Expr.splice(dctx.reader),
+                      Expr.splice(Expr(fieldMappings.size)),
+                      Expr.splice(constructLambda)
+                    ) { case (fieldName, arr, reader) =>
+                      Expr.splice {
+                        fieldMappings.foldRight(Expr.quote {
+                          if (Expr.splice(dctx.config).skipUnexpectedFields) reader.skip()
+                          else reader.decodeError("unexpected field: " + fieldName)
+                        }: Expr[Unit]) { case ((name, index, decodeFnErased), elseExpr) =>
+                          Expr.quote {
+                            if (fieldName == Expr.splice(dctx.config).fieldNameMapper(Expr.splice(Expr(name)))) {
+                              arr(Expr.splice(Expr(index))) = Expr.splice(decodeFnErased).apply(reader)
+                            } else Expr.splice(elseExpr)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+            }
+      }
+    }
+
+    /** Decode case class fields from an already-opened JSON object (for discriminator mode). The object's `{` and
+      * discriminator key-value have already been read. Returns Expr[A] that reads remaining fields via
+      * readObjectInline.
+      */
+    @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
+    private[compiletime] def decodeCaseClassFieldsInline[A: DecoderCtx](
+        caseClass: CaseClass[A]
+    ): MIO[Expr[A]] = {
+      implicit val StringT: Type[String] = CTypes.String
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+
+      val constructor = caseClass.primaryConstructor
+      val fieldsList = constructor.parameters.flatten.toList
+
+      NonEmptyList.fromList(fieldsList) match {
+        case None =>
+          // Zero-parameter case class: just read closing `}`
+          caseClass
+            .construct[MIO](new CaseClass.ConstructField[MIO] {
+              def apply(field: Parameter): MIO[Expr[field.tpe.Underlying]] =
+                MIO.fail(new RuntimeException(s"Unexpected field in zero-arg case class"))
+            })
+            .flatMap {
+              case Some(expr) =>
+                // Read just the `}` — object was already opened, discriminator already consumed
+                MIO.pure(Expr.quote {
+                  // After discriminator, if next token is `}`, there are no more fields
+                  // If next token is `,`, there are unexpected extra fields — just skip to `}`
+                  val reader = Expr.splice(dctx.reader)
+                  if (!reader.isNextToken('}'.toByte)) {
+                    if (reader.isCurrentToken(','.toByte)) {
+                      // skip remaining fields
+                      reader.rollbackToken()
+                      while (reader.isNextToken(','.toByte)) {
+                        val _ = reader.readKeyAsString()
+                        reader.skip()
+                      }
+                    }
+                  }
+                  Expr.splice(expr)
+                })
+              case None =>
+                MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}"))
+            }
+
+        case Some(fields) =>
+          implicit val AnyT: Type[Any] = CTypes.Any
+          implicit val ArrayAnyT: Type[Array[Any]] = CTypes.ArrayAny
+
+          fields
+            .parTraverse { case (fieldName, param) =>
+              import param.tpe.Underlying as Field
+              Log.namedScope(s"Deriving decoder for field $fieldName: ${Type[Field].prettyPrint}") {
+                deriveFieldDecoder[Field].map { decodeFn =>
+                  val decodeFnErased: Expr[JsonReader => Any] = Expr.quote { (r: JsonReader) =>
+                    Expr.splice(decodeFn).apply(r).asInstanceOf[Any]
+                  }
+                  val makeAccessor: Expr[Array[Any]] => (String, Expr_??) = { arrExpr =>
+                    val typedExpr = Expr.quote {
+                      JsoniterDerivationUtils.unsafeCast(
+                        Expr.splice(arrExpr)(Expr.splice(Expr(param.index))),
+                        Expr.splice(decodeFn)
+                      )
+                    }
+                    (fieldName, typedExpr.as_??)
+                  }
+                  (fieldName, param.index, decodeFnErased, makeAccessor)
+                }
+              }
+            }
+            .flatMap { fieldData =>
+              val fieldDataList = fieldData.toList
+
+              LambdaBuilder
+                .of1[Array[Any]]("decodedValues")
+                .traverse { decodedValuesExpr =>
+                  val fieldMap: Map[String, Expr_??] =
+                    fieldDataList.map(_._4(decodedValuesExpr)).toMap
+                  caseClass.primaryConstructor(fieldMap) match {
+                    case Right(constructExpr) => MIO.pure(constructExpr)
+                    case Left(error)          =>
+                      MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
+                  }
+                }
+                .map { builder =>
+                  val constructLambda = builder.build[A]
+
+                  val fieldMappings = fieldDataList.map { case (name, index, decodeFnErased, _) =>
+                    (name, index, decodeFnErased)
+                  }
+
+                  Expr.quote {
+                    JsoniterDerivationUtils.readObjectInline[A](
+                      Expr.splice(dctx.reader),
+                      Expr.splice(Expr(fieldMappings.size)),
+                      Expr.splice(constructLambda)
+                    ) { case (fieldName, arr, reader) =>
+                      Expr.splice {
+                        fieldMappings.foldRight(Expr.quote {
+                          if (Expr.splice(dctx.config).skipUnexpectedFields) reader.skip()
+                          else reader.decodeError("unexpected field: " + fieldName)
+                        }: Expr[Unit]) { case ((name, index, decodeFnErased), elseExpr) =>
+                          Expr.quote {
+                            if (fieldName == Expr.splice(dctx.config).fieldNameMapper(Expr.splice(Expr(name)))) {
+                              arr(Expr.splice(Expr(index))) = Expr.splice(decodeFnErased).apply(reader)
+                            } else Expr.splice(elseExpr)
+                          }
+                        }
+                      }
+                    }
+                  }
+                }
+            }
+      }
+    }
+
+    /** Derive a decode function for a case class field. Tries implicit summoning first, falls back to recursive
+      * derivation via the full rule chain.
+      */
+    @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
+    private def deriveFieldDecoder[Field: Type](implicit ctx: DecoderCtx[?]): MIO[Expr[JsonReader => Field]] = {
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+
+      CTypes
+        .JsonValueCodec[Field]
+        .summonExprIgnoring(DecUseImplicitWhenAvailableRule.ignoredImplicits*)
+        .toEither match {
+        case Right(codecExpr) =>
+          Log.info(s"Found implicit JsonValueCodec[${Type[Field].prettyPrint}]") >> MIO.pure(
+            Expr.quote { (r: JsonReader) =>
+              Expr.splice(codecExpr).decodeValue(r, Expr.splice(codecExpr).nullValue)
+            }
+          )
+        case Left(_) =>
+          Log.info(s"Building decoder for ${Type[Field].prettyPrint} via recursive derivation") >>
+            LambdaBuilder
+              .of1[JsonReader]("fieldReader")
+              .traverse { fieldReaderExpr =>
+                deriveDecoderRecursively[Field](using ctx.nest[Field](fieldReaderExpr))
+              }
+              .map { builder =>
+                builder.build[Field]
+              }
+      }
+    }
+  }
+
+  object DecHandleAsEnumRule extends DecoderDerivationRule("handle as enum when possible") {
+
+    def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as an enum") >> {
+        Enum.parse[A] match {
+          case Some(enumm) =>
+            for {
+              _ <- dctx.setHelper[A] { (reader, config) =>
+                decodeEnumCases[A](enumm)(using dctx.nestInCache(reader, config))
+              }
+              result <- dctx.getHelper[A].flatMap {
+                case Some(helperCall) =>
+                  MIO.pure(Rule.matched(helperCall(dctx.reader, dctx.config)))
+                case None =>
+                  MIO.pure(Rule.yielded(s"Failed to build helper for ${Type[A].prettyPrint}"))
+              }
+            } yield result
+          case None =>
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not an enum"))
+        }
+      }
+
+    @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
+    private def decodeEnumCases[A: DecoderCtx](
+        enumm: Enum[A]
+    ): MIO[Expr[A]] = {
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+      implicit val StringT: Type[String] = CTypes.String
+      implicit val ListStringT: Type[List[String]] = CTypes.ListString
+
+      val childrenList = enumm.directChildren.toList
+
+      NonEmptyList.fromList(childrenList) match {
+        case None =>
+          MIO.pure(Expr.quote {
+            Expr
+              .splice(dctx.reader)
+              .decodeError(
+                "Enum " + Expr.splice(Expr(Type[A].prettyPrint)) + " has no subtypes"
+              ): A
+          })
+
+        case Some(children) =>
+          val knownNames: List[String] = children.toList.map(_._1)
+
+          // For each child, derive BOTH wrapper-mode and inline (discriminator-mode) decoders
+          children
+            .parTraverse { case (childName, child) =>
+              import child.Underlying as ChildType
+              Log.namedScope(s"Deriving decoder for enum case $childName: ${Type[ChildType].prettyPrint}") {
+                for {
+                  wrapper <- deriveChildDecoder[A, ChildType](childName)
+                  inline <- deriveChildDecoderInline[A, ChildType](childName)
+                } yield (wrapper, inline)
+              }
+            }
+            .flatMap { allDispatchers =>
+              val wrapperDispatchers = allDispatchers.toList.map(_._1)
+              val inlineDispatchers = allDispatchers.toList.map(_._2)
+
+              def buildErrorExpr(typeNameExpr: Expr[String]): Expr[A] = Expr.quote {
+                Expr
+                  .splice(dctx.reader)
+                  .decodeError(
+                    "Unknown type discriminator: " + Expr.splice(typeNameExpr) +
+                      ". Expected one of: " + Expr.splice(Expr(knownNames)).mkString(", ")
+                  ): A
+              }
+
+              def buildDispatchLambda(
+                  dispatchers: List[(Expr[String], Expr[JsonReader], Expr[A]) => Expr[A]]
+              ): MIO[Expr[String => A]] =
+                LambdaBuilder
+                  .of1[String]("typeName")
+                  .traverse { typeNameExpr =>
+                    MIO.pure(dispatchers.foldRight(buildErrorExpr(typeNameExpr)) { case (dispatcher, elseExpr) =>
+                      dispatcher(typeNameExpr, dctx.reader, elseExpr)
+                    })
+                  }
+                  .map(_.build[A])
+
+              for {
+                wrapperDispatchFn <- buildDispatchLambda(wrapperDispatchers)
+                inlineDispatchFn <- buildDispatchLambda(inlineDispatchers)
+              } yield Expr.quote {
+                val config = Expr.splice(dctx.config)
+                val reader = Expr.splice(dctx.reader)
+                config.discriminatorFieldName match {
+                  case Some(field) =>
+                    JsoniterDerivationUtils.readWithDiscriminator[A](reader, field)(
+                      Expr.splice(inlineDispatchFn)
+                    )
+                  case None =>
+                    JsoniterDerivationUtils.readWrapped[A](reader)(Expr.splice(wrapperDispatchFn))
+                }
+              }
+            }
+      }
+    }
+
+    @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
+    private def deriveChildDecoder[A: DecoderCtx, ChildType: Type](
+        childName: String
+    ): MIO[(Expr[String], Expr[JsonReader], Expr[A]) => Expr[A]] = {
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+
+      CTypes
+        .JsonValueCodec[ChildType]
+        .summonExprIgnoring(DecUseImplicitWhenAvailableRule.ignoredImplicits*)
+        .toEither match {
+        case Right(codecExpr) =>
+          Log.info(s"Found implicit JsonValueCodec[$childName], using it") >>
+            MIO.pure { (typeNameExpr: Expr[String], readerExpr: Expr[JsonReader], elseExpr: Expr[A]) =>
+              Expr.quote {
+                if (
+                  Expr.splice(dctx.config).adtLeafClassNameMapper(Expr.splice(Expr(childName))) == Expr
+                    .splice(typeNameExpr)
+                )
+                  Expr
+                    .splice(codecExpr)
+                    .decodeValue(Expr.splice(readerExpr), Expr.splice(codecExpr).nullValue)
+                    .asInstanceOf[A]
+                else
+                  Expr.splice(elseExpr)
+              }
+            }
+
+        case Left(_) =>
+          // No implicit - derive via full rules chain
+          deriveDecoderRecursively[ChildType](using dctx.nest[ChildType](dctx.reader)).flatMap { _ =>
+            dctx.getHelper[ChildType].map {
+              case Some(helper) =>
+                (typeNameExpr: Expr[String], readerExpr: Expr[JsonReader], elseExpr: Expr[A]) => {
+                  val helperCallExpr = helper(readerExpr, dctx.config)
+                  Expr.quote {
+                    if (
+                      Expr.splice(dctx.config).adtLeafClassNameMapper(Expr.splice(Expr(childName))) == Expr
+                        .splice(typeNameExpr)
+                    )
+                      Expr.splice(helperCallExpr).asInstanceOf[A]
+                    else
+                      Expr.splice(elseExpr)
+                  }
+                }
+
+              case None =>
+                (typeNameExpr: Expr[String], readerExpr: Expr[JsonReader], elseExpr: Expr[A]) => elseExpr
+            }
+          }
+      }
+    }
+
+    /** Derive an inline child decoder for discriminator mode. Uses decodeCaseClassFieldsInline to read fields from an
+      * already-opened object.
+      */
+    @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
+    private def deriveChildDecoderInline[A: DecoderCtx, ChildType: Type](
+        childName: String
+    ): MIO[(Expr[String], Expr[JsonReader], Expr[A]) => Expr[A]] = {
+      implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+
+      CaseClass.parse[ChildType] match {
+        case Some(cc) =>
+          DecHandleAsCaseClassRule
+            .decodeCaseClassFieldsInline[ChildType](cc)(using dctx.nest[ChildType](dctx.reader))
+            .map { inlineExpr => (typeNameExpr: Expr[String], _: Expr[JsonReader], elseExpr: Expr[A]) =>
+              Expr.quote {
+                if (
+                  Expr.splice(dctx.config).adtLeafClassNameMapper(Expr.splice(Expr(childName))) == Expr
+                    .splice(typeNameExpr)
+                )
+                  Expr.splice(inlineExpr).asInstanceOf[A]
+                else
+                  Expr.splice(elseExpr)
+              }
+            }
+
+        case None =>
+          // Not a case class (e.g., case object) — fall back to wrapper-style decoder
+          deriveChildDecoder[A, ChildType](childName)
+      }
+    }
+  }
+
+  // Types
+
+  private[compiletime] object CTypes {
+
+    def JsonValueCodec: Type.Ctor1[JsonValueCodec] = Type.Ctor1.of[JsonValueCodec]
+    def KindlingsJsonValueCodec: Type.Ctor1[KindlingsJsonValueCodec] =
+      Type.Ctor1.of[KindlingsJsonValueCodec]
+    val CodecLogDerivation: Type[hearth.kindlings.jsoniterderivation.KindlingsJsonValueCodec.LogDerivation] =
+      Type.of[hearth.kindlings.jsoniterderivation.KindlingsJsonValueCodec.LogDerivation]
+    val JsoniterConfig: Type[JsoniterConfig] = Type.of[JsoniterConfig]
+    val JsonReader: Type[JsonReader] = Type.of[JsonReader]
+    val JsonWriter: Type[JsonWriter] = Type.of[JsonWriter]
+    val String: Type[String] = Type.of[String]
+    val Unit: Type[Unit] = Type.of[Unit]
+    val Any: Type[Any] = Type.of[Any]
+    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
+    val ListString: Type[List[String]] = Type.of[List[String]]
+  }
+}
+
+sealed private[compiletime] trait CodecDerivationError
+    extends util.control.NoStackTrace
+    with Product
+    with Serializable {
+  def message: String
+  override def getMessage(): String = message
+}
+private[compiletime] object CodecDerivationError {
+  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends CodecDerivationError {
+    override def message: String =
+      s"The type $tpeName was not handled by any codec derivation rule:\n${reasons.mkString("\n")}"
+  }
+}

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/runtime/JsoniterDerivationUtils.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/runtime/JsoniterDerivationUtils.scala
@@ -1,0 +1,194 @@
+package hearth.kindlings.jsoniterderivation.internal.runtime
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonWriter}
+
+object JsoniterDerivationUtils {
+
+  // --- Encoder helpers ---
+
+  def writeArray[A](out: JsonWriter, items: Iterable[A], encodeItem: A => Unit): Unit = {
+    out.writeArrayStart()
+    val iter = items.iterator
+    while (iter.hasNext) encodeItem(iter.next())
+    out.writeArrayEnd()
+  }
+
+  def writeMap[P, V](
+      out: JsonWriter,
+      pairs: Iterable[P],
+      extractKey: P => String,
+      encodeValue: V => Unit
+  ): Unit = {
+    out.writeObjectStart()
+    val iter = pairs.iterator
+    while (iter.hasNext) {
+      val p = iter.next()
+      out.writeKey(extractKey(p))
+      encodeValue(p.asInstanceOf[V]) // The caller should handle the value extraction
+    }
+    out.writeObjectEnd()
+  }
+
+  def writeMapStringKeyed[V](
+      out: JsonWriter,
+      entries: Iterable[(String, V)],
+      encodeValue: V => Unit
+  ): Unit = {
+    out.writeObjectStart()
+    val iter = entries.iterator
+    while (iter.hasNext) {
+      val (key, value) = iter.next()
+      out.writeKey(key)
+      encodeValue(value)
+    }
+    out.writeObjectEnd()
+  }
+
+  def writeWrapped(out: JsonWriter, typeName: String)(encodeInner: => Unit): Unit = {
+    out.writeObjectStart()
+    out.writeKey(typeName)
+    encodeInner
+    out.writeObjectEnd()
+  }
+
+  def writeWithDiscriminator(out: JsonWriter, discriminatorField: String, typeName: String)(
+      encodeFields: => Unit
+  ): Unit = {
+    // We need to inject the discriminator as the first field.
+    // The encodeFields writes: writeObjectStart(), writeKey(f1), ..., writeObjectEnd()
+    // But we need to intercept to add the discriminator before the other fields.
+    // Since we can't intercept, we'll write the discriminator first then relay the other fields.
+    out.writeObjectStart()
+    out.writeKey(discriminatorField)
+    out.writeVal(typeName)
+    // Now the encodeFields would normally write start/fields/end for a case class.
+    // We need encodeFields to write just the fields without start/end.
+    // This requires a different approach - encodeFields should just be the field writes.
+    // For now, let's handle this by not calling encodeFields directly.
+    // Instead, encodeFields is the full object encoding. We'll need to restructure.
+    // Actually, the macro generates writeObjectStart + fields + writeObjectEnd for case classes.
+    // For discriminator mode, we need to replace that with just the fields.
+    // Let's handle this at the macro level instead.
+    encodeFields // This includes writeObjectStart/writeObjectEnd which is wrong for discriminator mode
+    out.writeObjectEnd()
+  }
+
+  // --- Decoder helpers ---
+
+  def readOption[A](in: JsonReader)(decodeInner: JsonReader => A): Option[A] =
+    if (in.isNextToken('n'.toByte)) {
+      in.readNullOrError[Option[A]](None, "expected null")
+    } else {
+      in.rollbackToken()
+      Some(decodeInner(in))
+    }
+
+  def readCollection[Item, Coll](
+      in: JsonReader,
+      decodeItem: JsonReader => Item,
+      factory: scala.collection.Factory[Item, Coll]
+  ): Coll = {
+    val builder = factory.newBuilder
+    if (!in.isNextToken('['.toByte)) in.decodeError("expected '[' or null")
+    if (!in.isNextToken(']'.toByte)) {
+      in.rollbackToken()
+      builder += decodeItem(in)
+      while (in.isNextToken(','.toByte)) builder += decodeItem(in)
+      if (!in.isCurrentToken(']'.toByte)) in.decodeError("expected ']' or ','")
+    }
+    builder.result()
+  }
+
+  def readMap[V, M](
+      in: JsonReader,
+      decodeValue: JsonReader => V,
+      factory: scala.collection.Factory[(String, V), M]
+  ): M = {
+    val builder = factory.newBuilder
+    if (!in.isNextToken('{'.toByte)) in.decodeError("expected '{' or null")
+    if (!in.isNextToken('}'.toByte)) {
+      in.rollbackToken()
+      val key = in.readKeyAsString()
+      builder += ((key, decodeValue(in)))
+      while (in.isNextToken(','.toByte)) {
+        val k = in.readKeyAsString()
+        builder += ((k, decodeValue(in)))
+      }
+      if (!in.isCurrentToken('}'.toByte)) in.decodeError("expected '}' or ','")
+    }
+    builder.result()
+  }
+
+  def readEmptyObject(in: JsonReader): Unit = {
+    if (!in.isNextToken('{'.toByte)) in.decodeError("expected '{'")
+    if (!in.isNextToken('}'.toByte)) in.decodeError("expected '}'")
+  }
+
+  def readObject[A](
+      in: JsonReader,
+      fieldCount: Int,
+      construct: Array[Any] => A
+  )(dispatch: (String, Array[Any], JsonReader) => Unit): A = {
+    val arr = new Array[Any](fieldCount)
+    if (!in.isNextToken('{'.toByte)) in.decodeError("expected '{'")
+    if (!in.isNextToken('}'.toByte)) {
+      in.rollbackToken()
+      val key = in.readKeyAsString()
+      dispatch(key, arr, in)
+      while (in.isNextToken(','.toByte)) {
+        val k = in.readKeyAsString()
+        dispatch(k, arr, in)
+      }
+      if (!in.isCurrentToken('}'.toByte)) in.decodeError("expected '}' or ','")
+    }
+    construct(arr)
+  }
+
+  /** Read remaining fields of an already-opened object (e.g., after discriminator field was consumed). */
+  def readObjectInline[A](
+      in: JsonReader,
+      fieldCount: Int,
+      construct: Array[Any] => A
+  )(dispatch: (String, Array[Any], JsonReader) => Unit): A = {
+    val arr = new Array[Any](fieldCount)
+    // Object is already open and discriminator key-value has been read.
+    // Check for more fields (comma after discriminator value).
+    if (in.isNextToken(','.toByte)) {
+      val key = in.readKeyAsString()
+      dispatch(key, arr, in)
+      while (in.isNextToken(','.toByte)) {
+        val k = in.readKeyAsString()
+        dispatch(k, arr, in)
+      }
+      if (!in.isCurrentToken('}'.toByte)) in.decodeError("expected '}' or ','")
+    } else {
+      if (!in.isCurrentToken('}'.toByte)) in.decodeError("expected '}'")
+    }
+    construct(arr)
+  }
+
+  def readWrapped[A](in: JsonReader)(dispatch: String => A): A = {
+    if (!in.isNextToken('{'.toByte)) in.decodeError("expected '{' for wrapped enum")
+    val typeName = in.readKeyAsString()
+    val result = dispatch(typeName)
+    if (!in.isNextToken('}'.toByte)) in.decodeError("expected '}' after wrapped enum value")
+    result
+  }
+
+  def readWithDiscriminator[A](in: JsonReader, discriminatorField: String)(dispatch: String => A): A = {
+    // Read the object, find the discriminator field, then dispatch
+    // For simplicity, we require the discriminator to appear first
+    if (!in.isNextToken('{'.toByte)) in.decodeError("expected '{' for discriminated enum")
+    val firstKey = in.readKeyAsString()
+    if (firstKey != discriminatorField)
+      in.decodeError("expected discriminator field '" + discriminatorField + "' as first field, got '" + firstKey + "'")
+    val typeName = in.readString(null)
+    // Now we need to read the rest of the object as the body
+    // The dispatch function will continue reading from the same reader
+    dispatch(typeName)
+  }
+
+  /** Cast an `Any` value to `A`, using a decode function purely for type inference. */
+  @scala.annotation.nowarn("msg=unused explicit parameter")
+  def unsafeCast[A](value: Any, decodeFn: JsonReader => A): A = value.asInstanceOf[A]
+}

--- a/jsoniter-derivation/src/test/scala-3/hearth/kindlings/jsoniterderivation/JsoniterScala3Spec.scala
+++ b/jsoniter-derivation/src/test/scala-3/hearth/kindlings/jsoniterderivation/JsoniterScala3Spec.scala
@@ -1,0 +1,55 @@
+package hearth.kindlings.jsoniterderivation
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromString, writeToString}
+import hearth.MacroSuite
+
+enum Fruit {
+  case Apple(weight: Double)
+  case Banana(length: Double)
+}
+
+final class JsoniterScala3Spec extends MacroSuite {
+
+  group("Scala 3 enums") {
+
+    test("wrapper-style round-trip") {
+      val codec = KindlingsJsonValueCodec.derive[Fruit]
+      val value: Fruit = Fruit.Apple(1.5)
+      val json = writeToString(value)(codec)
+      assert(json.contains("\"Apple\""))
+      val decoded = readFromString[Fruit](json)(codec)
+      assertEquals(decoded, value)
+    }
+
+    test("second variant wrapper-style round-trip") {
+      val codec = KindlingsJsonValueCodec.derive[Fruit]
+      val value: Fruit = Fruit.Banana(20.0)
+      val json = writeToString(value)(codec)
+      assert(json.contains("\"Banana\""))
+      val decoded = readFromString[Fruit](json)(codec)
+      assertEquals(decoded, value)
+    }
+
+    test("discriminator-style round-trip") {
+      implicit val config: JsoniterConfig = JsoniterConfig.default.withDiscriminator("type")
+      val codec = KindlingsJsonValueCodec.derive[Fruit]
+      val value: Fruit = Fruit.Banana(20.0)
+      val json = writeToString(value)(codec)
+      assert(json.contains("\"type\":\"Banana\""))
+      val decoded = readFromString[Fruit](json)(codec)
+      assertEquals(decoded, value)
+    }
+
+    test("custom name transform round-trip") {
+      implicit val config: JsoniterConfig =
+        JsoniterConfig(adtLeafClassNameMapper = _.toLowerCase)
+      val codec = KindlingsJsonValueCodec.derive[Fruit]
+      val value: Fruit = Fruit.Apple(1.5)
+      val json = writeToString(value)(codec)
+      assert(json.contains("\"apple\""))
+      val decoded = readFromString[Fruit](json)(codec)
+      assertEquals(decoded, value)
+    }
+  }
+
+}

--- a/jsoniter-derivation/src/test/scala/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecSpec.scala
+++ b/jsoniter-derivation/src/test/scala/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecSpec.scala
@@ -1,0 +1,272 @@
+package hearth.kindlings.jsoniterderivation
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromString, writeToString, JsonValueCodec}
+import hearth.MacroSuite
+
+case class SimplePerson(name: String, age: Int)
+case class EmptyClass()
+case class SingleField(value: Int)
+case class Address(street: String, city: String)
+case class PersonWithAddress(name: String, age: Int, address: Address)
+case class TeamWithMembers(name: String, members: List[SimplePerson])
+case class RecursiveTree(value: Int, children: List[RecursiveTree])
+final case class WrappedInt(value: Int) extends AnyVal
+
+sealed trait Shape
+case class Circle(radius: Double) extends Shape
+case class Rectangle(width: Double, height: Double) extends Shape
+
+sealed trait Animal
+case class Dog(name: String, breed: String) extends Animal
+case class Cat(name: String, indoor: Boolean) extends Animal
+
+final class KindlingsJsonValueCodecSpec extends MacroSuite {
+
+  group("KindlingsJsonValueCodec") {
+
+    group("case classes") {
+
+      test("simple case class round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[SimplePerson]
+        val value = SimplePerson("Alice", 30)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[SimplePerson](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("empty case class round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[EmptyClass]
+        val value = EmptyClass()
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[EmptyClass](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("single field case class round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[SingleField]
+        val value = SingleField(42)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[SingleField](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("nested case class round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[PersonWithAddress]
+        val value = PersonWithAddress("Bob", 25, Address("123 Main St", "Springfield"))
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[PersonWithAddress](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("case class with collection field round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[TeamWithMembers]
+        val value = TeamWithMembers("Dev", List(SimplePerson("Alice", 30), SimplePerson("Bob", 25)))
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[TeamWithMembers](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("value classes") {
+
+      test("value class round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[WrappedInt]
+        val value = WrappedInt(42)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[WrappedInt](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("options") {
+
+      test("Some round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[Option[Int]]
+        val value: Option[Int] = Some(42)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[Option[Int]](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("None round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[Option[Int]]
+        val value: Option[Int] = None
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[Option[Int]](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("collections") {
+
+      test("List of ints round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[List[Int]]
+        val value = List(1, 2, 3)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[List[Int]](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("Vector of strings round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[Vector[String]]
+        val value = Vector("a", "b", "c")
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[Vector[String]](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("empty list round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[List[Int]]
+        val value = List.empty[Int]
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[List[Int]](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("maps") {
+
+      test("Map[String, Int] round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[Map[String, Int]]
+        val value = Map("a" -> 1, "b" -> 2)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[Map[String, Int]](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("empty map round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[Map[String, Int]]
+        val value = Map.empty[String, Int]
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[Map[String, Int]](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("sealed traits") {
+
+      test("wrapper-style round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[Shape]
+        val value: Shape = Circle(5.0)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[Shape](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("wrapper-style second case round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[Shape]
+        val value: Shape = Rectangle(3.0, 4.0)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[Shape](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("discriminator-style round-trip") {
+        implicit val config: JsoniterConfig = JsoniterConfig(discriminatorFieldName = Some("type"))
+        val codec = KindlingsJsonValueCodec.derive[Animal]
+        val value: Animal = Dog("Rex", "Labrador")
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[Animal](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("recursive types") {
+
+      test("recursive tree round-trip") {
+        val codec = KindlingsJsonValueCodec.derive[RecursiveTree]
+        val value = RecursiveTree(1, List(RecursiveTree(2, Nil), RecursiveTree(3, List(RecursiveTree(4, Nil)))))
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[RecursiveTree](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("configuration") {
+
+      test("snake_case field names") {
+        implicit val config: JsoniterConfig = JsoniterConfig.default.withSnakeCaseFieldNames
+        val codec = KindlingsJsonValueCodec.derive[PersonWithAddress]
+        val value = PersonWithAddress("Bob", 25, Address("123 Main", "SF"))
+        val json = writeToString(value)(codec)
+        assert(json.contains("\"person_with_address\"") || json.contains("\"name\""))
+        val decoded = readFromString[PersonWithAddress](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("custom constructor name transform") {
+        implicit val config: JsoniterConfig =
+          JsoniterConfig(adtLeafClassNameMapper = _.toLowerCase)
+        val codec = KindlingsJsonValueCodec.derive[Shape]
+        val value: Shape = Circle(5.0)
+        val json = writeToString(value)(codec)
+        assert(json.contains("\"circle\""))
+        val decoded = readFromString[Shape](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("derive and derived") {
+
+      test("explicit derive returns JsonValueCodec") {
+        val codec: JsonValueCodec[SimplePerson] = KindlingsJsonValueCodec.derive[SimplePerson]
+        val value = SimplePerson("Alice", 30)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[SimplePerson](json)(codec)
+        assertEquals(decoded, value)
+      }
+
+      test("derived provides KindlingsJsonValueCodec") {
+        val codec: KindlingsJsonValueCodec[SimplePerson] = KindlingsJsonValueCodec.derived[SimplePerson]
+        val value = SimplePerson("Alice", 30)
+        val json = writeToString(value)(codec)
+        val decoded = readFromString[SimplePerson](json)(codec)
+        assertEquals(decoded, value)
+      }
+    }
+
+    group("user-provided implicit priority") {
+
+      test("user-provided codec for nested field is used over derivation") {
+        // User-provided implicits for NESTED types take priority (the derived type itself is always derived)
+        @scala.annotation.nowarn("msg=is never used")
+        implicit val customIntCodec: JsonValueCodec[Int] = new JsonValueCodec[Int] {
+          def nullValue: Int = 0
+          def decodeValue(in: com.github.plokhotnyuk.jsoniter_scala.core.JsonReader, default: Int): Int =
+            in.readInt() * 10
+          def encodeValue(x: Int, out: com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter): Unit =
+            out.writeVal(x * 10)
+        }
+        val codec = KindlingsJsonValueCodec.derive[SingleField]
+        val json = writeToString(SingleField(5))(codec)
+        assertEquals(json, """{"value":50}""")
+        val decoded = readFromString[SingleField](json)(codec)
+        assertEquals(decoded, SingleField(500))
+      }
+    }
+  }
+
+  group("JsonValueCodecExtensions") {
+
+    test("map transforms codec") {
+      import JsonValueCodecExtensions.*
+      val intCodec = KindlingsJsonValueCodec.derive[SingleField]
+      val stringCodec = intCodec.map[String](sf => sf.value.toString)(s => SingleField(s.toInt))
+      val json = writeToString("42")(stringCodec)
+      val decoded = readFromString[String](json)(stringCodec)
+      assertEquals(decoded, "42")
+    }
+
+    test("mapDecode with Right") {
+      import JsonValueCodecExtensions.*
+      val intCodec = KindlingsJsonValueCodec.derive[SingleField]
+      val positiveCodec =
+        intCodec.mapDecode[Int](sf => if (sf.value > 0) Right(sf.value) else Left("must be positive"))(v =>
+          SingleField(v)
+        )
+      val json = writeToString(42)(positiveCodec)
+      val decoded = readFromString[Int](json)(positiveCodec)
+      assertEquals(decoded, 42)
+    }
+  }
+}

--- a/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/Json.scala
+++ b/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/Json.scala
@@ -1,0 +1,80 @@
+package hearth.kindlings.jsoniterjson
+
+/** Minimal JSON AST providing the same structural capabilities as jsoniter-scala-circe but without Circe/Cats
+  * dependencies.
+  */
+sealed trait Json extends Product with Serializable {
+
+  def isNull: Boolean = this.isInstanceOf[Json.Null.type]
+  def isBoolean: Boolean = this.isInstanceOf[Json.Bool]
+  def isNumber: Boolean = this.isInstanceOf[Json.Num]
+  def isString: Boolean = this.isInstanceOf[Json.Str]
+  def isArray: Boolean = this.isInstanceOf[Json.Arr]
+  def isObject: Boolean = this.isInstanceOf[Json.Obj]
+
+  def asBoolean: Option[Boolean] = this match {
+    case Json.Bool(b) => Some(b)
+    case _            => None
+  }
+
+  def asNumber: Option[JsonNumber] = this match {
+    case Json.Num(n) => Some(n)
+    case _           => None
+  }
+
+  def asString: Option[String] = this match {
+    case Json.Str(s) => Some(s)
+    case _           => None
+  }
+
+  def asArray: Option[Vector[Json]] = this match {
+    case Json.Arr(vs) => Some(vs)
+    case _            => None
+  }
+
+  def asObject: Option[JsonObject] = this match {
+    case Json.Obj(obj) => Some(obj)
+    case _             => None
+  }
+
+  def fold[A](
+      onNull: => A,
+      onBoolean: Boolean => A,
+      onNumber: JsonNumber => A,
+      onString: String => A,
+      onArray: Vector[Json] => A,
+      onObject: JsonObject => A
+  ): A = this match {
+    case Json.Null    => onNull
+    case Json.Bool(b) => onBoolean(b)
+    case Json.Num(n)  => onNumber(n)
+    case Json.Str(s)  => onString(s)
+    case Json.Arr(vs) => onArray(vs)
+    case Json.Obj(o)  => onObject(o)
+  }
+}
+object Json {
+  case object Null extends Json
+  final case class Bool(value: Boolean) extends Json
+  final case class Num(value: JsonNumber) extends Json
+  final case class Str(value: String) extends Json
+  final case class Arr(values: Vector[Json]) extends Json
+  final case class Obj(fields: JsonObject) extends Json
+
+  val True: Json = Bool(true)
+  val False: Json = Bool(false)
+
+  def fromBoolean(b: Boolean): Json = Bool(b)
+  def fromInt(n: Int): Json = Num(JsonNumber.fromInt(n))
+  def fromLong(n: Long): Json = Num(JsonNumber.fromLong(n))
+  def fromDouble(n: Double): Option[Json] = JsonNumber.fromDouble(n).map(Num(_))
+  def fromFloat(n: Float): Option[Json] = JsonNumber.fromFloat(n).map(Num(_))
+  def fromBigDecimal(n: BigDecimal): Json = Num(JsonNumber.fromBigDecimal(n))
+  def fromBigInt(n: BigInt): Json = Num(JsonNumber.fromBigInt(n))
+  def fromString(s: String): Json = Str(s)
+  def fromValues(vs: Iterable[Json]): Json = Arr(vs.toVector)
+  def fromJsonObject(obj: JsonObject): Json = Obj(obj)
+
+  def arr(values: Json*): Json = Arr(values.toVector)
+  def obj(fields: (String, Json)*): Json = Obj(JsonObject(fields.toVector))
+}

--- a/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/JsonNumber.scala
+++ b/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/JsonNumber.scala
@@ -1,0 +1,48 @@
+package hearth.kindlings.jsoniterjson
+
+/** String-backed number representation to preserve precision.
+  *
+  * Numbers are stored as their string representation to avoid precision loss that can occur with Double/Float
+  * conversions. Conversion methods are provided to extract values in specific numeric types.
+  */
+final case class JsonNumber private (value: String) {
+
+  def toInt: Option[Int] = try Some(value.toInt)
+  catch { case _: NumberFormatException => None }
+
+  def toLong: Option[Long] = try Some(value.toLong)
+  catch { case _: NumberFormatException => None }
+
+  def toDouble: Option[Double] = try {
+    val d = value.toDouble
+    if (d.isNaN || d.isInfinite) None else Some(d)
+  } catch { case _: NumberFormatException => None }
+
+  def toFloat: Option[Float] = try {
+    val f = value.toFloat
+    if (f.isNaN || f.isInfinite) None else Some(f)
+  } catch { case _: NumberFormatException => None }
+
+  def toBigDecimal: Option[BigDecimal] = try Some(BigDecimal(value))
+  catch { case _: NumberFormatException => None }
+
+  def toBigInt: Option[BigInt] = try Some(BigInt(value))
+  catch { case _: NumberFormatException => None }
+
+  override def toString: String = value
+}
+object JsonNumber {
+
+  def fromInt(n: Int): JsonNumber = new JsonNumber(n.toString)
+  def fromLong(n: Long): JsonNumber = new JsonNumber(n.toString)
+  def fromDouble(n: Double): Option[JsonNumber] =
+    if (n.isNaN || n.isInfinite) None else Some(new JsonNumber(n.toString))
+  def fromFloat(n: Float): Option[JsonNumber] =
+    if (n.isNaN || n.isInfinite) None else Some(new JsonNumber(n.toString))
+  def fromBigDecimal(n: BigDecimal): JsonNumber = new JsonNumber(n.toString)
+  def fromBigInt(n: BigInt): JsonNumber = new JsonNumber(n.toString)
+  def fromString(s: String): Option[JsonNumber] = try {
+    val _ = BigDecimal(s) // validate
+    Some(new JsonNumber(s))
+  } catch { case _: NumberFormatException => None }
+}

--- a/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/JsonObject.scala
+++ b/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/JsonObject.scala
@@ -1,0 +1,44 @@
+package hearth.kindlings.jsoniterjson
+
+/** Ordered collection of key-value pairs representing a JSON object.
+  *
+  * Preserves insertion order. Duplicate keys are allowed but only the last value for a given key is returned by
+  * `apply`.
+  */
+final case class JsonObject(fields: Vector[(String, Json)]) {
+
+  def apply(key: String): Option[Json] = {
+    var i = fields.length - 1
+    while (i >= 0) {
+      if (fields(i)._1 == key) return Some(fields(i)._2)
+      i -= 1
+    }
+    None
+  }
+
+  def add(key: String, value: Json): JsonObject = JsonObject(fields :+ (key -> value))
+
+  def remove(key: String): JsonObject = JsonObject(fields.filterNot(_._1 == key))
+
+  def keys: Vector[String] = fields.map(_._1)
+
+  def values: Vector[Json] = fields.map(_._2)
+
+  def size: Int = fields.size
+
+  def isEmpty: Boolean = fields.isEmpty
+
+  def nonEmpty: Boolean = fields.nonEmpty
+
+  def toMap: Map[String, Json] = fields.toMap
+
+  def mapValues(f: Json => Json): JsonObject = JsonObject(fields.map { case (k, v) => (k, f(v)) })
+}
+object JsonObject {
+
+  val empty: JsonObject = JsonObject(Vector.empty)
+
+  def apply(entries: (String, Json)*): JsonObject = JsonObject(entries.toVector)
+
+  def fromIterable(entries: Iterable[(String, Json)]): JsonObject = JsonObject(entries.toVector)
+}

--- a/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/codec/JsonCodec.scala
+++ b/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/codec/JsonCodec.scala
@@ -1,0 +1,86 @@
+package hearth.kindlings.jsoniterjson.codec
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{JsonReader, JsonValueCodec, JsonWriter}
+import hearth.kindlings.jsoniterjson.{Json, JsonNumber, JsonObject}
+
+/** Hand-written `JsonValueCodec[Json]` that reads/writes JSON tokens from/to jsoniter-scala's streaming API.
+  *
+  * Numbers are read as `BigDecimal` to preserve precision.
+  */
+object JsonCodec {
+
+  implicit val jsonValueCodec: JsonValueCodec[Json] = new JsonValueCodec[Json] {
+
+    val nullValue: Json = Json.Null
+
+    def decodeValue(in: JsonReader, default: Json): Json = decode(in)
+
+    def encodeValue(x: Json, out: JsonWriter): Unit = encode(x, out)
+
+    private def decode(in: JsonReader): Json = {
+      val b = in.nextToken()
+      if (b == 'n'.toByte) {
+        in.readNullOrError(Json.Null, "expected null")
+      } else if (b == 't'.toByte || b == 'f'.toByte) {
+        in.rollbackToken()
+        Json.Bool(in.readBoolean())
+      } else if (b == '"'.toByte) {
+        in.rollbackToken()
+        Json.Str(in.readString(null))
+      } else if (b == '['.toByte) {
+        if (in.isNextToken(']'.toByte)) Json.Arr(Vector.empty)
+        else {
+          in.rollbackToken()
+          val builder = Vector.newBuilder[Json]
+          builder += decode(in)
+          while (in.isNextToken(','.toByte)) builder += decode(in)
+          if (!in.isCurrentToken(']'.toByte)) in.decodeError("expected ']' or ','")
+          Json.Arr(builder.result())
+        }
+      } else if (b == '{'.toByte) {
+        if (in.isNextToken('}'.toByte)) Json.Obj(JsonObject.empty)
+        else {
+          in.rollbackToken()
+          val builder = Vector.newBuilder[(String, Json)]
+          val key = in.readKeyAsString()
+          builder += ((key, decode(in)))
+          while (in.isNextToken(','.toByte)) {
+            val k = in.readKeyAsString()
+            builder += ((k, decode(in)))
+          }
+          if (!in.isCurrentToken('}'.toByte)) in.decodeError("expected '}' or ','")
+          Json.Obj(JsonObject(builder.result()))
+        }
+      } else {
+        in.rollbackToken()
+        val bd = in.readBigDecimal(null)
+        Json.Num(JsonNumber.fromBigDecimal(bd))
+      }
+    }
+
+    private def encode(json: Json, out: JsonWriter): Unit = json match {
+      case Json.Null    => out.writeNull()
+      case Json.Bool(b) => out.writeVal(b)
+      case Json.Str(s)  => out.writeVal(s)
+      case Json.Num(n)  =>
+        n.toBigDecimal match {
+          case Some(bd) => out.writeVal(bd)
+          case None     => out.writeVal(n.value) // fallback to string representation
+        }
+      case Json.Arr(vs) =>
+        out.writeArrayStart()
+        val iter = vs.iterator
+        while (iter.hasNext) encode(iter.next(), out)
+        out.writeArrayEnd()
+      case Json.Obj(obj) =>
+        out.writeObjectStart()
+        val iter = obj.fields.iterator
+        while (iter.hasNext) {
+          val (key, value) = iter.next()
+          out.writeKey(key)
+          encode(value, out)
+        }
+        out.writeObjectEnd()
+    }
+  }
+}

--- a/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/optics/JsonOptic.scala
+++ b/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/optics/JsonOptic.scala
@@ -1,0 +1,49 @@
+package hearth.kindlings.jsoniterjson.optics
+
+import hearth.kindlings.jsoniterjson.{Json, JsonObject}
+
+/** Minimal lens/prism-like accessor for JSON values. */
+trait JsonOptic { self =>
+
+  def get(json: Json): Option[Json]
+  def modify(f: Json => Json)(json: Json): Json
+  def set(value: Json)(json: Json): Json = modify(_ => value)(json)
+
+  def andThen(that: JsonOptic): JsonOptic = new JsonOptic {
+    def get(json: Json): Option[Json] = self.get(json).flatMap(that.get)
+    def modify(f: Json => Json)(json: Json): Json = self.modify(that.modify(f))(json)
+  }
+}
+object JsonOptic {
+
+  /** Access a field in a JSON object. */
+  def field(name: String): JsonOptic = new JsonOptic {
+    def get(json: Json): Option[Json] = json.asObject.flatMap(_(name))
+    def modify(f: Json => Json)(json: Json): Json = json match {
+      case Json.Obj(obj) =>
+        val newFields = obj.fields.map { case (k, v) =>
+          if (k == name) (k, f(v)) else (k, v)
+        }
+        Json.Obj(JsonObject(newFields))
+      case other => other
+    }
+  }
+
+  /** Access an element in a JSON array by index. */
+  def index(i: Int): JsonOptic = new JsonOptic {
+    def get(json: Json): Option[Json] = json.asArray.flatMap(vs => if (i >= 0 && i < vs.size) Some(vs(i)) else None)
+    def modify(f: Json => Json)(json: Json): Json = json match {
+      case Json.Arr(vs) if i >= 0 && i < vs.size => Json.Arr(vs.updated(i, f(vs(i))))
+      case other                                 => other
+    }
+  }
+
+  /** Traverse all elements of a JSON array. */
+  val each: JsonTraversal = new JsonTraversal {
+    def getAll(json: Json): Vector[Json] = json.asArray.getOrElse(Vector.empty)
+    def modify(f: Json => Json)(json: Json): Json = json match {
+      case Json.Arr(vs) => Json.Arr(vs.map(f))
+      case other        => other
+    }
+  }
+}

--- a/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/optics/JsonPath.scala
+++ b/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/optics/JsonPath.scala
@@ -1,0 +1,25 @@
+package hearth.kindlings.jsoniterjson.optics
+
+import hearth.kindlings.jsoniterjson.Json
+
+/** Chained field/index access for JSON navigation.
+  *
+  * Example: `JsonPath.root.field("users").index(0).field("name").get(json)`
+  */
+final class JsonPath private (private val optic: JsonOptic) {
+
+  def field(name: String): JsonPath = new JsonPath(optic.andThen(JsonOptic.field(name)))
+  def index(i: Int): JsonPath = new JsonPath(optic.andThen(JsonOptic.index(i)))
+
+  def get(json: Json): Option[Json] = optic.get(json)
+  def modify(f: Json => Json)(json: Json): Json = optic.modify(f)(json)
+  def set(value: Json)(json: Json): Json = optic.set(value)(json)
+}
+object JsonPath {
+
+  /** Starting point for building JSON paths. */
+  val root: JsonPath = new JsonPath(new JsonOptic {
+    def get(json: Json): Option[Json] = Some(json)
+    def modify(f: Json => Json)(json: Json): Json = f(json)
+  })
+}

--- a/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/optics/JsonTraversal.scala
+++ b/jsoniter-json/src/main/scala/hearth/kindlings/jsoniterjson/optics/JsonTraversal.scala
@@ -1,0 +1,10 @@
+package hearth.kindlings.jsoniterjson.optics
+
+import hearth.kindlings.jsoniterjson.Json
+
+/** A traversal that can access multiple JSON values. */
+trait JsonTraversal {
+  def getAll(json: Json): Vector[Json]
+  def modify(f: Json => Json)(json: Json): Json
+  def set(value: Json)(json: Json): Json = modify(_ => value)(json)
+}

--- a/jsoniter-json/src/test/scala/hearth/kindlings/jsoniterjson/JsonCodecSpec.scala
+++ b/jsoniter-json/src/test/scala/hearth/kindlings/jsoniterjson/JsonCodecSpec.scala
@@ -1,0 +1,158 @@
+package hearth.kindlings.jsoniterjson
+
+import com.github.plokhotnyuk.jsoniter_scala.core.{readFromString, writeToString}
+import hearth.kindlings.jsoniterjson.codec.JsonCodec.*
+import munit.FunSuite
+
+final class JsonCodecSpec extends FunSuite {
+
+  test("round-trip: null") {
+    val json: Json = Json.Null
+    val str = writeToString(json)
+    assertEquals(str, "null")
+    assertEquals(readFromString[Json](str), json)
+  }
+
+  test("round-trip: boolean true") {
+    val json: Json = Json.True
+    val str = writeToString(json)
+    assertEquals(str, "true")
+    assertEquals(readFromString[Json](str), json)
+  }
+
+  test("round-trip: boolean false") {
+    val json: Json = Json.False
+    val str = writeToString(json)
+    assertEquals(str, "false")
+    assertEquals(readFromString[Json](str), json)
+  }
+
+  test("round-trip: string") {
+    val json: Json = Json.fromString("hello")
+    val str = writeToString(json)
+    assertEquals(str, "\"hello\"")
+    assertEquals(readFromString[Json](str), json)
+  }
+
+  test("round-trip: integer number") {
+    val json: Json = Json.fromInt(42)
+    val str = writeToString(json)
+    assertEquals(str, "42")
+    val decoded = readFromString[Json](str)
+    assertEquals(decoded.asNumber.flatMap(_.toInt), Some(42))
+  }
+
+  test("round-trip: long number") {
+    val json: Json = Json.fromLong(9999999999L)
+    val str = writeToString(json)
+    val decoded = readFromString[Json](str)
+    assertEquals(decoded.asNumber.flatMap(_.toLong), Some(9999999999L))
+  }
+
+  test("round-trip: decimal number") {
+    val json: Json = Json.fromBigDecimal(BigDecimal("3.14"))
+    val str = writeToString(json)
+    val decoded = readFromString[Json](str)
+    assertEquals(decoded.asNumber.flatMap(_.toBigDecimal), Some(BigDecimal("3.14")))
+  }
+
+  test("round-trip: empty array") {
+    val json: Json = Json.arr()
+    val str = writeToString(json)
+    assertEquals(str, "[]")
+    assertEquals(readFromString[Json](str), json)
+  }
+
+  test("round-trip: array of mixed values") {
+    val json: Json = Json.arr(Json.fromInt(1), Json.fromString("two"), Json.True, Json.Null)
+    val str = writeToString(json)
+    val decoded = readFromString[Json](str)
+    assertEquals(decoded.asArray.map(_.size), Some(4))
+  }
+
+  test("round-trip: empty object") {
+    val json: Json = Json.obj()
+    val str = writeToString(json)
+    assertEquals(str, "{}")
+    assertEquals(readFromString[Json](str), json)
+  }
+
+  test("round-trip: simple object") {
+    val json: Json = Json.obj("name" -> Json.fromString("Alice"), "age" -> Json.fromInt(30))
+    val str = writeToString(json)
+    val decoded = readFromString[Json](str)
+    assertEquals(decoded.asObject.flatMap(_("name")), Some(Json.fromString("Alice")))
+    assertEquals(decoded.asObject.flatMap(_("age")).flatMap(_.asNumber).flatMap(_.toInt), Some(30))
+  }
+
+  test("round-trip: nested structure") {
+    val json: Json = Json.obj(
+      "users" -> Json.arr(
+        Json.obj("name" -> Json.fromString("Alice"), "active" -> Json.True),
+        Json.obj("name" -> Json.fromString("Bob"), "active" -> Json.False)
+      )
+    )
+    val str = writeToString(json)
+    val decoded = readFromString[Json](str)
+    val users = decoded.asObject.flatMap(_("users")).flatMap(_.asArray)
+    assertEquals(users.map(_.size), Some(2))
+  }
+
+  test("AST: type checks") {
+    assert(Json.Null.isNull)
+    assert(!Json.Null.isBoolean)
+    assert(Json.True.isBoolean)
+    assert(Json.fromInt(1).isNumber)
+    assert(Json.fromString("x").isString)
+    assert(Json.arr().isArray)
+    assert(Json.obj().isObject)
+  }
+
+  test("AST: fold") {
+    val json: Json = Json.fromInt(42)
+    val result = json.fold(
+      onNull = "null",
+      onBoolean = b => s"bool:$b",
+      onNumber = n => s"num:${n.value}",
+      onString = s => s"str:$s",
+      onArray = a => s"arr:${a.size}",
+      onObject = o => s"obj:${o.size}"
+    )
+    assertEquals(result, "num:42")
+  }
+
+  test("JsonObject: apply") {
+    val obj = JsonObject("a" -> Json.fromInt(1), "b" -> Json.fromInt(2))
+    assertEquals(obj("a"), Some(Json.fromInt(1)))
+    assertEquals(obj("c"), None)
+  }
+
+  test("JsonObject: add and remove") {
+    val obj = JsonObject.empty.add("x", Json.fromInt(1))
+    assertEquals(obj("x"), Some(Json.fromInt(1)))
+    val removed = obj.remove("x")
+    assertEquals(removed("x"), None)
+  }
+
+  test("JsonObject: preserves insertion order") {
+    val obj = JsonObject("z" -> Json.Null, "a" -> Json.Null, "m" -> Json.Null)
+    assertEquals(obj.keys, Vector("z", "a", "m"))
+  }
+
+  test("JsonNumber: fromInt roundtrip") {
+    val n = JsonNumber.fromInt(42)
+    assertEquals(n.toInt, Some(42))
+    assertEquals(n.toLong, Some(42L))
+  }
+
+  test("JsonNumber: fromString validation") {
+    assert(JsonNumber.fromString("123").isDefined)
+    assert(JsonNumber.fromString("3.14").isDefined)
+    assert(JsonNumber.fromString("not-a-number").isEmpty)
+  }
+
+  test("JsonNumber: precision preservation") {
+    val n = JsonNumber.fromBigDecimal(BigDecimal("12345678901234567890.12345678901234567890"))
+    assertEquals(n.toBigDecimal, Some(BigDecimal("12345678901234567890.12345678901234567890")))
+  }
+}

--- a/jsoniter-json/src/test/scala/hearth/kindlings/jsoniterjson/JsonOpticsSpec.scala
+++ b/jsoniter-json/src/test/scala/hearth/kindlings/jsoniterjson/JsonOpticsSpec.scala
@@ -1,0 +1,99 @@
+package hearth.kindlings.jsoniterjson
+
+import hearth.kindlings.jsoniterjson.optics.{JsonOptic, JsonPath}
+import munit.FunSuite
+
+final class JsonOpticsSpec extends FunSuite {
+
+  val sampleJson: Json = Json.obj(
+    "name" -> Json.fromString("Alice"),
+    "age" -> Json.fromInt(30),
+    "address" -> Json.obj(
+      "street" -> Json.fromString("123 Main St"),
+      "city" -> Json.fromString("Springfield")
+    ),
+    "scores" -> Json.arr(Json.fromInt(95), Json.fromInt(87), Json.fromInt(92))
+  )
+
+  test("field: get existing field") {
+    val result = JsonOptic.field("name").get(sampleJson)
+    assertEquals(result, Some(Json.fromString("Alice")))
+  }
+
+  test("field: get missing field") {
+    val result = JsonOptic.field("missing").get(sampleJson)
+    assertEquals(result, None)
+  }
+
+  test("field: modify field") {
+    val modified = JsonOptic.field("name").set(Json.fromString("Bob"))(sampleJson)
+    assertEquals(JsonOptic.field("name").get(modified), Some(Json.fromString("Bob")))
+  }
+
+  test("index: get element") {
+    val scores = JsonOptic.field("scores").get(sampleJson).get
+    val result = JsonOptic.index(0).get(scores)
+    assertEquals(result, Some(Json.fromInt(95)))
+  }
+
+  test("index: get out of bounds") {
+    val scores = JsonOptic.field("scores").get(sampleJson).get
+    val result = JsonOptic.index(99).get(scores)
+    assertEquals(result, None)
+  }
+
+  test("index: modify element") {
+    val scores = JsonOptic.field("scores").get(sampleJson).get
+    val modified = JsonOptic.index(1).set(Json.fromInt(100))(scores)
+    assertEquals(JsonOptic.index(1).get(modified), Some(Json.fromInt(100)))
+  }
+
+  test("composed: field then field") {
+    val optic = JsonOptic.field("address").andThen(JsonOptic.field("city"))
+    assertEquals(optic.get(sampleJson), Some(Json.fromString("Springfield")))
+  }
+
+  test("composed: field then index") {
+    val optic = JsonOptic.field("scores").andThen(JsonOptic.index(2))
+    assertEquals(optic.get(sampleJson), Some(Json.fromInt(92)))
+  }
+
+  test("composed: modify deeply nested") {
+    val optic = JsonOptic.field("address").andThen(JsonOptic.field("city"))
+    val modified = optic.set(Json.fromString("Shelbyville"))(sampleJson)
+    assertEquals(optic.get(modified), Some(Json.fromString("Shelbyville")))
+  }
+
+  test("each: getAll from array") {
+    val scores = JsonOptic.field("scores").get(sampleJson).get
+    val all = JsonOptic.each.getAll(scores)
+    assertEquals(all.size, 3)
+  }
+
+  test("each: modify all elements") {
+    val scores = Json.arr(Json.fromInt(1), Json.fromInt(2), Json.fromInt(3))
+    val modified = JsonOptic.each.modify(_ => Json.fromInt(0))(scores)
+    assertEquals(modified, Json.arr(Json.fromInt(0), Json.fromInt(0), Json.fromInt(0)))
+  }
+
+  test("JsonPath: chained field access") {
+    val result = JsonPath.root.field("address").field("street").get(sampleJson)
+    assertEquals(result, Some(Json.fromString("123 Main St")))
+  }
+
+  test("JsonPath: field then index access") {
+    val result = JsonPath.root.field("scores").index(0).get(sampleJson)
+    assertEquals(result, Some(Json.fromInt(95)))
+  }
+
+  test("JsonPath: modify via path") {
+    val modified = JsonPath.root.field("address").field("city").set(Json.fromString("Capital City"))(sampleJson)
+    val result = JsonPath.root.field("address").field("city").get(modified)
+    assertEquals(result, Some(Json.fromString("Capital City")))
+  }
+
+  test("JsonPath: get from root") {
+    val result = JsonPath.root.get(sampleJson)
+    assertEquals(result, Some(sampleJson))
+  }
+}


### PR DESCRIPTION
 - sanely-automatic derivation of Jsoniter codecs
   - with nice compilation errors
   - and debug logs on demand
 - extension methods with inlined body (if there is not type class)
 - JSON AST that does not rely on Circe
 - extension methods for invariant mapping the codecs (map/mapDecoder

Perhaps the author of Jsoniter Scala would not be happy with my code here, but I am happy that Claude Code wrote 100% of it, hands-off, while I could focus on $work.