### PR TITLE
Add Refined and Iron value type integrations with integration tests

### DIFF
--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -479,6 +479,7 @@ trait DecoderMacrosImpl { this: MacroCommons & StdExtensions & SchemaForMacrosIm
 
   object DecHandleAsValueTypeRule extends DecoderDerivationRule("handle as value type when possible") {
 
+    @scala.annotation.nowarn("msg=is never used")
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
         Type[A] match {
@@ -486,9 +487,19 @@ trait DecoderMacrosImpl { this: MacroCommons & StdExtensions & SchemaForMacrosIm
             import isValueType.Underlying as Inner
             for {
               innerResult <- deriveDecoderRecursively[Inner](using dctx.nest[Inner](dctx.avroValue))
-            } yield {
-              val wrapped = isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[A]]
-              Rule.matched(wrapped)
+            } yield isValueType.value.wrap match {
+              case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                // Wrap returns Either[String, A] — throw AvroRuntimeException on Left
+                val eitherResult = isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[String, A]]]
+                Rule.matched(Expr.quote {
+                  Expr.splice(eitherResult) match {
+                    case scala.Right(v)  => v
+                    case scala.Left(msg) => throw new org.apache.avro.AvroRuntimeException(msg)
+                  }
+                })
+              case _ =>
+                // PlainValue — original behavior
+                Rule.matched(isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[A]])
             }
 
           case _ =>

--- a/build.sbt
+++ b/build.sbt
@@ -296,7 +296,8 @@ val al = new {
     } yield s"$name${if (isJVM(platform)) "" else platform}$scalaSuffix"
     val jvmOnly = if (isJVM(platform)) jvmOnlyProdProjects.map(name => s"$name$scalaSuffix") else Vector.empty
     val scala3Only =
-      if (isScala3(scalaSuffix)) scala3OnlyProdProjects.map(name => s"$name${if (isJVM(platform)) "" else platform}$scalaSuffix")
+      if (isScala3(scalaSuffix))
+        scala3OnlyProdProjects.map(name => s"$name${if (isJVM(platform)) "" else platform}$scalaSuffix")
       else Vector.empty
     crossPlatformProjects ++ jvmOnly ++ scala3Only
   }
@@ -616,8 +617,14 @@ lazy val integrationTests = projectMatrix
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE ++ ironDepForScala3) *)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
-  .dependsOn(fastShowPretty, circeDerivation, jsoniterDerivation, yamlDerivation, tapirSchemaDerivation,
-    refinedIntegration)
+  .dependsOn(
+    fastShowPretty,
+    circeDerivation,
+    jsoniterDerivation,
+    yamlDerivation,
+    tapirSchemaDerivation,
+    refinedIntegration
+  )
   .settings(noPublishSettings *)
   .settings(settings *)
   .settings(dependencies *)

--- a/build.sbt
+++ b/build.sbt
@@ -31,6 +31,8 @@ val versions = new {
   val jsoniterScala = "2.38.9"
   val scalaYaml = "0.3.1"
   val tapir = "1.11.50"
+  val refined = "0.11.3"
+  val iron = "3.0.1"
 
   // Explicitly handle Scala 2.13 and Scala 3 separately.
   def fold[A](scalaVersion: String)(for2_13: => Seq[A], for3: => Seq[A]): Seq[A] =
@@ -276,19 +278,27 @@ val al = new {
       "jsoniterJson",
       "yamlDerivation",
       "jsonSchemaConfigMacroProviders",
-      "tapirSchemaDerivation"
+      "tapirSchemaDerivation",
+      "refinedIntegration"
     )
 
   private val jvmOnlyProdProjects = Vector("avroDerivation")
 
+  private val scala3OnlyProdProjects = Vector("ironIntegration")
+
   private def isJVM(platform: String): Boolean = platform == "JVM"
+
+  private def isScala3(scalaSuffix: String): Boolean = scalaSuffix == "3"
 
   private def projects(platform: String, scalaSuffix: String): Vector[String] = {
     val crossPlatformProjects = for {
       name <- prodProjects
     } yield s"$name${if (isJVM(platform)) "" else platform}$scalaSuffix"
     val jvmOnly = if (isJVM(platform)) jvmOnlyProdProjects.map(name => s"$name$scalaSuffix") else Vector.empty
-    crossPlatformProjects ++ jvmOnly
+    val scala3Only =
+      if (isScala3(scalaSuffix)) scala3OnlyProdProjects.map(name => s"$name${if (isJVM(platform)) "" else platform}$scalaSuffix")
+      else Vector.empty
+    crossPlatformProjects ++ jvmOnly ++ scala3Only
   }
 
   def ci(platform: String, scalaSuffix: String): String = {
@@ -318,7 +328,11 @@ val al = new {
     } yield s"$name${if (isJVM(platform)) "" else platform}$scalaSuffix/publishLocal"
     val jvmOnly =
       if (isJVM(platform)) jvmOnlyProdProjects.map(name => s"$name$scalaSuffix/publishLocal") else Vector.empty
-    crossPlatform ++ jvmOnly
+    val scala3Only =
+      if (isScala3(scalaSuffix))
+        scala3OnlyProdProjects.map(name => s"$name${if (isJVM(platform)) "" else platform}$scalaSuffix/publishLocal")
+      else Vector.empty
+    crossPlatform ++ jvmOnly ++ scala3Only
   }
 
   val publishLocalForTests = (publishLocal("JVM", "") ++ publishLocal("JVM", "3")).mkString(" ; ")
@@ -340,6 +354,9 @@ lazy val root = project
   .aggregate(avroDerivation.projectRefs *)
   .aggregate(jsonSchemaConfigMacroProviders.projectRefs *)
   .aggregate(tapirSchemaDerivation.projectRefs *)
+  .aggregate(refinedIntegration.projectRefs *)
+  .aggregate(ironIntegration.projectRefs *)
+  .aggregate(integrationTests.projectRefs *)
   .settings(
     moduleName := "kindlings",
     name := "kindlings",
@@ -551,3 +568,70 @@ lazy val tapirSchemaDerivation = projectMatrix
   )
   .dependsOn(circeDerivation % Test)
   .dependsOn(jsoniterDerivation % Test)
+
+lazy val refinedIntegration = projectMatrix
+  .in(file("refined-integration"))
+  .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .enablePlugins(GitVersioning, GitBranchPrompt)
+  .disablePlugins(WelcomePlugin)
+  .settings(
+    moduleName := "kindlings-refined-integration",
+    name := "kindlings-refined-integration",
+    description := "Refined types integration — IsValueType provider for eu.timepit.refined.api.Refined",
+    macroExtensionTraits := Seq("hearth.std.StandardMacroExtension")
+  )
+  .settings(settings *)
+  .settings(dependencies *)
+  .settings(versionSchemeSettings *)
+  .settings(publishSettings *)
+  .settings(libraryDependencies += "eu.timepit" %%% "refined" % versions.refined)
+
+lazy val ironIntegration = projectMatrix
+  .in(file("iron-integration"))
+  .someVariations(List(versions.scala3), versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .enablePlugins(GitVersioning, GitBranchPrompt)
+  .disablePlugins(WelcomePlugin)
+  .settings(
+    moduleName := "kindlings-iron-integration",
+    name := "kindlings-iron-integration",
+    description := "Iron types integration — IsValueType provider for io.github.iltotore.iron.IronType",
+    macroExtensionTraits := Seq("hearth.std.StandardMacroExtension")
+  )
+  .settings(settings *)
+  .settings(dependencies *)
+  .settings(versionSchemeSettings *)
+  .settings(publishSettings *)
+  .settings(libraryDependencies += "io.github.iltotore" %%% "iron" % versions.iron)
+
+// Iron dependency added conditionally for Scala 3 only (ironIntegration has no Scala 2.13 rows)
+val ironDepForScala3 = List(
+  MatrixAction.ForScala(_.isScala3).Configure { project =>
+    val suffix = project.id.stripPrefix("integrationTests") // "3", "JS3", "Native3"
+    project.dependsOn(LocalProject(s"ironIntegration$suffix"))
+  }
+)
+
+lazy val integrationTests = projectMatrix
+  .in(file("integration-tests"))
+  .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE ++ ironDepForScala3) *)
+  .enablePlugins(GitVersioning, GitBranchPrompt)
+  .disablePlugins(WelcomePlugin)
+  .dependsOn(fastShowPretty, circeDerivation, jsoniterDerivation, yamlDerivation, tapirSchemaDerivation,
+    refinedIntegration)
+  .settings(noPublishSettings *)
+  .settings(settings *)
+  .settings(dependencies *)
+  .settings(
+    libraryDependencies ++= Seq(
+      "eu.timepit" %%% "refined" % versions.refined,
+      "io.circe" %%% "circe-core" % versions.circe,
+      "io.circe" %%% "circe-parser" % versions.circe,
+      "com.github.plokhotnyuk.jsoniter-scala" %%% "jsoniter-scala-core" % versions.jsoniterScala,
+      "org.virtuslab" %%% "scala-yaml" % versions.scalaYaml,
+      "com.softwaremill.sttp.tapir" %%% "tapir-core" % versions.tapir
+    ),
+    libraryDependencies ++= versions.fold(scalaVersion.value)(
+      for3 = Seq("io.github.iltotore" %%% "iron" % versions.iron),
+      for2_13 = Seq.empty
+    )
+  )

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -582,18 +582,41 @@ trait DecoderMacrosImpl { this: MacroCommons & StdExtensions & AnnotationSupport
             // Summon a Decoder[Inner]
             DTypes.Decoder[Inner].summonExprIgnoring(DecUseImplicitWhenAvailableRule.ignoredImplicits*).toEither match {
               case Right(innerDecoder) =>
-                // Build wrap lambda outside quotes to avoid staging issues with wrap.Result type
-                LambdaBuilder
-                  .of1[Inner]("inner")
-                  .traverse { innerExpr =>
-                    MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
-                  }
-                  .map { builder =>
-                    val wrapLambda = builder.build[A]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(innerDecoder).apply(Expr.splice(dctx.cursor)).map(Expr.splice(wrapLambda))
-                    })
-                  }
+                isValueType.value.wrap match {
+                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                    // Wrap returns Either[String, A] — convert Left(String) to Left(DecodingFailure)
+                    @scala.annotation.nowarn("msg=is never used")
+                    implicit val EitherDFA: Type[Either[DecodingFailure, A]] = DTypes.DecoderResult[A]
+                    LambdaBuilder
+                      .of1[Inner]("inner")
+                      .traverse { innerExpr =>
+                        val wrapResult = isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[String, A]]]
+                        MIO.pure(Expr.quote {
+                          Expr.splice(wrapResult).left.map { (msg: String) =>
+                            io.circe.DecodingFailure(msg, Expr.splice(dctx.cursor).history)
+                          }
+                        })
+                      }
+                      .map { builder =>
+                        val wrapLambda = builder.build[Either[DecodingFailure, A]]
+                        Rule.matched(Expr.quote {
+                          Expr.splice(innerDecoder).apply(Expr.splice(dctx.cursor)).flatMap(Expr.splice(wrapLambda))
+                        })
+                      }
+                  case _ =>
+                    // PlainValue — original behavior
+                    LambdaBuilder
+                      .of1[Inner]("inner")
+                      .traverse { innerExpr =>
+                        MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
+                      }
+                      .map { builder =>
+                        val wrapLambda = builder.build[A]
+                        Rule.matched(Expr.quote {
+                          Expr.splice(innerDecoder).apply(Expr.splice(dctx.cursor)).map(Expr.splice(wrapLambda))
+                        })
+                      }
+                }
               case Left(reason) =>
                 MIO.pure(Rule.yielded(s"Value type inner ${Type[Inner].prettyPrint} has no Decoder: $reason"))
             }
