### PR TITLE
Make timeout configurable in every derivation

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -67,10 +67,11 @@ The most load-bearing entries to keep in mind for any macro work:
 ## Standard extensions, `LambdaBuilder`, and def-caching rules
 
 - **Load standard extensions exactly once per macro bundle.** See
-  `docs/contributing/load-standard-extensions-skill.md`. Use the per-module
-  `LoadStandardExtensionsOnce` trait + `ensureStandardExtensionsLoaded()` instead of
-  calling `Environment.loadStandardExtensions()` directly. Issue
-  `kubuszok/kindlings#65`.
+  `docs/contributing/load-standard-extensions-skill.md`. The shared implementation
+  lives in `derivation-commons` (`hearth.kindlings.derivation.compiletime.LoadStandardExtensionsOnce`);
+  per-module thin delegates re-export it in each module's `internal.compiletime` package.
+  Use `ensureStandardExtensionsLoaded()` instead of calling
+  `Environment.loadStandardExtensions()` directly. Issue `kubuszok/kindlings#65`.
 - **`LambdaBuilder` only for collection/Optional iteration lambdas.** Strict rule, no
   exceptions. See `docs/contributing/lambda-builder-when-to-use-skill.md`. For
   multi-method type-class instances or any other shape that needs pre-derived helper
@@ -97,6 +98,22 @@ The most load-bearing entries to keep in mind for any macro work:
   `def`s.** Use `ValDefBuilder.ofLazy` for summoned/standalone instances and
   `ValDefBuilder.ofDef*` (with `cache.forwardDeclare` + `cache.buildCachedWith`) for
   recursive helpers.