@@ -809,27 +832,65 @@ trait DecoderMacrosImpl { this: MacroCommons & StdExtensions & AnnotationSupport
                   import isValueType.Underlying as Inner
                   deriveKeyDecoder[Inner].flatMap {
                     case Some(innerKeyDecoder) =>
-                      // Build wrap lambda outside quotes
-                      LambdaBuilder
-                        .of1[Inner]("inner")
-                        .traverse { innerExpr =>
-                          MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[K]])
-                        }
-                        .flatMap { wrapBuilder =>
-                          val wrapLambda = wrapBuilder.build[K]
+                      isValueType.value.wrap match {
+                        case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                          // Wrap returns Either[String, K] — convert Left(String) to Left(DecodingFailure)
+                          // EitherDFK implicit is already in scope from line 747
                           LambdaBuilder
-                            .of1[String]("keyStr")
-                            .traverse { keyStrExpr =>
+                            .of1[Inner]("inner")
+                            .traverse { innerExpr =>
+                              val wrapResult =
+                                isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[String, K]]]
                               MIO.pure(Expr.quote {
-                                Expr.splice(innerKeyDecoder).apply(Expr.splice(keyStrExpr)).map(Expr.splice(wrapLambda))
+                                Expr.splice(wrapResult).left.map { (msg: String) =>
+                                  io.circe.DecodingFailure(msg, Nil)
+                                }
                               })
                             }
-                            .map { builder =>
-                              Some(builder.build[Either[DecodingFailure, K]]): Option[
-                                Expr[String => Either[DecodingFailure, K]]
-                              ]
+                            .flatMap { wrapBuilder =>
+                              val wrapLambda = wrapBuilder.build[Either[DecodingFailure, K]]
+                              LambdaBuilder
+                                .of1[String]("keyStr")
+                                .traverse { keyStrExpr =>
+                                  MIO.pure(Expr.quote {
+                                    Expr
+                                      .splice(innerKeyDecoder)
+                                      .apply(Expr.splice(keyStrExpr))
+                                      .flatMap(Expr.splice(wrapLambda))
+                                  })
+                                }
+                                .map { builder =>
+                                  Some(builder.build[Either[DecodingFailure, K]]): Option[
+                                    Expr[String => Either[DecodingFailure, K]]
+                                  ]
+                                }
                             }
-                        }
+                        case _ =>
+                          // PlainValue — original behavior
+                          LambdaBuilder
+                            .of1[Inner]("inner")
+                            .traverse { innerExpr =>
+                              MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[K]])
+                            }
+                            .flatMap { wrapBuilder =>
+                              val wrapLambda = wrapBuilder.build[K]
+                              LambdaBuilder
+                                .of1[String]("keyStr")
+                                .traverse { keyStrExpr =>
+                                  MIO.pure(Expr.quote {
+                                    Expr
+                                      .splice(innerKeyDecoder)
+                                      .apply(Expr.splice(keyStrExpr))
+                                      .map(Expr.splice(wrapLambda))
+                                  })
+                                }
+                                .map { builder =>
+                                  Some(builder.build[Either[DecodingFailure, K]]): Option[
+                                    Expr[String => Either[DecodingFailure, K]]
+                                  ]
+                                }
+                            }
+                      }
                     case None => MIO.pure(None)
                   }
                 case _ =>

--- a/docs/contributing/value-type-integration-skill.md
+++ b/docs/contributing/value-type-integration-skill.md
@@ -1,0 +1,202 @@
+# Value Type Integration Skill
+
+This document covers creating **value type integrations** — modules that teach Hearth's derivation system how to handle types from external libraries (e.g., refined types, iron types) as value types.
+
+## When to create a value type integration
+
+Create a value type integration when:
+- An external library defines wrapper types (opaque types, AnyVal subclasses with private constructors, etc.)
+- These types should be treated as "thin wrappers" around an underlying type
+- Existing encoders/decoders should encode/decode the **underlying** value, not the wrapper
+- The existing `IsValueTypeProviderForAnyVal` and `IsValueTypeProviderForOpaque` cannot handle them (e.g., private constructors, no companion smart constructors)
+
+Do **NOT** create a value type integration for types that need full derivation (multiple fields, sealed hierarchies, etc.) — use a derivation module instead.
+
+## Architecture
+
+### How `IsValueType` works
+
+1. `StandardMacroExtension` implementations register `IsValueType.Provider` instances
+2. When a derivation macro encounters a type, it checks `IsValueType.unapply(tpe)`
+3. Providers are tried in registration order until one matches
+4. The matched `IsValueTypeOf[Outer, Inner]` provides:
+   - `unwrap: Expr[Outer] => Expr[Inner]` — extract the underlying value
+   - `wrap: CtorLikeOf[Inner, Outer]` — construct the wrapper from the underlying value
+   - `ctors: CtorLikes[Outer]` — all available constructors
+
+### `CtorLikeOf` variants
+
+| Variant | `Result[A]` | Use case |
+|---------|------------|----------|
+| `PlainValue` | `A` | No-fail wrapping (AnyVal, opaque `assume`) |
+| `EitherStringOrValue` | `Either[String, A]` | Validated wrapping (refined, iron) |
+| `EitherThrowableOrValue` | `Either[Throwable, A]` | Wrapping that may throw |
+
+For value types with **validation** (refined, iron), set `wrap` to `EitherStringOrValue`. Decoder rules handle Both `PlainValue` and `EitherStringOrValue`:
+- **Circe/YAML** (Either-based decoders): `EitherStringOrValue` → `.flatMap` + convert `Left(String)` to `Left(LibraryError)`
+- **Jsoniter/Avro** (exception-based decoders): `EitherStringOrValue` → match on result, throw on `Left`
+- **Encoders**: only use `unwrap`, so `wrap` variant doesn't matter
+
+### Service discovery via `ServiceResourceGenPlugin`
+
+Setting `macroExtensionTraits := Seq("hearth.std.StandardMacroExtension")` in `build.sbt` causes the plugin to:
+1. Scan compiled classes for implementations of `StandardMacroExtension`
+2. Generate `META-INF/services/hearth.std.StandardMacroExtension` listing the providers
+3. `Environment.loadStandardExtensions()` discovers and registers them at macro expansion time
+
+## Step-by-step: Creating a new integration
+
+### 1. Create the module directory
+
+```
+my-integration/
+└── src/main/scala/hearth/kindlings/myintegration/
+    └── internal/compiletime/
+        └── IsValueTypeProviderForMyType.scala
+```
+
+### 2. Add build configuration
+
+```scala
+// In build.sbt versions:
+val myLib = "x.y.z"
+
+// Project matrix:
+lazy val myIntegration = projectMatrix
+  .in(file("my-integration"))
+  .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .enablePlugins(GitVersioning, GitBranchPrompt)
+  .disablePlugins(WelcomePlugin)
+  .settings(
+    moduleName := "kindlings-my-integration",
+    name := "kindlings-my-integration",
+    description := "My types integration — IsValueType provider for ...",
+    macroExtensionTraits := Seq("hearth.std.StandardMacroExtension")
+  )
+  .settings(settings *)
+  .settings(dependencies *)
+  .settings(versionSchemeSettings *)
+  .settings(publishSettings *)
+  .settings(libraryDependencies += "org.example" %%% "my-lib" % versions.myLib)
+```
+
+Add to: `root` aggregate, `al.prodProjects` (or `al.scala3OnlyProdProjects` for Scala 3-only).
+
+### 3. Implement the provider
+
+```scala
+package hearth.kindlings.myintegration.internal.compiletime
+
+import hearth.fp.data.NonEmptyList
+import hearth.std.{MacroCommons, StandardMacroExtension, StdExtensions}
+
+final class IsValueTypeProviderForMyType extends StandardMacroExtension { loader =>
+
+  override def extend(ctx: MacroCommons & StdExtensions): Unit = {
+    import ctx.*
+
+    IsValueType.registerProvider(new IsValueType.Provider {
+
+      override def name: String = loader.getClass.getName
+
+      // Always use fromUntyped for cross-compilation-boundary compatibility
+      private lazy val MyTypeCtor = {
+        val impl = Type.Ctor2.of[mylib.MyType]  // or Ctor1 for single-param
+        Type.Ctor2.fromUntyped[mylib.MyType](impl.asUntyped)
+      }
+
+      @scala.annotation.nowarn("msg=is never used")
+      override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
+        MyTypeCtor.unapply(tpe) match {
+          case Some(types) =>
+            import types.{A => Inner, B => Param}
+            implicit val AT: Type[A] = tpe
+
+            val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr => /* extract inner value */
+            val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
+              ctor = innerExpr => /* validate and wrap, returning Either[String, A] */,
+              method = None
+            )
+
+            ProviderResult.Matched(Existential[IsValueTypeOf[A, *], Inner](
+              new IsValueTypeOf[A, Inner] {
+                override val unwrap = unwrapExpr
+                override val wrap = eitherCtor
+                override lazy val ctors = NonEmptyList.one(
+                  Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                )
+              }
+            ))
+
+          case None => skipped(s"${tpe.prettyPrint} is not a MyType")
+        }
+    })
+  }
+}
+```
+
+### 4. Add tests to `integration-tests`
+
+Add test types to `integration-tests/src/test/scala/` (or `scala-3/` for Scala 3-only types) and create spec files following the pattern in existing refined/iron specs.
+
+### 5. Verify
+
+```bash
+# Compile the integration module
+sbt --client "myIntegration/clean ; myIntegration3/clean ; myIntegration/compile ; myIntegration3/compile"
+
+# Run existing tests (verify no regressions)
+sbt --client "test-jvm-2_13 ; test-jvm-3"
+
+# Run integration tests
+sbt --client "integrationTests/test ; integrationTests3/test"
+```
+
+## Cross-compilation considerations
+
+- **Shared code** (Scala 2 + 3): Place in `src/main/scala/`. Use Hearth's macro-agnostic APIs (`Expr.quote`, `Type.of`, etc.).
+- **Scala 3 only**: Can use `scala.compiletime.summonInline` and other Scala 3 features directly.
+- **`@nowarn` for unused types**: `implicit Type[X]` needed by `Expr.quote` may trigger "never used" warnings. Wrap with `@scala.annotation.nowarn("msg=is never used")`.
+- **Path-dependent types in quotes**: Types from `Type.Ctor2.unapply` are path-dependent. They generally work in cross-quotes, but if issues arise, use `LambdaBuilder` or `asInstanceOf` to avoid direct type references.
+
+### Critical: `Type.Ctor2.fromUntyped` for cross-compilation-boundary matching
+
+When a provider module is compiled separately from the downstream project that triggers macro expansion, `Type.Ctor2.of[F]` may fail to match types. This happens because the `Impl` class (generated by `of`) captures `scala.quoted.Type[F]` at compile time of the provider module, which may resolve to a different internal `TypeRepr` path than the types seen during macro expansion in the downstream project.
+
+**Always use `fromUntyped`** to create your `Ctor2`:
+
+```scala
+// WRONG — may fail across compilation boundaries:
+private lazy val MyCtor = Type.Ctor2.of[mylib.MyType]
+
+// CORRECT — uses =:= and baseType for matching, handles path differences:
+private lazy val MyCtor = {
+  val impl = Type.Ctor2.of[mylib.MyType]
+  Type.Ctor2.fromUntyped[mylib.MyType](impl.asUntyped)
+}
+```
+
+The `FromUntypedImpl.unapply` uses `TypeRepr.=:=` (semantic type equality) and `baseType` (symbol-based lookup) for matching, which correctly handles different internal path representations. The `Impl.unapply` uses `case '[HKT[a, b]]` pattern matching which is sensitive to `Type[HKT]` compilation context.
+
+This pattern applies to both `Type.Ctor1` and `Type.Ctor2`, and also for summoning types:
+
+```scala
+val validateType: Type[Validate[Inner, Pred]] = {
+  val impl = Type.Ctor2.of[Validate]
+  Type.Ctor2.fromUntyped[Validate](impl.asUntyped).apply[Inner, Pred]
+}
+```
+
+## Reference implementation
+
+- **Refined integration**: `refined-integration/src/main/scala/.../IsValueTypeProviderForRefined.scala` — cross-compiled (Scala 2 + 3), uses `refineV` for validation, `Refined.unapply` for unwrapping
+- **Iron integration**: `iron-integration/src/main/scala/.../IsValueTypeProviderForIron.scala` — Scala 3 only, uses `RuntimeConstraint.test` for validation, `asInstanceOf` for unwrapping (opaque type)
+
+## Checklist for new integrations
+
+- [ ] Module directory and `build.sbt` configuration
+- [ ] `macroExtensionTraits` set to `"hearth.std.StandardMacroExtension"`
+- [ ] `IsValueType.Provider` implementation with `unwrap`, `wrap` (EitherStringOrValue), and `ctors`
+- [ ] Added to `root` aggregate and appropriate project lists (`prodProjects` / `scala3OnlyProdProjects`)
+- [ ] Integration tests covering: encoding, decoding valid, decoding invalid, round-trip
+- [ ] Tests pass on all target platforms: `sbt --client "test-jvm-2_13 ; test-jvm-3"`