+
+## Configurable derivation timeout
+
+All derivation modules use `DerivationTimeout` from `derivation-commons`
+(`hearth.kindlings.derivation.compiletime.DerivationTimeout`). Default: 120 seconds.
+Override per-module via `-Xmacro-settings`:
+
+```
+-Xmacro-settings:jsoniterDerivation.timeout=300s
+-Xmacro-settings:catsDerivation.timeout=5m
+-Xmacro-settings:circeDerivation.timeout=5000ms
+```
+
+Supported formats: plain integer (seconds), `Ns`/`Nseconds`, `Nms`/`Nmilliseconds`, `Nm`/`Nminutes`.
+Each module reads from its own settings namespace (e.g. `jsoniterDerivation`, `catsDerivation`).
+Invalid values emit a compiler warning and fall back to default.
 
 Hearth source is at `../hearth/` when documentation is insufficient.
 See `docs/contributing/hearth-documentation-skill.md` § "Hearth source as reference" for key files.

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/AvroDerivationTimeout.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/AvroDerivationTimeout.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.avroderivation.internal.compiletime
+
+trait AvroDerivationTimeout extends hearth.kindlings.derivation.compiletime.DerivationTimeout {
+  this: hearth.MacroCommons =>
+  override protected def derivationSettingsNamespace: String = "avroDerivation"
+}

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -9,7 +9,8 @@ import hearth.kindlings.avroderivation.annotations.{avroFixed, fieldName, transi
 import org.apache.avro.Schema
 
 trait DecoderMacrosImpl
-    extends rules.AvroDecoderUseCachedDefWhenAvailableRuleImpl
+    extends AvroDerivationTimeout
+    with rules.AvroDecoderUseCachedDefWhenAvailableRuleImpl
     with rules.AvroDecoderUseImplicitWhenAvailableRuleImpl
     with rules.AvroDecoderHandleAsLiteralTypeRuleImpl
     with rules.AvroDecoderUseBuiltInSupportRuleImpl
@@ -108,7 +109,8 @@ trait DecoderMacrosImpl
       .runToExprOrFail(
         "AvroDecoder.derived",
         infoRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>
@@ -167,7 +169,8 @@ trait DecoderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -9,7 +9,8 @@ import hearth.kindlings.avroderivation.annotations.{avroFixed, fieldName, transi
 import org.apache.avro.Schema
 
 trait EncoderMacrosImpl
-    extends rules.AvroEncoderUseCachedDefWhenAvailableRuleImpl
+    extends AvroDerivationTimeout
+    with rules.AvroEncoderUseCachedDefWhenAvailableRuleImpl
     with rules.AvroEncoderUseImplicitWhenAvailableRuleImpl
     with rules.AvroEncoderHandleAsLiteralTypeRuleImpl
     with rules.AvroEncoderUseBuiltInSupportRuleImpl
@@ -104,7 +105,8 @@ trait EncoderMacrosImpl
       .runToExprOrFail(
         "AvroEncoder.derived",
         infoRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>
@@ -163,7 +165,8 @@ trait EncoderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/LoadStandardExtensionsOnce.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/LoadStandardExtensionsOnce.scala
@@ -1,28 +1,5 @@
 package hearth.kindlings.avroderivation.internal.compiletime
 
-import hearth.MacroCommons
-import hearth.fp.effect.*
-import hearth.std.*
-
-/** Per-macro-expansion guard so that [[Environment.loadStandardExtensions]] is invoked at most once even when a single
-  * derivation chains together multiple entry points (e.g. encoder derivation that internally derives a schema, or
-  * recursive helper expansions).
-  *
-  * Hearth deduplicates already-applied extensions internally, but each redundant call still pays the ServiceLoader cost
-  * and emits a "skipping re-initialization" info log (issue kubuszok/kindlings#65).
-  */
-trait LoadStandardExtensionsOnce { this: MacroCommons & StdExtensions =>
-
-  private var standardExtensionsLoaded: Boolean = false
-
-  /** Loads the standard Hearth extensions exactly once per macro bundle instance. Safe to call from any derivation
-    * entry point; subsequent invocations are no-ops.
-    */
-  protected def ensureStandardExtensionsLoaded(): MIO[Unit] =
-    if (standardExtensionsLoaded) MIO.pure(())
-    else
-      Environment.loadStandardExtensions().toMIO(allowFailures = false).map { _ =>
-        standardExtensionsLoaded = true
-        ()
-      }
+trait LoadStandardExtensionsOnce extends hearth.kindlings.derivation.compiletime.LoadStandardExtensionsOnce {
+  this: hearth.MacroCommons & hearth.std.StdExtensions =>
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -22,7 +22,8 @@ import hearth.kindlings.avroderivation.annotations.{
 import org.apache.avro.Schema
 
 trait SchemaForMacrosImpl
-    extends rules.AvroSchemaForUseCachedDefWhenAvailableRuleImpl
+    extends AvroDerivationTimeout
+    with rules.AvroSchemaForUseCachedDefWhenAvailableRuleImpl
     with rules.AvroSchemaForCheckSelfRecordRuleImpl
     with rules.AvroSchemaForUseImplicitWhenAvailableRuleImpl
     with rules.AvroSchemaForHandleAsLiteralTypeRuleImpl
@@ -109,7 +110,8 @@ trait SchemaForMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogSchemaDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogSchemaDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogSchemaDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/build.sbt
+++ b/build.sbt
@@ -280,6 +280,7 @@ val al = new {
 
   private val prodProjects =
     Vector(
+      "derivationCommons",
       "fastShowPretty",
       "circeDerivation",
       "jsoniterDerivation",
@@ -361,6 +362,7 @@ lazy val root = project
   .settings(settings)
   .settings(publishSettings)
   .settings(noPublishSettings)
+  .aggregate(derivationCommons.projectRefs *)
   .aggregate(fastShowPretty.projectRefs *)
   .aggregate(circeDerivation.projectRefs *)
   .aggregate(jsoniterDerivation.projectRefs *)
@@ -426,6 +428,7 @@ lazy val root = project
 lazy val fastShowPretty = projectMatrix
   .in(file("fast-show-pretty"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -441,7 +444,7 @@ lazy val fastShowPretty = projectMatrix
 lazy val circeDerivation = projectMatrix
   .in(file("circe-derivation"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
-  .dependsOn(jsonSchemaConfigMacroProviders)
+  .dependsOn(derivationCommons, jsonSchemaConfigMacroProviders)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -464,7 +467,7 @@ lazy val circeDerivation = projectMatrix
 lazy val jsoniterDerivation = projectMatrix
   .in(file("jsoniter-derivation"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
-  .dependsOn(jsonSchemaConfigMacroProviders)
+  .dependsOn(derivationCommons, jsonSchemaConfigMacroProviders)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -523,6 +526,7 @@ lazy val jsoniterJson = projectMatrix
 lazy val ubjsonDerivation = projectMatrix
   .in(file("ubjson-derivation"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -538,6 +542,7 @@ lazy val ubjsonDerivation = projectMatrix
 lazy val yamlDerivation = projectMatrix
   .in(file("yaml-derivation"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -558,6 +563,7 @@ lazy val yamlDerivation = projectMatrix
 lazy val xmlDerivation = projectMatrix
   .in(file("xml-derivation"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -579,6 +585,7 @@ lazy val xmlDerivation = projectMatrix
 lazy val avroDerivation = projectMatrix
   .in(file("avro-derivation"))
   .someVariations(versions.scalas, List(VirtualAxis.jvm))((useCrossQuotes ++ only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -599,6 +606,7 @@ lazy val avroDerivation = projectMatrix
 lazy val pureconfigDerivation = projectMatrix
   .in(file("pureconfig-derivation"))
   .someVariations(versions.scalas, List(VirtualAxis.jvm))((useCrossQuotes ++ only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -641,6 +649,7 @@ lazy val sconfigDerivation = projectMatrix
   .someVariations(versions.scalas, versions.platforms)(
     (useCrossQuotes ++ only1VersionInIDE ++ sconfigJavaTimePolyfill) *
   )
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -657,6 +666,21 @@ lazy val sconfigDerivation = projectMatrix
       "org.ekrich" %%% "sconfig" % versions.sconfig
     )
   )
+
+lazy val derivationCommons = projectMatrix
+  .in(file("derivation-commons"))
+  .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .enablePlugins(GitVersioning, GitBranchPrompt)
+  .disablePlugins(WelcomePlugin)
+  .settings(
+    moduleName := "kindlings-derivation-commons",
+    name := "kindlings-derivation-commons",
+    description := "Shared compile-time utilities for Kindlings derivation modules"
+  )
+  .settings(settings *)
+  .settings(dependencies *)
+  .settings(versionSchemeSettings *)
+  .settings(publishSettings *)
 
 lazy val jsonSchemaConfigMacroProviders = projectMatrix
   .in(file("json-schema-config-macro-providers"))
@@ -676,7 +700,7 @@ lazy val jsonSchemaConfigMacroProviders = projectMatrix
 lazy val tapirSchemaDerivation = projectMatrix
   .in(file("tapir-schema-derivation"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
-  .dependsOn(jsonSchemaConfigMacroProviders)
+  .dependsOn(derivationCommons, jsonSchemaConfigMacroProviders)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -736,6 +760,7 @@ lazy val ironIntegration = projectMatrix
 lazy val catsDerivation = projectMatrix
   .in(file("cats-derivation"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(
@@ -757,6 +782,7 @@ lazy val catsDerivation = projectMatrix
 lazy val scalacheckDerivation = projectMatrix
   .in(file("scalacheck-derivation"))
   .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
   .enablePlugins(GitVersioning, GitBranchPrompt)
   .disablePlugins(WelcomePlugin)
   .settings(

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AlternativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AlternativeMacrosImpl.scala
@@ -16,7 +16,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   *   - ap[A, B]: needs F[Any] erasure because ff: F[A => B] and fa: F[A] have different type parameters
   *   - combineK[A]: summons Semigroup for field types at macro time, needs concrete types
   */
-trait AlternativeMacrosImpl { this: MacroCommons & StdExtensions =>
+trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveAlternative[F[_]](
@@ -140,7 +140,8 @@ trait AlternativeMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogAltDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogAltDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogAltDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplicativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplicativeMacrosImpl.scala
@@ -12,7 +12,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * cross-quotes support for method-level type parameters inside Expr.quote/Expr.splice. For ap, uses an erased approach
   * since both ff: F[A => B] and fa: F[A] must be treated as F[Any] for field extraction.
   */
-trait ApplicativeMacrosImpl extends rules.ApplicativeCaseClassRuleImpl { this: MacroCommons & StdExtensions =>
+trait ApplicativeMacrosImpl extends rules.ApplicativeCaseClassRuleImpl with CatsDerivationTimeout {
+  this: MacroCommons & StdExtensions =>
 
   final case class ApplicativeCaseClassResult[F[_]](
       FCtor: Type.Ctor1[F],
@@ -103,7 +104,8 @@ trait ApplicativeMacrosImpl extends rules.ApplicativeCaseClassRuleImpl { this: M
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogApplicativeDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogApplicativeDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogApplicativeDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplyMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplyMacrosImpl.scala
@@ -12,7 +12,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   * support for method-level type parameters inside Expr.quote/Expr.splice. For ap, uses an erased approach since both
   * ff: F[A => B] and fa: F[A] must be treated as F[Any] for field extraction.
   */
-trait ApplyMacrosImpl { this: MacroCommons & StdExtensions =>
+trait ApplyMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveApply[F[_]](FCtor0: Type.Ctor1[F], ApplyFType: Type[cats.Apply[F]]): Expr[cats.Apply[F]] = {
@@ -108,7 +108,8 @@ trait ApplyMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogApplyDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogApplyDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogApplyDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationTimeout.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationTimeout.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.catsderivation.internal.compiletime
+
+trait CatsDerivationTimeout extends hearth.kindlings.derivation.compiletime.DerivationTimeout {
+  this: hearth.MacroCommons =>
+  override protected def derivationSettingsNamespace: String = "catsDerivation"
+}

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ConsKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ConsKMacrosImpl.scala
@@ -17,7 +17,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   *
   * Uses erased approach: builds body for F[Any] with Any, wraps with asInstanceOf.
   */
-trait ConsKMacrosImpl { this: MacroCommons & StdExtensions =>
+trait ConsKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   /** Bridge method: summon ConsK for the type constructor of a nested field type.
     *
@@ -119,7 +119,8 @@ trait ConsKMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogConsKDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogConsKDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogConsKDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ContravariantMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ContravariantMacrosImpl.scala
@@ -12,7 +12,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   * for method-level type parameters inside Expr.quote/Expr.splice. Supports Function1[A, R] fields where A is the type
   * parameter (contravariant position).
   */
-trait ContravariantMacrosImpl { this: MacroCommons & StdExtensions =>
+trait ContravariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveContravariant[F[_]](
@@ -118,7 +118,8 @@ trait ContravariantMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogContravariantDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogContravariantDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogContravariantDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyKMacrosImpl.scala
@@ -7,7 +7,7 @@ import hearth.std.*
 import hearth.kindlings.catsderivation.LogDerivation
 
 /** EmptyK derivation: constructs empty F[A] by summoning Empty for each field type in F[Any]. */
-trait EmptyKMacrosImpl { this: MacroCommons & StdExtensions =>
+trait EmptyKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveEmptyK[F[_]](FCtor0: Type.Ctor1[F], EmptyKFType: Type[alleycats.EmptyK[F]]): Expr[alleycats.EmptyK[F]] = {
@@ -48,7 +48,8 @@ trait EmptyKMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogEmptyKDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEmptyKDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEmptyKDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyMacrosImpl.scala
@@ -12,7 +12,8 @@ trait EmptyMacrosImpl
     with rules.EmptyUseImplicitRuleImpl
     with rules.EmptyBuiltInRuleImpl
     with rules.EmptyCaseClassRuleImpl
-    with rules.EmptyEnumRuleImpl { this: MacroCommons & StdExtensions =>
+    with rules.EmptyEnumRuleImpl
+    with CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used")
   def deriveEmpty[A: Type]: Expr[alleycats.Empty[A]] = {
@@ -54,7 +55,8 @@ trait EmptyMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogEmptyDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEmptyDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEmptyDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EqMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EqMacrosImpl.scala
@@ -14,7 +14,8 @@ trait EqMacrosImpl
     with rules.EqOptionRuleImpl
     with rules.EqSingletonRuleImpl
     with rules.EqCaseClassRuleImpl
-    with rules.EqEnumRuleImpl { this: MacroCommons & StdExtensions =>
+    with rules.EqEnumRuleImpl
+    with CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used")
   def deriveEq[A: Type]: Expr[cats.kernel.Eq[A]] = {
@@ -64,7 +65,8 @@ trait EqMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogEqDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEqDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEqDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FoldableMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FoldableMacrosImpl.scala
@@ -11,7 +11,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   * Uses free type variables A and B directly in the generated code, relying on Hearth 0.2.0-264+ cross-quotes support
   * for method-level type parameters inside Expr.quote/Expr.splice.
   */
-trait FoldableMacrosImpl { this: MacroCommons & StdExtensions =>
+trait FoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveFoldable[F[_]](
@@ -106,7 +106,8 @@ trait FoldableMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogFoldableDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogFoldableDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogFoldableDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
@@ -11,7 +11,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * Uses free type variables A and B directly in the generated code, relying on Hearth 0.2.0-264+ cross-quotes support
   * for method-level type parameters inside Expr.quote/Expr.splice.
   */
-trait FunctorMacrosImpl extends rules.FunctorCaseClassRuleImpl { this: MacroCommons & StdExtensions =>
+trait FunctorMacrosImpl extends rules.FunctorCaseClassRuleImpl with CatsDerivationTimeout {
+  this: MacroCommons & StdExtensions =>
 
   final case class FunctorCaseClassResult[F[_]](FCtor: Type.Ctor1[F], directFieldSet: Set[String])
 
@@ -78,7 +79,8 @@ trait FunctorMacrosImpl extends rules.FunctorCaseClassRuleImpl { this: MacroComm
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogFunctorDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogFunctorDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogFunctorDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/HashMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/HashMacrosImpl.scala
@@ -38,7 +38,8 @@ trait HashMacrosImpl
     with rules.HashBuiltInRuleImpl
     with rules.HashSingletonRuleImpl
     with rules.HashCaseClassRuleImpl
-    with rules.HashEnumRuleImpl { this: MacroCommons & StdExtensions =>
+    with rules.HashEnumRuleImpl
+    with CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used")
   def deriveHash[A: Type]: Expr[cats.kernel.Hash[A]] = {
@@ -167,7 +168,8 @@ trait HashMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogEqDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEqDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEqDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/InvariantMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/InvariantMacrosImpl.scala
@@ -12,7 +12,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   * for method-level type parameters inside Expr.quote/Expr.splice. Supports direct A fields (covariant), Function1[A,
   * R] fields (contravariant), Function1[R, A] fields (covariant), and Function1[A, A] fields (both).
   */
-trait InvariantMacrosImpl { this: MacroCommons & StdExtensions =>
+trait InvariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveInvariant[F[_]](
@@ -114,7 +114,8 @@ trait InvariantMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogInvariantDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogInvariantDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogInvariantDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/MonoidKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/MonoidKMacrosImpl.scala
@@ -7,7 +7,7 @@ import hearth.std.*
 import hearth.kindlings.catsderivation.LogDerivation
 
 /** MonoidK derivation: combines EmptyK + SemigroupK by summoning Monoid for each field type in F[Any]. */
-trait MonoidKMacrosImpl { this: MacroCommons & StdExtensions =>
+trait MonoidKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveMonoidK[F[_]](
@@ -66,7 +66,8 @@ trait MonoidKMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogMonoidKDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogMonoidKDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogMonoidKDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/MonoidMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/MonoidMacrosImpl.scala
@@ -10,7 +10,8 @@ trait MonoidMacrosImpl
     with rules.MonoidUseCachedRuleImpl
     with rules.MonoidUseImplicitRuleImpl
     with rules.MonoidBuiltInRuleImpl
-    with rules.MonoidCaseClassRuleImpl { this: MacroCommons & StdExtensions =>
+    with rules.MonoidCaseClassRuleImpl
+    with CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   final case class MonoidDerivationResult[A](empty: Expr[A], combine: (Expr[A], Expr[A]) => MIO[Expr[A]])
 
@@ -109,7 +110,8 @@ trait MonoidMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogSemigroupDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogSemigroupDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogSemigroupDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyAlternativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyAlternativeMacrosImpl.scala
@@ -15,7 +15,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   *   - ap[A, B]: needs F[Any] erasure because ff: F[A => B] and fa: F[A] have different type parameters
   *   - combineK[A]: summons Semigroup for field types at macro time, needs concrete types
   */
-trait NonEmptyAlternativeMacrosImpl { this: MacroCommons & StdExtensions =>
+trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveNonEmptyAlternative[F[_]](
@@ -134,7 +134,8 @@ trait NonEmptyAlternativeMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogNEADerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogNEADerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogNEADerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyTraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyTraverseMacrosImpl.scala
@@ -15,7 +15,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   * For nonEmptyTraverse, instead of seeding with G.pure (which requires Applicative), we seed with the first field
   * mapped through f (giving G[B]), then combine remaining fields using G.map2.
   */
-trait NonEmptyTraverseMacrosImpl { this: MacroCommons & StdExtensions =>
+trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveNonEmptyTraverse[F[_]](
@@ -255,7 +255,8 @@ trait NonEmptyTraverseMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogNETDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogNETDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogNETDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/OrderMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/OrderMacrosImpl.scala
@@ -14,7 +14,8 @@ trait OrderMacrosImpl
     with rules.OrderValueTypeRuleImpl
     with rules.OrderSingletonRuleImpl
     with rules.OrderCaseClassRuleImpl
-    with rules.OrderEnumRuleImpl { this: MacroCommons & StdExtensions =>
+    with rules.OrderEnumRuleImpl
+    with CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used")
   def deriveOrder[A: Type]: Expr[cats.kernel.Order[A]] = {
@@ -64,7 +65,8 @@ trait OrderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogOrderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogOrderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogOrderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/PureMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/PureMacrosImpl.scala
@@ -12,7 +12,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   * method-level type parameters inside Expr.quote/Expr.splice. All type-parameter-dependent fields are filled with the
   * provided value. Invariant fields cause a derivation error.
   */
-trait PureMacrosImpl { this: MacroCommons & StdExtensions =>
+trait PureMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def derivePure[F[_]](FCtor0: Type.Ctor1[F], PureFType: Type[alleycats.Pure[F]]): Expr[alleycats.Pure[F]] = {
@@ -92,7 +92,8 @@ trait PureMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogPureDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogPureDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogPureDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ReducibleMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ReducibleMacrosImpl.scala
@@ -14,7 +14,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   *
   * Requires at least one direct field (non-empty guarantee).
   */
-trait ReducibleMacrosImpl { this: MacroCommons & StdExtensions =>
+trait ReducibleMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveReducible[F[_]](
@@ -157,7 +157,8 @@ trait ReducibleMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogReducibleDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogReducibleDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogReducibleDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupKMacrosImpl.scala
@@ -7,7 +7,7 @@ import hearth.std.*
 import hearth.kindlings.catsderivation.LogDerivation
 
 /** SemigroupK derivation: combines F[A] values field-wise by summoning Semigroup for each field type in F[Any]. */
-trait SemigroupKMacrosImpl { this: MacroCommons & StdExtensions =>
+trait SemigroupKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveSemigroupK[F[_]](
@@ -58,7 +58,8 @@ trait SemigroupKMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogSemigroupKDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogSemigroupKDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogSemigroupKDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupMacrosImpl.scala
@@ -11,7 +11,8 @@ trait SemigroupMacrosImpl
     extends rules.SemigroupUseCachedRuleImpl
     with rules.SemigroupUseImplicitRuleImpl
     with rules.SemigroupBuiltInRuleImpl
-    with rules.SemigroupCaseClassRuleImpl {
+    with rules.SemigroupCaseClassRuleImpl
+    with CatsDerivationTimeout {
   this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used")
@@ -110,7 +111,8 @@ trait SemigroupMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogSemigroupDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogSemigroupDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogSemigroupDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ShowMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ShowMacrosImpl.scala
@@ -16,7 +16,8 @@ trait ShowMacrosImpl
     with rules.ShowCollectionRuleImpl
     with rules.ShowSingletonRuleImpl
     with rules.ShowCaseClassRuleImpl
-    with rules.ShowEnumRuleImpl { this: MacroCommons & StdExtensions =>
+    with rules.ShowEnumRuleImpl
+    with CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   // Entrypoint
 
@@ -73,7 +74,8 @@ trait ShowMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogShowDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogShowDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogShowDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/TraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/TraverseMacrosImpl.scala
@@ -16,7 +16,7 @@ import hearth.kindlings.catsderivation.LogDerivation
   *
   * These are spliced at the top level of the traverse method body, then used with Applicative[G] operations at runtime.
   */
-trait TraverseMacrosImpl { this: MacroCommons & StdExtensions =>
+trait TraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveTraverse[F[_]](
@@ -186,7 +186,8 @@ trait TraverseMacrosImpl { this: MacroCommons & StdExtensions =>
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogTraverseDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogTraverseDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogTraverseDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/CirceDerivationTimeout.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/CirceDerivationTimeout.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.circederivation.internal.compiletime
+
+trait CirceDerivationTimeout extends hearth.kindlings.derivation.compiletime.DerivationTimeout {
+  this: hearth.MacroCommons =>
+  override protected def derivationSettingsNamespace: String = "circeDerivation"
+}

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -12,7 +12,8 @@ import cats.data.ValidatedNel
 import io.circe.{Decoder, DecodingFailure, HCursor, Json, KeyDecoder}
 
 trait DecoderMacrosImpl
-    extends rules.DecoderUseCachedDefWhenAvailableRuleImpl
+    extends CirceDerivationTimeout
+    with rules.DecoderUseCachedDefWhenAvailableRuleImpl
     with rules.DecoderUseImplicitWhenAvailableRuleImpl
     with rules.DecoderHandleAsLiteralTypeRuleImpl
     with rules.DecoderHandleAsValueTypeRuleImpl
@@ -176,7 +177,8 @@ trait DecoderMacrosImpl
       .runToExprOrFail(
         "KindlingsDecoder.derived",
         infoRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>
@@ -236,7 +238,8 @@ trait DecoderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -9,7 +9,8 @@ import hearth.kindlings.circederivation.annotations.{fieldName, transientField}
 import io.circe.{Encoder, Json, JsonObject, KeyEncoder}
 
 trait EncoderMacrosImpl
-    extends rules.EncoderUseCachedDefWhenAvailableRuleImpl
+    extends CirceDerivationTimeout
+    with rules.EncoderUseCachedDefWhenAvailableRuleImpl
     with rules.EncoderUseImplicitWhenAvailableRuleImpl
     with rules.EncoderHandleAsLiteralTypeRuleImpl
     with rules.EncoderHandleAsValueTypeRuleImpl
@@ -146,7 +147,8 @@ trait EncoderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/LoadStandardExtensionsOnce.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/LoadStandardExtensionsOnce.scala
@@ -1,28 +1,5 @@
 package hearth.kindlings.circederivation.internal.compiletime
 
-import hearth.MacroCommons
-import hearth.fp.effect.*
-import hearth.std.*
-
-/** Per-macro-expansion guard so that [[Environment.loadStandardExtensions]] is invoked at most once even when a single
-  * derivation chains together multiple entry points (e.g. the codec derivation that internally calls both the encoder
-  * and the decoder entry point, or a decoder entry point that re-enters via a cached helper builder).
-  *
-  * Hearth deduplicates already-applied extensions internally, but each redundant call still pays the ServiceLoader cost
-  * and emits a "skipping re-initialization" info log (issue kubuszok/kindlings#65).
-  */
-trait LoadStandardExtensionsOnce { this: MacroCommons & StdExtensions =>
-
-  private var standardExtensionsLoaded: Boolean = false
-
-  /** Loads the standard Hearth extensions exactly once per macro bundle instance. Safe to call from any derivation
-    * entry point; subsequent invocations are no-ops.
-    */
-  protected def ensureStandardExtensionsLoaded(): MIO[Unit] =
-    if (standardExtensionsLoaded) MIO.pure(())
-    else
-      Environment.loadStandardExtensions().toMIO(allowFailures = false).map { _ =>
-        standardExtensionsLoaded = true
-        ()
-      }
+trait LoadStandardExtensionsOnce extends hearth.kindlings.derivation.compiletime.LoadStandardExtensionsOnce {
+  this: hearth.MacroCommons & hearth.std.StdExtensions =>
 }

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/DerivationTimeout.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/DerivationTimeout.scala
@@ -1,0 +1,61 @@
+package hearth.kindlings.derivation.compiletime
+
+trait DerivationTimeout {
+  this: hearth.MacroCommons =>
+
+  protected def derivationSettingsNamespace: String
+
+  protected lazy val derivationTimeout: scala.concurrent.duration.FiniteDuration = {
+    import scala.concurrent.duration.FiniteDuration
+    import java.util.concurrent.TimeUnit
+
+    (for {
+      data <- Environment.typedSettings.toOption
+      moduleSettings <- data.get(derivationSettingsNamespace)
+      timeoutData <- moduleSettings.get("timeout")
+      duration <- timeoutData.asInt
+        .filter(_ > 0)
+        .map(n => FiniteDuration(n.toLong, TimeUnit.SECONDS))
+        .orElse(timeoutData.asLong.filter(_ > 0).map(n => FiniteDuration(n, TimeUnit.SECONDS)))
+        .orElse(timeoutData.asString.flatMap(parseDurationString))
+    } yield duration).getOrElse(DerivationTimeout.Default)
+  }
+
+  private def parseDurationString(str: String): Option[scala.concurrent.duration.FiniteDuration] = {
+    import scala.concurrent.duration.FiniteDuration
+    import java.util.concurrent.TimeUnit
+    str.trim match {
+      case DerivationTimeout.DurationPattern(num, unit) =>
+        val n = num.toLong
+        if (n > 0) {
+          val tu = unit match {
+            case "ms" | "millis" | "milliseconds" => TimeUnit.MILLISECONDS
+            case "s" | "second" | "seconds"       => TimeUnit.SECONDS
+            case "m" | "minute" | "minutes"       => TimeUnit.MINUTES
+          }
+          Some(FiniteDuration(n, tu))
+        } else {
+          Environment.reportWarn(
+            s"$derivationSettingsNamespace.timeout: value must be positive, got '$str'. " +
+              s"Using default of ${DerivationTimeout.Default.toSeconds}s."
+          )
+          None
+        }
+      case _ =>
+        Environment.reportWarn(
+          s"$derivationSettingsNamespace.timeout: unrecognized format '$str'. " +
+            s"Expected formats: 120, 120s, 5000ms, 5m. " +
+            s"Using default of ${DerivationTimeout.Default.toSeconds}s."
+        )
+        None
+    }
+  }
+}
+
+object DerivationTimeout {
+
+  val Default: scala.concurrent.duration.FiniteDuration =
+    scala.concurrent.duration.FiniteDuration(120, java.util.concurrent.TimeUnit.SECONDS)
+
+  private val DurationPattern = """^\s*(\d+)\s*(ms|millis|milliseconds|s|seconds?|m|minutes?)\s*$""".r
+}

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/LoadStandardExtensionsOnce.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/LoadStandardExtensionsOnce.scala
@@ -1,0 +1,28 @@
+package hearth.kindlings.derivation.compiletime
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+
+/** Per-macro-expansion guard so that [[Environment.loadStandardExtensions]] is invoked at most once even when a single
+  * derivation chains together multiple entry points (e.g. a codec derivation that internally calls both the encoder and
+  * the decoder entry point, or a decoder entry point that re-enters via a cached helper builder).
+  *
+  * Hearth deduplicates already-applied extensions internally, but each redundant call still pays the ServiceLoader cost
+  * and emits a "skipping re-initialization" info log (issue kubuszok/kindlings#65).
+  */
+trait LoadStandardExtensionsOnce { this: MacroCommons & StdExtensions =>
+
+  private var standardExtensionsLoaded: Boolean = false
+
+  /** Loads the standard Hearth extensions exactly once per macro bundle instance. Safe to call from any derivation
+    * entry point; subsequent invocations are no-ops.
+    */
+  protected def ensureStandardExtensionsLoaded(): MIO[Unit] =
+    if (standardExtensionsLoaded) MIO.pure(())
+    else
+      Environment.loadStandardExtensions().toMIO(allowFailures = false).map { _ =>
+        standardExtensionsLoaded = true
+        ()
+      }
+}

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacrosImpl.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacrosImpl.scala
@@ -7,7 +7,8 @@ import hearth.std.*
 import hearth.kindlings.fastshowpretty.{FastShowPretty, RenderConfig}
 
 trait FastShowPrettyMacrosImpl
-    extends rules.FastShowPrettyUseCachedDefWhenAvailableRuleImpl
+    extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with rules.FastShowPrettyUseCachedDefWhenAvailableRuleImpl
     with rules.FastShowPrettyUseImplicitWhenAvailableRuleImpl
     with rules.FastShowPrettyUseBuiltInSupportRuleImpl
     with rules.FastShowPrettyHandleAsValueTypeRuleImpl
@@ -18,6 +19,8 @@ trait FastShowPrettyMacrosImpl
     with rules.FastShowPrettyHandleAsSingletonRuleImpl
     with rules.FastShowPrettyHandleAsCaseClassRuleImpl
     with rules.FastShowPrettyHandleAsEnumRuleImpl { this: MacroCommons & StdExtensions =>
+
+  override protected def derivationSettingsNamespace: String = "fastShowPrettyDerivation"
 
   // Entrypoints to the macro
 
@@ -117,7 +120,8 @@ trait FastShowPrettyMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -18,7 +18,8 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{
 }
 
 trait CodecMacrosImpl
-    extends rules.EncoderUseCachedDefWhenAvailableRuleImpl
+    extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with rules.EncoderUseCachedDefWhenAvailableRuleImpl
     with rules.EncoderUseImplicitWhenAvailableRuleImpl
     with rules.EncoderHandleAsLiteralTypeRuleImpl
     with rules.EncoderHandleAsBuiltInRuleImpl
@@ -42,6 +43,8 @@ trait CodecMacrosImpl
     with rules.DecoderHandleAsSingletonRuleImpl
     with rules.DecoderHandleAsCaseClassRuleImpl
     with rules.DecoderHandleAsEnumRuleImpl { this: MacroCommons & StdExtensions & AnnotationSupport =>
+
+  override protected def derivationSettingsNamespace: String = "jsoniterDerivation"
 
   // Shared type representations — centralized here so all rules access them consistently.
   private[compiletime] object CTypes {
@@ -302,7 +305,7 @@ trait CodecMacrosImpl
         "KindlingsJsonCodec.deriveKeyCodec",
         infoRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
         errorRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        timeout = scala.concurrent.duration.FiniteDuration(120, java.util.concurrent.TimeUnit.SECONDS)
+        timeout = derivationTimeout
       )(renderDerivationErrorMessage)
   }
 
@@ -427,7 +430,7 @@ trait CodecMacrosImpl
         "KindlingsJsonCodec.derive",
         infoRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
         errorRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        timeout = scala.concurrent.duration.FiniteDuration(120, java.util.concurrent.TimeUnit.SECONDS)
+        timeout = derivationTimeout
       )(renderDerivationErrorMessage)
   }
 
@@ -491,7 +494,7 @@ trait CodecMacrosImpl
         macroName,
         infoRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
         errorRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        timeout = scala.concurrent.duration.FiniteDuration(120, java.util.concurrent.TimeUnit.SECONDS)
+        timeout = derivationTimeout
       )(renderDerivationErrorMessage)
   }
 
@@ -555,7 +558,7 @@ trait CodecMacrosImpl
         macroName,
         infoRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
         errorRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        timeout = scala.concurrent.duration.FiniteDuration(120, java.util.concurrent.TimeUnit.SECONDS)
+        timeout = derivationTimeout
       )(renderDerivationErrorMessage)
   }
 
@@ -647,7 +650,7 @@ trait CodecMacrosImpl
         macroName,
         infoRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
         errorRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        timeout = scala.concurrent.duration.FiniteDuration(120, java.util.concurrent.TimeUnit.SECONDS)
+        timeout = derivationTimeout
       )(renderDerivationErrorMessage)
   }
 

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/LoadStandardExtensionsOnce.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/LoadStandardExtensionsOnce.scala
@@ -1,28 +1,5 @@
 package hearth.kindlings.pureconfigderivation.internal.compiletime
 
-import hearth.MacroCommons
-import hearth.fp.effect.*
-import hearth.std.*
-
-/** Per-macro-expansion guard so that [[Environment.loadStandardExtensions]] is invoked at most once even when a single
-  * derivation chains together multiple entry points (e.g. the convert derivation that internally calls both the reader
-  * and the writer entry point).
-  *
-  * Hearth deduplicates already-applied extensions internally, but each redundant call still pays the ServiceLoader cost
-  * and emits a "skipping re-initialization" info log (issue kubuszok/kindlings#65).
-  */
-trait LoadStandardExtensionsOnce { this: MacroCommons & StdExtensions =>
-
-  private var standardExtensionsLoaded: Boolean = false
-
-  /** Loads the standard Hearth extensions exactly once per macro bundle instance. Safe to call from any derivation
-    * entry point; subsequent invocations are no-ops.
-    */
-  protected def ensureStandardExtensionsLoaded(): MIO[Unit] =
-    if (standardExtensionsLoaded) MIO.pure(())
-    else
-      Environment.loadStandardExtensions().toMIO(allowFailures = false).map { _ =>
-        standardExtensionsLoaded = true
-        ()
-      }
+trait LoadStandardExtensionsOnce extends hearth.kindlings.derivation.compiletime.LoadStandardExtensionsOnce {
+  this: hearth.MacroCommons & hearth.std.StdExtensions =>
 }

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/PureconfigDerivationTimeout.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/PureconfigDerivationTimeout.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.pureconfigderivation.internal.compiletime
+
+trait PureconfigDerivationTimeout extends hearth.kindlings.derivation.compiletime.DerivationTimeout {
+  this: hearth.MacroCommons =>
+  override protected def derivationSettingsNamespace: String = "pureconfigDerivation"
+}

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -16,7 +16,8 @@ import pureconfig.ConfigCursor
 import pureconfig.error.ConfigReaderFailures
 
 trait ReaderMacrosImpl
-    extends rules.ReaderUseCachedDefWhenAvailableRuleImpl
+    extends PureconfigDerivationTimeout
+    with rules.ReaderUseCachedDefWhenAvailableRuleImpl
     with rules.ReaderUseImplicitWhenAvailableRuleImpl
     with rules.ReaderHandleAsValueTypeRuleImpl
     with rules.ReaderHandleAsOptionRuleImpl
@@ -91,7 +92,8 @@ trait ReaderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogReaderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogReaderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogReaderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/WriterMacrosImpl.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/WriterMacrosImpl.scala
@@ -15,7 +15,8 @@ import hearth.kindlings.pureconfigderivation.annotations.{configKey, transientFi
 import pureconfig.ConfigWriter
 
 trait WriterMacrosImpl
-    extends rules.WriterUseCachedDefWhenAvailableRuleImpl
+    extends PureconfigDerivationTimeout
+    with rules.WriterUseCachedDefWhenAvailableRuleImpl
     with rules.WriterUseImplicitWhenAvailableRuleImpl
     with rules.WriterHandleAsValueTypeRuleImpl
     with rules.WriterHandleAsOptionRuleImpl
@@ -88,7 +89,8 @@ trait WriterMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogWriterDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogWriterDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogWriterDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ArbitraryMacrosImpl.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ArbitraryMacrosImpl.scala
@@ -7,7 +7,8 @@ import hearth.std.*
 import org.scalacheck.{Arbitrary, Gen}
 
 trait ArbitraryMacrosImpl
-    extends rules.ArbitraryUseCachedRuleImpl
+    extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with rules.ArbitraryUseCachedRuleImpl
     with rules.ArbitraryUseImplicitRuleImpl
     with rules.ArbitraryBuiltInRuleImpl
     with rules.ArbitraryHandleAsOptionRuleImpl
@@ -15,6 +16,8 @@ trait ArbitraryMacrosImpl
     with rules.ArbitraryHandleAsSingletonRuleImpl
     with rules.ArbitraryHandleAsCaseClassRuleImpl
     with rules.ArbitraryHandleAsEnumRuleImpl { this: MacroCommons & StdExtensions =>
+
+  override protected def derivationSettingsNamespace: String = "scalacheckDerivation"
 
   // Entrypoint
   @scala.annotation.nowarn("msg=is never used")
@@ -85,7 +88,8 @@ trait ArbitraryMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogArbitraryDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogArbitraryDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogArbitraryDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
         val hint =

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/LoadStandardExtensionsOnce.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/LoadStandardExtensionsOnce.scala
@@ -1,18 +1,5 @@
 package hearth.kindlings.sconfigderivation.internal.compiletime
 
-import hearth.MacroCommons
-import hearth.fp.effect.*
-import hearth.std.*
-
-trait LoadStandardExtensionsOnce { this: MacroCommons & StdExtensions =>
-
-  private var standardExtensionsLoaded: Boolean = false
-
-  protected def ensureStandardExtensionsLoaded(): MIO[Unit] =
-    if (standardExtensionsLoaded) MIO.pure(())
-    else
-      Environment.loadStandardExtensions().toMIO(allowFailures = false).map { _ =>
-        standardExtensionsLoaded = true
-        ()
-      }
+trait LoadStandardExtensionsOnce extends hearth.kindlings.derivation.compiletime.LoadStandardExtensionsOnce {
+  this: hearth.MacroCommons & hearth.std.StdExtensions =>
 }

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -9,7 +9,8 @@ import hearth.kindlings.sconfigderivation.annotations.{configKey, transientField
 import org.ekrich.config.ConfigValue
 
 trait ReaderMacrosImpl
-    extends rules.ReaderUseCachedDefWhenAvailableRuleImpl
+    extends SconfigDerivationTimeout
+    with rules.ReaderUseCachedDefWhenAvailableRuleImpl
     with rules.ReaderUseImplicitWhenAvailableRuleImpl
     with rules.ReaderHandleAsValueTypeRuleImpl
     with rules.ReaderHandleAsOptionRuleImpl
@@ -77,7 +78,8 @@ trait ReaderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogReaderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogReaderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogReaderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/SconfigDerivationTimeout.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/SconfigDerivationTimeout.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.sconfigderivation.internal.compiletime
+
+trait SconfigDerivationTimeout extends hearth.kindlings.derivation.compiletime.DerivationTimeout {
+  this: hearth.MacroCommons =>
+  override protected def derivationSettingsNamespace: String = "sconfigDerivation"
+}

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/WriterMacrosImpl.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/WriterMacrosImpl.scala
@@ -9,7 +9,8 @@ import hearth.kindlings.sconfigderivation.annotations.{configKey, transientField
 import org.ekrich.config.ConfigValue
 
 trait WriterMacrosImpl
-    extends rules.WriterUseCachedDefWhenAvailableRuleImpl
+    extends SconfigDerivationTimeout
+    with rules.WriterUseCachedDefWhenAvailableRuleImpl
     with rules.WriterUseImplicitWhenAvailableRuleImpl
     with rules.WriterHandleAsValueTypeRuleImpl
     with rules.WriterHandleAsOptionRuleImpl
@@ -75,7 +76,8 @@ trait WriterMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogWriterDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogWriterDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogWriterDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/SchemaMacrosImpl.scala
+++ b/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/SchemaMacrosImpl.scala
@@ -11,7 +11,8 @@ import sttp.tapir.{Schema, SchemaType}
 import sttp.tapir.Schema.SName
 
 trait SchemaMacrosImpl
-    extends rules.SchemaUseCachedWhenAvailableRuleImpl
+    extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with rules.SchemaUseCachedWhenAvailableRuleImpl
     with rules.SchemaUseSelfRefWhenRecursiveRuleImpl
     with rules.SchemaUseImplicitWhenAvailableRuleImpl
     with rules.SchemaHandleAsOptionRuleImpl
@@ -22,6 +23,8 @@ trait SchemaMacrosImpl
     with rules.SchemaHandleAsCaseClassRuleImpl
     with rules.SchemaHandleAsEnumRuleImpl {
   this: MacroCommons & StdExtensions & JsonSchemaConfigs & AnnotationSupport =>
+
+  override protected def derivationSettingsNamespace: String = "tapirSchemaDerivation"
 
   // Type helpers
 
@@ -117,7 +120,8 @@ trait SchemaMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogSchemaDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogSchemaDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogSchemaDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -9,7 +9,8 @@ import hearth.kindlings.ubjsonderivation.{UBJsonConfig, UBJsonReader, UBJsonValu
 import hearth.kindlings.ubjsonderivation.annotations.{fieldName as fieldNameAnn, stringified, transientField}
 
 trait CodecMacrosImpl
-    extends rules.EncoderUseCachedDefWhenAvailableRuleImpl
+    extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with rules.EncoderUseCachedDefWhenAvailableRuleImpl
     with rules.EncoderUseImplicitWhenAvailableRuleImpl
     with rules.EncoderHandleAsBuiltInRuleImpl
     with rules.EncoderHandleAsValueTypeRuleImpl
@@ -29,6 +30,8 @@ trait CodecMacrosImpl
     with rules.DecoderHandleAsSingletonRuleImpl
     with rules.DecoderHandleAsCaseClassRuleImpl
     with rules.DecoderHandleAsEnumRuleImpl { this: MacroCommons & StdExtensions & AnnotationSupport =>
+
+  override protected def derivationSettingsNamespace: String = "ubjsonDerivation"
 
   // Entrypoints
 
@@ -139,7 +142,8 @@ trait CodecMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogCodecDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -8,7 +8,8 @@ import hearth.kindlings.xmlderivation.{KindlingsXmlDecoder, XmlConfig, XmlDecodi
 import hearth.kindlings.xmlderivation.internal.runtime.XmlDerivationUtils
 
 trait DecoderMacrosImpl
-    extends rules.DecoderUseCachedDefWhenAvailableRuleImpl
+    extends XmlDerivationTimeout
+    with rules.DecoderUseCachedDefWhenAvailableRuleImpl
     with rules.DecoderUseImplicitWhenAvailableRuleImpl
     with rules.DecoderHandleAsBuiltInRuleImpl
     with rules.DecoderHandleAsValueTypeRuleImpl
@@ -165,7 +166,8 @@ trait DecoderMacrosImpl
       .runToExprOrFail(
         "KindlingsXmlDecoder.derived",
         infoRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>
@@ -225,7 +227,8 @@ trait DecoderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -8,7 +8,8 @@ import hearth.kindlings.xmlderivation.{KindlingsXmlEncoder, XmlConfig}
 import hearth.kindlings.xmlderivation.internal.runtime.XmlDerivationUtils
 
 trait EncoderMacrosImpl
-    extends rules.EncoderUseCachedDefWhenAvailableRuleImpl
+    extends XmlDerivationTimeout
+    with rules.EncoderUseCachedDefWhenAvailableRuleImpl
     with rules.EncoderUseImplicitWhenAvailableRuleImpl
     with rules.EncoderHandleAsBuiltInRuleImpl
     with rules.EncoderHandleAsValueTypeRuleImpl
@@ -138,7 +139,8 @@ trait EncoderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/XmlDerivationTimeout.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/XmlDerivationTimeout.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.xmlderivation.internal.compiletime
+
+trait XmlDerivationTimeout extends hearth.kindlings.derivation.compiletime.DerivationTimeout {
+  this: hearth.MacroCommons =>
+  override protected def derivationSettingsNamespace: String = "xmlDerivation"
+}

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -11,7 +11,8 @@ import hearth.kindlings.yamlderivation.internal.runtime.YamlDerivationUtils
 import org.virtuslab.yaml.{ConstructError, Node, YamlDecoder, YamlError}
 
 trait DecoderMacrosImpl
-    extends rules.DecoderUseCachedDefWhenAvailableRuleImpl
+    extends YamlDerivationTimeout
+    with rules.DecoderUseCachedDefWhenAvailableRuleImpl
     with rules.DecoderUseImplicitWhenAvailableRuleImpl
     with rules.DecoderHandleAsLiteralTypeRuleImpl
     with rules.DecoderHandleAsValueTypeRuleImpl
@@ -153,7 +154,8 @@ trait DecoderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogDecoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -10,7 +10,8 @@ import hearth.kindlings.yamlderivation.internal.runtime.YamlDerivationUtils
 import org.virtuslab.yaml.{Node, YamlEncoder}
 
 trait EncoderMacrosImpl
-    extends rules.EncoderUseCachedDefWhenAvailableRuleImpl
+    extends YamlDerivationTimeout
+    with rules.EncoderUseCachedDefWhenAvailableRuleImpl
     with rules.EncoderUseImplicitWhenAvailableRuleImpl
     with rules.EncoderHandleAsLiteralTypeRuleImpl
     with rules.EncoderHandleAsValueTypeRuleImpl
@@ -120,7 +121,8 @@ trait EncoderMacrosImpl
       .runToExprOrFail(
         macroName,
         infoRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
-        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender
+        errorRendering = if (shouldWeLogEncoderDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
       ) { (errorLogs, errors) =>
         val errorsRendered = errors
           .map { e =>

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/LoadStandardExtensionsOnce.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/LoadStandardExtensionsOnce.scala
@@ -1,28 +1,5 @@
 package hearth.kindlings.yamlderivation.internal.compiletime
 
-import hearth.MacroCommons
-import hearth.fp.effect.*
-import hearth.std.*
-
-/** Per-macro-expansion guard so that [[Environment.loadStandardExtensions]] is invoked at most once even when a single
-  * derivation chains together multiple entry points (e.g. the codec derivation that internally calls both the encoder
-  * and the decoder entry point).
-  *
-  * Hearth deduplicates already-applied extensions internally, but each redundant call still pays the ServiceLoader cost
-  * and emits a "skipping re-initialization" info log (issue kubuszok/kindlings#65).
-  */
-trait LoadStandardExtensionsOnce { this: MacroCommons & StdExtensions =>
-
-  private var standardExtensionsLoaded: Boolean = false
-
-  /** Loads the standard Hearth extensions exactly once per macro bundle instance. Safe to call from any derivation
-    * entry point; subsequent invocations are no-ops.
-    */
-  protected def ensureStandardExtensionsLoaded(): MIO[Unit] =
-    if (standardExtensionsLoaded) MIO.pure(())
-    else
-      Environment.loadStandardExtensions().toMIO(allowFailures = false).map { _ =>
-        standardExtensionsLoaded = true
-        ()
-      }
+trait LoadStandardExtensionsOnce extends hearth.kindlings.derivation.compiletime.LoadStandardExtensionsOnce {
+  this: hearth.MacroCommons & hearth.std.StdExtensions =>
 }

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/YamlDerivationTimeout.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/YamlDerivationTimeout.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.yamlderivation.internal.compiletime
+
+trait YamlDerivationTimeout extends hearth.kindlings.derivation.compiletime.DerivationTimeout {
+  this: hearth.MacroCommons =>
+  override protected def derivationSettingsNamespace: String = "yamlDerivation"
+}


### PR DESCRIPTION
We added timeout to macro expansion, so that super slow expansion would not hang the whole compilation AND to send a clear signal to maintainers that some macros are broken and need more attention (usually macro should return after a few milliseconds, much longer than that is usually a problem).

However, in case there is some legitimate case for a super long compilation, we need a way to override that timeout.