--- a/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronCirceSpec.scala
+++ b/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronCirceSpec.scala
@@ -1,0 +1,67 @@
+package hearth.kindlings.integrationtests
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.any.*
+import io.github.iltotore.iron.constraint.numeric.*
+import io.github.iltotore.iron.constraint.string.*
+import hearth.MacroSuite
+import hearth.kindlings.circederivation.{KindlingsDecoder, KindlingsEncoder}
+import io.circe.Json
+
+final class IronCirceSpec extends MacroSuite {
+
+  group("Iron + Circe") {
+
+    group("encoding") {
+
+      test("iron value encodes as underlying type") {
+        val age: Int :| Positive = 30
+        KindlingsEncoder.encode(age) ==> Json.fromInt(30)
+      }
+
+      test("case class with iron fields encodes normally") {
+        val person = IronPerson("Alice", 30)
+        val expected = Json.obj("name" -> Json.fromString("Alice"), "age" -> Json.fromInt(30))
+        KindlingsEncoder.encode(person) ==> expected
+      }
+    }
+
+    group("decoding valid") {
+
+      test("iron value decodes from valid underlying") {
+        val result = KindlingsDecoder.decode[Int :| Positive](Json.fromInt(42))
+        assert(result.isRight, s"Expected Right but got $result")
+      }
+
+      test("case class with iron fields decodes valid JSON") {
+        val json = Json.obj("name" -> Json.fromString("Alice"), "age" -> Json.fromInt(30))
+        val result = KindlingsDecoder.decode[IronPerson](json)
+        assert(result.isRight, s"Expected Right but got $result")
+      }
+    }
+
+    group("decoding invalid") {
+
+      test("iron positive rejects negative") {
+        val result = KindlingsDecoder.decode[Int :| Positive](Json.fromInt(-1))
+        assert(result.isLeft, s"Expected Left but got $result")
+      }
+
+      test("case class with invalid iron field produces error") {
+        val json = Json.obj("name" -> Json.fromString("Alice"), "age" -> Json.fromInt(-1))
+        val result = KindlingsDecoder.decode[IronPerson](json)
+        assert(result.isLeft, s"Expected Left but got $result")
+      }
+    }
+
+    group("round-trip") {
+
+      test("encode then decode preserves value") {
+        val person = IronPerson("Alice", 30)
+        val json = KindlingsEncoder.encode(person)
+        val decoded = KindlingsDecoder.decode[IronPerson](json)
+        assert(decoded.isRight, s"Expected Right but got $decoded")
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronFastShowPrettySpec.scala
+++ b/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronFastShowPrettySpec.scala
@@ -1,0 +1,26 @@
+package hearth.kindlings.integrationtests
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.any.*
+import io.github.iltotore.iron.constraint.numeric.*
+import io.github.iltotore.iron.constraint.string.*
+import hearth.MacroSuite
+import hearth.kindlings.fastshowpretty.{FastShowPretty, RenderConfig}
+
+final class IronFastShowPrettySpec extends MacroSuite {
+
+  group("Iron + FastShowPretty") {
+
+    test("iron value renders as underlying") {
+      val age: Int :| Positive = 30
+      FastShowPretty.render(age, RenderConfig.Default) ==> "30"
+    }
+
+    test("case class with iron fields renders normally") {
+      val person = IronPerson("Alice", 30)
+      val result = FastShowPretty.render(person, RenderConfig.Default)
+      assert(result.contains("Alice"), s"Expected 'Alice' in: $result")
+      assert(result.contains("30"), s"Expected '30' in: $result")
+    }
+  }
+}

--- a/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronJsoniterSpec.scala
+++ b/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronJsoniterSpec.scala
@@ -1,0 +1,64 @@
+package hearth.kindlings.integrationtests
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.any.*
+import io.github.iltotore.iron.constraint.numeric.*
+import io.github.iltotore.iron.constraint.string.*
+import hearth.MacroSuite
+import hearth.kindlings.jsoniterderivation.KindlingsJsonValueCodec
+
+final class IronJsoniterSpec extends MacroSuite {
+
+  group("Iron + Jsoniter") {
+
+    group("encoding") {
+
+      test("case class with iron fields encodes correctly") {
+        val person = IronPerson("Alice", 30)
+        val codec = KindlingsJsonValueCodec.derived[IronPerson]
+        val json = new String(
+          com.github.plokhotnyuk.jsoniter_scala.core.writeToArray(person)(codec),
+          "UTF-8"
+        )
+        assert(json.contains("\"name\":\"Alice\""))
+        assert(json.contains("\"age\":30"))
+      }
+    }
+
+    group("decoding valid") {
+
+      test("case class with iron fields decodes valid JSON") {
+        val codec = KindlingsJsonValueCodec.derived[IronPerson]
+        val result = com.github.plokhotnyuk.jsoniter_scala.core.readFromString(
+          """{"name":"Alice","age":30}"""
+        )(codec)
+        assertEquals(result.name: String, "Alice")
+        assertEquals(result.age: Int, 30)
+      }
+    }
+
+    group("decoding invalid") {
+
+      test("iron positive rejects negative with error") {
+        val codec = KindlingsJsonValueCodec.derived[IronPerson]
+        intercept[com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException] {
+          com.github.plokhotnyuk.jsoniter_scala.core.readFromString(
+            """{"name":"Alice","age":-1}"""
+          )(codec)
+        }
+      }
+    }
+
+    group("round-trip") {
+
+      test("encode then decode preserves value") {
+        val codec = KindlingsJsonValueCodec.derived[IronPerson]
+        val person = IronPerson("Alice", 30)
+        val bytes = com.github.plokhotnyuk.jsoniter_scala.core.writeToArray(person)(codec)
+        val decoded = com.github.plokhotnyuk.jsoniter_scala.core.readFromArray(bytes)(codec)
+        assertEquals(decoded.name: String, "Alice")
+        assertEquals(decoded.age: Int, 30)
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronTapirSchemaSpec.scala
+++ b/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronTapirSchemaSpec.scala
@@ -1,0 +1,34 @@
+package hearth.kindlings.integrationtests
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.any.*
+import io.github.iltotore.iron.constraint.numeric.*
+import io.github.iltotore.iron.constraint.string.*
+import hearth.MacroSuite
+import hearth.kindlings.circederivation.Configuration
+import hearth.kindlings.tapirschemaderivation.{KindlingsSchema, PreferSchemaConfig}
+import sttp.tapir.{Schema, SchemaType}
+
+final class IronTapirSchemaSpec extends MacroSuite {
+
+  implicit val preferCirce: PreferSchemaConfig[Configuration] = PreferSchemaConfig[Configuration]
+
+  group("Iron + Tapir Schema") {
+
+    test("iron int has integer schema type") {
+      val schema = KindlingsSchema.derived[Int :| Positive]
+      assert(
+        schema.schema.schemaType.isInstanceOf[SchemaType.SInteger[?]],
+        s"Expected SInteger but got ${schema.schema.schemaType}"
+      )
+    }
+
+    test("case class with iron fields derives product schema") {
+      val schema = KindlingsSchema.derived[IronPerson]
+      assert(
+        schema.schema.schemaType.isInstanceOf[SchemaType.SProduct[?]],
+        s"Expected SProduct but got ${schema.schema.schemaType}"
+      )
+    }
+  }
+}

--- a/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronYamlSpec.scala
+++ b/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/IronYamlSpec.scala
@@ -1,0 +1,47 @@
+package hearth.kindlings.integrationtests
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.numeric.*
+import io.github.iltotore.iron.constraint.string.*
+import hearth.MacroSuite
+import hearth.kindlings.yamlderivation.{KindlingsYamlDecoder, KindlingsYamlEncoder}
+import org.virtuslab.yaml.Node
+import org.virtuslab.yaml.Node.{MappingNode, ScalarNode}
+
+final class IronYamlSpec extends MacroSuite {
+
+  private def scalarNode(value: String): Node = ScalarNode(value)
+
+  private def mappingOf(entries: (String, Node)*): Node =
+    MappingNode(entries.map { case (k, v) => (ScalarNode(k): Node) -> v }.toMap)
+
+  group("Iron + YAML") {
+
+    group("encoding") {
+
+      test("case class with iron fields encodes correctly") {
+        val person = IronPerson("Alice", 30)
+        val node = KindlingsYamlEncoder.encode(person)
+        node ==> mappingOf("name" -> scalarNode("Alice"), "age" -> scalarNode("30"))
+      }
+    }
+
+    group("decoding valid") {
+
+      test("case class with iron fields decodes valid YAML") {
+        val node = mappingOf("name" -> scalarNode("Alice"), "age" -> scalarNode("30"))
+        val result = KindlingsYamlDecoder.decode[IronPerson](node)
+        assert(result.isRight, s"Expected Right but got $result")
+      }
+    }
+
+    group("decoding invalid") {
+
+      test("iron positive rejects negative") {
+        val node = mappingOf("name" -> scalarNode("Alice"), "age" -> scalarNode("-1"))
+        val result = KindlingsYamlDecoder.decode[IronPerson](node)
+        assert(result.isLeft, s"Expected Left but got $result")
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/ironExamples.scala
+++ b/integration-tests/src/test/scala-3/hearth/kindlings/integrationtests/ironExamples.scala
@@ -1,0 +1,9 @@
+package hearth.kindlings.integrationtests
+
+import io.github.iltotore.iron.*
+import io.github.iltotore.iron.constraint.any.*
+import io.github.iltotore.iron.constraint.numeric.*
+import io.github.iltotore.iron.constraint.string.*
+
+case class IronPerson(name: String :| Not[Blank], age: Int :| Positive)
+case class WithIronOption(value: Option[Int :| Positive])

--- a/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedCirceSpec.scala
+++ b/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedCirceSpec.scala
@@ -1,0 +1,79 @@
+package hearth.kindlings.integrationtests
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.Positive
+import eu.timepit.refined.refineV
+import hearth.MacroSuite
+import hearth.kindlings.circederivation.{KindlingsDecoder, KindlingsEncoder}
+import io.circe.Json
+
+final class RefinedCirceSpec extends MacroSuite {
+
+  private val alice = refineV[NonEmpty]("Alice").toOption.get
+  private val thirty = refineV[Positive](30).toOption.get
+
+  group("Refined + Circe") {
+
+    group("encoding") {
+
+      test("case class with refined fields encodes normally") {
+        val person = RefinedPerson(alice, thirty)
+        val expected = Json.obj("name" -> Json.fromString("Alice"), "age" -> Json.fromInt(30))
+        KindlingsEncoder.encode(person) ==> expected
+      }
+    }
+
+    group("decoding valid") {
+
+      test("refined value decodes from valid underlying") {
+        val result = KindlingsDecoder.decode[String Refined NonEmpty](Json.fromString("hello"))
+        assert(result.isRight)
+        result.foreach(v => assertEquals(v.value, "hello"))
+      }
+
+      test("case class with refined fields decodes valid JSON") {
+        val json = Json.obj("name" -> Json.fromString("Alice"), "age" -> Json.fromInt(30))
+        val result = KindlingsDecoder.decode[RefinedPerson](json)
+        assert(result.isRight)
+        result.foreach { p =>
+          assertEquals(p.name.value, "Alice")
+          assertEquals(p.age.value, 30)
+        }
+      }
+    }
+
+    group("decoding invalid") {
+
+      test("refined value rejects invalid underlying with error") {
+        val result = KindlingsDecoder.decode[String Refined NonEmpty](Json.fromString(""))
+        assert(result.isLeft, s"Expected Left but got $result")
+      }
+
+      test("refined positive rejects negative") {
+        val result = KindlingsDecoder.decode[Int Refined Positive](Json.fromInt(-1))
+        assert(result.isLeft, s"Expected Left but got $result")
+      }
+
+      test("case class with invalid refined field produces error") {
+        val json = Json.obj("name" -> Json.fromString(""), "age" -> Json.fromInt(30))
+        val result = KindlingsDecoder.decode[RefinedPerson](json)
+        assert(result.isLeft, s"Expected Left but got $result")
+      }
+    }
+
+    group("round-trip") {
+
+      test("encode then decode preserves value") {
+        val person = RefinedPerson(alice, thirty)
+        val json = KindlingsEncoder.encode(person)
+        val decoded = KindlingsDecoder.decode[RefinedPerson](json)
+        assert(decoded.isRight)
+        decoded.foreach { p =>
+          assertEquals(p.name.value, "Alice")
+          assertEquals(p.age.value, 30)
+        }
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedFastShowPrettySpec.scala
+++ b/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedFastShowPrettySpec.scala
@@ -1,0 +1,23 @@
+package hearth.kindlings.integrationtests
+
+import eu.timepit.refined.refineV
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.Positive
+import hearth.MacroSuite
+import hearth.kindlings.fastshowpretty.{FastShowPretty, RenderConfig}
+
+final class RefinedFastShowPrettySpec extends MacroSuite {
+
+  private val alice = refineV[NonEmpty]("Alice").toOption.get
+  private val thirty = refineV[Positive](30).toOption.get
+
+  group("Refined + FastShowPretty") {
+
+    test("case class with refined fields renders normally") {
+      val person = RefinedPerson(alice, thirty)
+      val result = FastShowPretty.render(person, RenderConfig.Default)
+      assert(result.contains("Alice"), s"Expected 'Alice' in: $result")
+      assert(result.contains("30"), s"Expected '30' in: $result")
+    }
+  }
+}

--- a/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedJsoniterSpec.scala
+++ b/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedJsoniterSpec.scala
@@ -1,0 +1,76 @@
+package hearth.kindlings.integrationtests
+
+import eu.timepit.refined.refineV
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.Positive
+import hearth.MacroSuite
+import hearth.kindlings.jsoniterderivation.KindlingsJsonValueCodec
+
+final class RefinedJsoniterSpec extends MacroSuite {
+
+  private val alice = refineV[NonEmpty]("Alice").toOption.get
+  private val thirty = refineV[Positive](30).toOption.get
+
+  group("Refined + Jsoniter") {
+
+    group("encoding") {
+
+      test("case class with refined fields encodes correctly") {
+        val person = RefinedPerson(alice, thirty)
+        val json = new String(
+          com.github.plokhotnyuk.jsoniter_scala.core.writeToArray(person)(
+            KindlingsJsonValueCodec.derived[RefinedPerson]
+          ),
+          "UTF-8"
+        )
+        assert(json.contains("\"name\":\"Alice\""))
+        assert(json.contains("\"age\":30"))
+      }
+    }
+
+    group("decoding valid") {
+
+      test("case class with refined fields decodes valid JSON") {
+        val codec = KindlingsJsonValueCodec.derived[RefinedPerson]
+        val result = com.github.plokhotnyuk.jsoniter_scala.core.readFromString(
+          """{"name":"Alice","age":30}"""
+        )(codec)
+        assertEquals(result.name.value, "Alice")
+        assertEquals(result.age.value, 30)
+      }
+    }
+
+    group("decoding invalid") {
+
+      test("refined positive rejects negative with error") {
+        val codec = KindlingsJsonValueCodec.derived[RefinedPerson]
+        intercept[com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException] {
+          com.github.plokhotnyuk.jsoniter_scala.core.readFromString(
+            """{"name":"Alice","age":-1}"""
+          )(codec)
+        }
+      }
+
+      test("refined non-empty rejects empty string with error") {
+        val codec = KindlingsJsonValueCodec.derived[RefinedPerson]
+        intercept[com.github.plokhotnyuk.jsoniter_scala.core.JsonReaderException] {
+          com.github.plokhotnyuk.jsoniter_scala.core.readFromString(
+            """{"name":"","age":30}"""
+          )(codec)
+        }
+      }
+    }
+
+    group("round-trip") {
+
+      test("encode then decode preserves value") {
+        val codec = KindlingsJsonValueCodec.derived[RefinedPerson]
+        val person = RefinedPerson(alice, thirty)
+        val bytes = com.github.plokhotnyuk.jsoniter_scala.core.writeToArray(person)(codec)
+        val decoded = com.github.plokhotnyuk.jsoniter_scala.core.readFromArray(bytes)(codec)
+        assertEquals(decoded.name.value, "Alice")
+        assertEquals(decoded.age.value, 30)
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedTapirSchemaSpec.scala
+++ b/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedTapirSchemaSpec.scala
@@ -1,0 +1,41 @@
+package hearth.kindlings.integrationtests
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.Positive
+import hearth.MacroSuite
+import hearth.kindlings.circederivation.Configuration
+import hearth.kindlings.tapirschemaderivation.{KindlingsSchema, PreferSchemaConfig}
+import sttp.tapir.SchemaType
+
+final class RefinedTapirSchemaSpec extends MacroSuite {
+
+  implicit val preferCirce: PreferSchemaConfig[Configuration] = PreferSchemaConfig[Configuration]
+
+  group("Refined + Tapir Schema") {
+
+    test("refined string has string schema type") {
+      val schema = KindlingsSchema.derived[String Refined NonEmpty]
+      assert(
+        schema.schema.schemaType.isInstanceOf[SchemaType.SString[?]],
+        s"Expected SString but got ${schema.schema.schemaType}"
+      )
+    }
+
+    test("refined int has integer schema type") {
+      val schema = KindlingsSchema.derived[Int Refined Positive]
+      assert(
+        schema.schema.schemaType.isInstanceOf[SchemaType.SInteger[?]],
+        s"Expected SInteger but got ${schema.schema.schemaType}"
+      )
+    }
+
+    test("case class with refined fields derives product schema") {
+      val schema = KindlingsSchema.derived[RefinedPerson]
+      assert(
+        schema.schema.schemaType.isInstanceOf[SchemaType.SProduct[?]],
+        s"Expected SProduct but got ${schema.schema.schemaType}"
+      )
+    }
+  }
+}

--- a/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedYamlSpec.scala
+++ b/integration-tests/src/test/scala/hearth/kindlings/integrationtests/RefinedYamlSpec.scala
@@ -1,0 +1,68 @@
+package hearth.kindlings.integrationtests
+
+import eu.timepit.refined.refineV
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.Positive
+import hearth.MacroSuite
+import hearth.kindlings.yamlderivation.{KindlingsYamlDecoder, KindlingsYamlEncoder}
+import org.virtuslab.yaml.Node
+import org.virtuslab.yaml.Node.{MappingNode, ScalarNode}
+
+final class RefinedYamlSpec extends MacroSuite {
+
+  private val alice = refineV[NonEmpty]("Alice").toOption.get
+  private val thirty = refineV[Positive](30).toOption.get
+
+  private def scalarNode(value: String): Node = ScalarNode(value)
+
+  private def mappingOf(entries: (String, Node)*): Node =
+    MappingNode(entries.map { case (k, v) => (ScalarNode(k): Node) -> v }.toMap)
+
+  group("Refined + YAML") {
+
+    group("encoding") {
+
+      test("case class with refined fields encodes correctly") {
+        val person = RefinedPerson(alice, thirty)
+        val node = KindlingsYamlEncoder.encode(person)
+        node ==> mappingOf("name" -> scalarNode("Alice"), "age" -> scalarNode("30"))
+      }
+    }
+
+    group("decoding valid") {
+
+      test("case class with refined fields decodes valid YAML") {
+        val node = mappingOf("name" -> scalarNode("Alice"), "age" -> scalarNode("30"))
+        val result = KindlingsYamlDecoder.decode[RefinedPerson](node)
+        assert(result.isRight, s"Expected Right but got $result")
+        result.foreach { p =>
+          assertEquals(p.name.value, "Alice")
+          assertEquals(p.age.value, 30)
+        }
+      }
+    }
+
+    group("decoding invalid") {
+
+      test("refined positive rejects negative") {
+        val node = mappingOf("name" -> scalarNode("Alice"), "age" -> scalarNode("-1"))
+        val result = KindlingsYamlDecoder.decode[RefinedPerson](node)
+        assert(result.isLeft, s"Expected Left but got $result")
+      }
+    }
+
+    group("round-trip") {
+
+      test("encode then decode preserves value") {
+        val person = RefinedPerson(alice, thirty)
+        val node = KindlingsYamlEncoder.encode(person)
+        val decoded = KindlingsYamlDecoder.decode[RefinedPerson](node)
+        assert(decoded.isRight, s"Expected Right but got $decoded")
+        decoded.foreach { p =>
+          assertEquals(p.name.value, "Alice")
+          assertEquals(p.age.value, 30)
+        }
+      }
+    }
+  }
+}

--- a/integration-tests/src/test/scala/hearth/kindlings/integrationtests/examples.scala
+++ b/integration-tests/src/test/scala/hearth/kindlings/integrationtests/examples.scala
@@ -1,0 +1,9 @@
+package hearth.kindlings.integrationtests
+
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.collection.NonEmpty
+import eu.timepit.refined.numeric.Positive
+
+case class RefinedPerson(name: String Refined NonEmpty, age: Int Refined Positive)
+case class WithRefinedOption(value: Option[Int Refined Positive])
+case class WithRefinedList(values: List[String Refined NonEmpty])

--- a/iron-integration/src/main/scala/hearth/kindlings/ironintegration/internal/compiletime/IsValueTypeProviderForIron.scala
+++ b/iron-integration/src/main/scala/hearth/kindlings/ironintegration/internal/compiletime/IsValueTypeProviderForIron.scala
@@ -1,0 +1,76 @@
+package hearth.kindlings.ironintegration.internal.compiletime
+
+import hearth.fp.data.NonEmptyList
+import hearth.MacroCommons
+import hearth.std.{ProviderResult, StandardMacroExtension, StdExtensions}
+
+final class IsValueTypeProviderForIron extends StandardMacroExtension { loader =>
+
+  override def extend(ctx: MacroCommons & StdExtensions): Unit = {
+    import ctx.*
+
+    IsValueType.registerProvider(new IsValueType.Provider {
+
+      override def name: String = loader.getClass.getName
+
+      // Use fromUntyped to avoid cross-compilation-boundary issues with Type.Ctor2.of.
+      // The Impl (from .of) captures scala.quoted.Type[HKT] at compile time, which may
+      // resolve to a different TypeRepr path than the one seen during macro expansion in
+      // downstream projects. FromUntypedImpl uses =:= and baseType for matching, which
+      // handles path differences correctly.
+      private lazy val IronTypeCtor = {
+        val impl = Type.Ctor2.of[io.github.iltotore.iron.IronType]
+        Type.Ctor2.fromUntyped[io.github.iltotore.iron.IronType](impl.asUntyped)
+      }
+
+      @scala.annotation.nowarn("msg=is never used")
+      override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
+        IronTypeCtor.unapply(tpe) match {
+          case Some((inner, constraint)) =>
+            import inner.Underlying as Inner
+            import constraint.Underlying as Constr
+            implicit val AT: Type[A] = tpe
+
+            // Construct Type[RuntimeConstraint[Inner, Constr]] for summoning
+            // NOT implicit to avoid Type.of bootstrap cycle
+            val runtimeConstraintType: Type[io.github.iltotore.iron.RuntimeConstraint[Inner, Constr]] =
+              Type.Ctor2.of[io.github.iltotore.iron.RuntimeConstraint].apply[Inner, Constr]
+
+            // Unwrap: IronType is opaque — underlying value IS the same type at runtime
+            val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr =>
+              Expr.quote { Expr.splice(outerExpr).asInstanceOf[Inner] }
+
+            // Wrap (runtime): validate via RuntimeConstraint[Inner, C].test + .message
+            val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
+              ctor = innerExpr => {
+                // Summon RuntimeConstraint[Inner, Constr] at macro expansion time
+                val constraintExpr = Expr.summonImplicit(using runtimeConstraintType).toOption.getOrElse(
+                  throw new RuntimeException(
+                    s"No RuntimeConstraint instance found for IronType[${Type[Inner].prettyPrint}, ${Type[Constr].prettyPrint}]"
+                  )
+                )
+                Expr.quote {
+                  val v = Expr.splice(innerExpr)
+                  val c = Expr.splice(constraintExpr)
+                  if (c.test(v)) Right(v.asInstanceOf[A])
+                  else Left("Should satisfy " + c.message)
+                }
+              },
+              method = None
+            )
+
+            ProviderResult.Matched(Existential[IsValueTypeOf[A, *], Inner](
+              new IsValueTypeOf[A, Inner] {
+                override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
+                override val wrap: CtorLikeOf[Inner, A] = eitherCtor
+                override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
+                  Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                )
+              }
+            ))
+
+          case None => skipped(s"${tpe.prettyPrint} is not an Iron type")
+        }
+    })
+  }
+}

--- a/iron-integration/src/main/scala/hearth/kindlings/ironintegration/internal/compiletime/IsValueTypeProviderForIron.scala
+++ b/iron-integration/src/main/scala/hearth/kindlings/ironintegration/internal/compiletime/IsValueTypeProviderForIron.scala
@@ -37,18 +37,20 @@ final class IsValueTypeProviderForIron extends StandardMacroExtension { loader =
               Type.Ctor2.of[io.github.iltotore.iron.RuntimeConstraint].apply[Inner, Constr]
 
             // Unwrap: IronType is opaque — underlying value IS the same type at runtime
-            val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr =>
-              Expr.quote { Expr.splice(outerExpr).asInstanceOf[Inner] }
+            val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr => Expr.quote(Expr.splice(outerExpr).asInstanceOf[Inner])
 
             // Wrap (runtime): validate via RuntimeConstraint[Inner, C].test + .message
             val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
               ctor = innerExpr => {
                 // Summon RuntimeConstraint[Inner, Constr] at macro expansion time
-                val constraintExpr = Expr.summonImplicit(using runtimeConstraintType).toOption.getOrElse(
-                  throw new RuntimeException(
-                    s"No RuntimeConstraint instance found for IronType[${Type[Inner].prettyPrint}, ${Type[Constr].prettyPrint}]"
+                val constraintExpr = Expr
+                  .summonImplicit(using runtimeConstraintType)
+                  .toOption
+                  .getOrElse(
+                    throw new RuntimeException(
+                      s"No RuntimeConstraint instance found for IronType[${Type[Inner].prettyPrint}, ${Type[Constr].prettyPrint}]"
+                    )
                   )
-                )
                 Expr.quote {
                   val v = Expr.splice(innerExpr)
                   val c = Expr.splice(constraintExpr)
@@ -59,15 +61,17 @@ final class IsValueTypeProviderForIron extends StandardMacroExtension { loader =
               method = None
             )
 
-            ProviderResult.Matched(Existential[IsValueTypeOf[A, *], Inner](
-              new IsValueTypeOf[A, Inner] {
-                override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
-                override val wrap: CtorLikeOf[Inner, A] = eitherCtor
-                override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
-                  Existential[CtorLikeOf[*, A], Inner](eitherCtor)
-                )
-              }
-            ))
+            ProviderResult.Matched(
+              Existential[IsValueTypeOf[A, *], Inner](
+                new IsValueTypeOf[A, Inner] {
+                  override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
+                  override val wrap: CtorLikeOf[Inner, A] = eitherCtor
+                  override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
+                    Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                  )
+                }
+              )
+            )
 
           case None => skipped(s"${tpe.prettyPrint} is not an Iron type")
         }

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -2170,6 +2170,7 @@ trait CodecMacrosImpl { this: MacroCommons & StdExtensions & AnnotationSupport =
 
   object DecHandleAsValueTypeRule extends DecoderDerivationRule("handle as value type when possible") {
 
+    @scala.annotation.nowarn("msg=is never used")
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
         Type[A] match {
@@ -2177,10 +2178,22 @@ trait CodecMacrosImpl { this: MacroCommons & StdExtensions & AnnotationSupport =
             import isValueType.Underlying as Inner
 
             // Build wrap lambda outside quotes to avoid staging issues with wrap.Result type
+            // For EitherStringOrValue wraps, handle the Either and throw on Left
             LambdaBuilder
               .of1[Inner]("inner")
               .traverse { innerExpr =>
-                MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
+                isValueType.value.wrap match {
+                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                    val wrapResult = isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[String, A]]]
+                    MIO.pure(Expr.quote {
+                      Expr.splice(wrapResult) match {
+                        case scala.Right(v)  => v
+                        case scala.Left(msg) => Expr.splice(dctx.reader).decodeError(msg)
+                      }
+                    })
+                  case _ =>
+                    MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
+                }
               }
               .flatMap { builder =>
                 val wrapLambda = builder.build[A]
@@ -2464,11 +2477,27 @@ trait CodecMacrosImpl { this: MacroCommons & StdExtensions & AnnotationSupport =
                 case IsValueType(isValueType) =>
                   import isValueType.Underlying as Inner
                   // Build wrap lambda outside quotes
-                  LambdaBuilder
-                    .of1[Inner]("inner")
-                    .traverse { innerExpr =>
-                      MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[K]])
-                    }
+                  // For EitherStringOrValue wraps, handle Either and throw on Left
+                  @scala.annotation.nowarn("msg=is never used")
+                  def buildWrapLambda() =
+                    LambdaBuilder
+                      .of1[Inner]("inner")
+                      .traverse { innerExpr =>
+                        isValueType.value.wrap match {
+                          case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                            val wrapResult =
+                              isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[String, K]]]
+                            MIO.pure(Expr.quote {
+                              Expr.splice(wrapResult) match {
+                                case scala.Right(v)  => v
+                                case scala.Left(msg) => throw new IllegalArgumentException(msg)
+                              }
+                            })
+                          case _ =>
+                            MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[K]])
+                        }
+                      }
+                  buildWrapLambda()
                     .flatMap { wrapBuilder =>
                       val wrapLambda = wrapBuilder.build[K]
                       deriveKeyDecoding[Inner].flatMap {

--- a/refined-integration/src/main/scala/hearth/kindlings/refinedintegration/internal/compiletime/IsValueTypeProviderForRefined.scala
+++ b/refined-integration/src/main/scala/hearth/kindlings/refinedintegration/internal/compiletime/IsValueTypeProviderForRefined.scala
@@ -42,19 +42,24 @@ final class IsValueTypeProviderForRefined extends StandardMacroExtension { loade
             // Cast to Refined[Inner, Pred] first since A is abstract.
             val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr =>
               Expr.quote {
-                eu.timepit.refined.api.Refined.unapply(
-                  Expr.splice(outerExpr).asInstanceOf[eu.timepit.refined.api.Refined[Inner, Pred]]
-                ).get
+                eu.timepit.refined.api.Refined
+                  .unapply(
+                    Expr.splice(outerExpr).asInstanceOf[eu.timepit.refined.api.Refined[Inner, Pred]]
+                  )
+                  .get
               }
 
             val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
               ctor = innerExpr => {
                 // Summon Validate[Inner, Pred] at macro expansion time (user's call site)
-                val validateExpr = Expr.summonImplicit(using validateType).toOption.getOrElse(
-                  throw new RuntimeException(
-                    s"No Validate instance found for Refined[${Type[Inner].prettyPrint}, ${Type[Pred].prettyPrint}]"
+                val validateExpr = Expr
+                  .summonImplicit(using validateType)
+                  .toOption
+                  .getOrElse(
+                    throw new RuntimeException(
+                      s"No Validate instance found for Refined[${Type[Inner].prettyPrint}, ${Type[Pred].prettyPrint}]"
+                    )
                   )
-                )
                 // Use refineV which returns Either[String, Refined[Inner, Pred]] and works
                 // on both Scala 2 (AnyVal) and Scala 3 (opaque type)
                 Expr.quote {
@@ -66,15 +71,17 @@ final class IsValueTypeProviderForRefined extends StandardMacroExtension { loade
               method = None
             )
 
-            ProviderResult.Matched(Existential[IsValueTypeOf[A, *], Inner](
-              new IsValueTypeOf[A, Inner] {
-                override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
-                override val wrap: CtorLikeOf[Inner, A] = eitherCtor
-                override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
-                  Existential[CtorLikeOf[*, A], Inner](eitherCtor)
-                )
-              }
-            ))
+            ProviderResult.Matched(
+              Existential[IsValueTypeOf[A, *], Inner](
+                new IsValueTypeOf[A, Inner] {
+                  override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
+                  override val wrap: CtorLikeOf[Inner, A] = eitherCtor
+                  override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
+                    Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                  )
+                }
+              )
+            )
 
           case None => skipped(s"${tpe.prettyPrint} is not a Refined type")
         }

--- a/refined-integration/src/main/scala/hearth/kindlings/refinedintegration/internal/compiletime/IsValueTypeProviderForRefined.scala
+++ b/refined-integration/src/main/scala/hearth/kindlings/refinedintegration/internal/compiletime/IsValueTypeProviderForRefined.scala
@@ -1,0 +1,83 @@
+package hearth.kindlings.refinedintegration.internal.compiletime
+
+import hearth.fp.data.NonEmptyList
+import hearth.MacroCommons
+import hearth.std.{ProviderResult, StandardMacroExtension, StdExtensions}
+
+final class IsValueTypeProviderForRefined extends StandardMacroExtension { loader =>
+
+  override def extend(ctx: MacroCommons & StdExtensions): Unit = {
+    import ctx.*
+
+    IsValueType.registerProvider(new IsValueType.Provider {
+
+      override def name: String = loader.getClass.getName
+
+      // Use fromUntyped to avoid cross-compilation-boundary issues with Type.Ctor2.of's Impl.
+      // The Impl captures scala.quoted.Type[HKT] at compile time, which may resolve to a
+      // different TypeRepr path than the one seen during macro expansion in downstream projects.
+      // FromUntypedImpl uses =:= and baseType for matching, which handles path differences.
+      private lazy val RefinedCtor = {
+        val impl = Type.Ctor2.of[eu.timepit.refined.api.Refined]
+        Type.Ctor2.fromUntyped[eu.timepit.refined.api.Refined](impl.asUntyped)
+      }
+
+      @scala.annotation.nowarn("msg=is never used")
+      override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
+        RefinedCtor.unapply(tpe) match {
+          case Some((inner, pred)) =>
+            import inner.Underlying as Inner
+            import pred.Underlying as Pred
+            implicit val AT: Type[A] = tpe
+
+            // Construct Type[Validate[Inner, Pred]] for summoning later
+            // NOT implicit to avoid Type.of bootstrap cycle
+            val validateType: Type[eu.timepit.refined.api.Validate[Inner, Pred]] = {
+              val impl = Type.Ctor2.of[eu.timepit.refined.api.Validate]
+              Type.Ctor2.fromUntyped[eu.timepit.refined.api.Validate](impl.asUntyped).apply[Inner, Pred]
+            }
+
+            // Unwrap: use Refined.unapply which works on both Scala 2 (AnyVal with .value)
+            // and Scala 3 (opaque type identity).
+            // Cast to Refined[Inner, Pred] first since A is abstract.
+            val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr =>
+              Expr.quote {
+                eu.timepit.refined.api.Refined.unapply(
+                  Expr.splice(outerExpr).asInstanceOf[eu.timepit.refined.api.Refined[Inner, Pred]]
+                ).get
+              }
+
+            val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
+              ctor = innerExpr => {
+                // Summon Validate[Inner, Pred] at macro expansion time (user's call site)
+                val validateExpr = Expr.summonImplicit(using validateType).toOption.getOrElse(
+                  throw new RuntimeException(
+                    s"No Validate instance found for Refined[${Type[Inner].prettyPrint}, ${Type[Pred].prettyPrint}]"
+                  )
+                )
+                // Use refineV which returns Either[String, Refined[Inner, Pred]] and works
+                // on both Scala 2 (AnyVal) and Scala 3 (opaque type)
+                Expr.quote {
+                  val v = Expr.splice(innerExpr)
+                  val validate = Expr.splice(validateExpr)
+                  eu.timepit.refined.refineV[Pred].apply[Inner](v)(validate).asInstanceOf[Either[String, A]]
+                }
+              },
+              method = None
+            )
+
+            ProviderResult.Matched(Existential[IsValueTypeOf[A, *], Inner](
+              new IsValueTypeOf[A, Inner] {
+                override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
+                override val wrap: CtorLikeOf[Inner, A] = eitherCtor
+                override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
+                  Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                )
+              }
+            ))
+
+          case None => skipped(s"${tpe.prettyPrint} is not a Refined type")
+        }
+    })
+  }
+}

--- a/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/SchemaMacrosImpl.scala
+++ b/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/SchemaMacrosImpl.scala
@@ -287,6 +287,16 @@ trait SchemaMacrosImpl { this: MacroCommons & StdExtensions & JsonSchemaConfigs 
             }
           }
 
+      // Value type (AnyVal, opaque, Refined, Iron) — derive schema for underlying type
+      case IsValueType(isValueType) =>
+        import isValueType.Underlying as Inner
+        Log.info(s"Deriving Schema for value type ${Type[A].prettyPrint} as ${Type[Inner].prettyPrint}") >>
+          deriveSchemaRecursively[Inner](jsonCfg, cache, inProgress, derivedType).map { innerSchema =>
+            Expr.quote {
+              Expr.splice(innerSchema).asInstanceOf[Schema[A]]
+            }
+          }
+
       case _ =>
         // Singleton (case object / val) — before CaseClass, produces product schema with no fields
         SingletonValue.parse[A].toEither match {

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -453,20 +453,47 @@ trait DecoderMacrosImpl { this: MacroCommons & StdExtensions & AnnotationSupport
               .summonExprIgnoring(DecUseImplicitWhenAvailableRule.ignoredImplicits*)
               .toEither match {
               case Right(innerDecoder) =>
-                LambdaBuilder
-                  .of1[Inner]("inner")
-                  .traverse { innerExpr =>
-                    MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
-                  }
-                  .map { builder =>
-                    val wrapLambda = builder.build[A]
-                    Rule.matched(Expr.quote {
-                      Expr
-                        .splice(innerDecoder)
-                        .construct(Expr.splice(dctx.node))(org.virtuslab.yaml.LoadSettings.empty)
-                        .map(Expr.splice(wrapLambda))
-                    })
-                  }
+                isValueType.value.wrap match {
+                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                    // Wrap returns Either[String, A] — convert Left(String) to Left(ConstructError)
+                    @scala.annotation.nowarn("msg=is never used")
+                    implicit val EitherCEA: Type[Either[ConstructError, A]] = DTypes.DecoderResult[A]
+                    LambdaBuilder
+                      .of1[Inner]("inner")
+                      .traverse { innerExpr =>
+                        val wrapResult = isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[String, A]]]
+                        MIO.pure(Expr.quote {
+                          Expr.splice(wrapResult).left.map { (msg: String) =>
+                            ConstructError.from(msg, Expr.splice(dctx.node))
+                          }
+                        })
+                      }
+                      .map { builder =>
+                        val wrapLambda = builder.build[Either[ConstructError, A]]
+                        Rule.matched(Expr.quote {
+                          Expr
+                            .splice(innerDecoder)
+                            .construct(Expr.splice(dctx.node))(org.virtuslab.yaml.LoadSettings.empty)
+                            .flatMap(Expr.splice(wrapLambda))
+                        })
+                      }
+                  case _ =>
+                    // PlainValue — original behavior
+                    LambdaBuilder
+                      .of1[Inner]("inner")
+                      .traverse { innerExpr =>
+                        MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
+                      }
+                      .map { builder =>
+                        val wrapLambda = builder.build[A]
+                        Rule.matched(Expr.quote {
+                          Expr
+                            .splice(innerDecoder)
+                            .construct(Expr.splice(dctx.node))(org.virtuslab.yaml.LoadSettings.empty)
+                            .map(Expr.splice(wrapLambda))
+                        })
+                      }
+                }
               case Left(reason) =>
                 MIO.pure(Rule.yielded(s"Value type inner ${Type[Inner].prettyPrint} has no YamlDecoder: $reason"))
             }


### PR DESCRIPTION
- Add refined-integration module: IsValueType provider for eu.timepit.refined.api.Refined (Scala 2.13 + 3), uses refineV for validated wrapping and Refined.unapply for unwrapping
- Add iron-integration module: IsValueType provider for io.github.iltotore.iron.IronType (Scala 3 only), uses RuntimeConstraint for validated wrapping
- Update decoder rules in circe, jsoniter, yaml, and avro to handle EitherStringOrValue wraps from validated value type providers
- Add IsValueType support to tapir-schema-derivation for value type schema passthrough
- Add integration-tests module with 58 tests covering encoding, decoding (valid/invalid), and round-trips for both Refined and Iron across all derivation modules
- Add value-type-integration-skill.md documenting the fromUntyped pattern for cross-compilation-boundary Type.Ctor2 matching