### PR TITLE
Fix avro schema derivation for nested unions, namespace collisions, a…

### DIFF
--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -162,16 +162,20 @@ trait SchemaForMacrosImpl
       tpe = Type[B]
     )
 
+    /** Sanitize a type's plainPrint for use as a Scala identifier in generated code. */
+    private def sanitizedTypeName[B: Type]: String =
+      Type[B].plainPrint.replaceAll("[^a-zA-Z0-9_]", "_")
+
     def getCachedSchema[B: Type]: MIO[Option[Expr[Schema]]] = {
       implicit val SchemaT: Type[Schema] = SfTypes.Schema
-      cache.get0Ary[Schema](s"cached-schema-for-${Type[B].shortName}")
+      cache.get0Ary[Schema](s"cached-schema-for-${Type[B].plainPrint}")
     }
     def setCachedSchema[B: Type](instance: Expr[Schema]): MIO[Unit] = {
       implicit val SchemaT: Type[Schema] = SfTypes.Schema
       Log.info(s"Caching schema for ${Type[B].prettyPrint}") >>
         cache.buildCachedWith(
-          s"cached-schema-for-${Type[B].shortName}",
-          ValDefBuilder.ofLazy[Schema](s"schema_${Type[B].shortName}")
+          s"cached-schema-for-${Type[B].plainPrint}",
+          ValDefBuilder.ofLazy[Schema](s"schema_${sanitizedTypeName[B]}")
         )(_ => instance)
     }
 
@@ -183,14 +187,14 @@ trait SchemaForMacrosImpl
       implicit val SchemaT: Type[Schema] = SfTypes.Schema
       Log.info(s"Registering self-record schema for ${Type[B].prettyPrint}") >>
         cache.buildCachedWith(
-          s"self-record-for-${Type[B].shortName}",
-          ValDefBuilder.ofVal[Schema](s"selfRecord_${Type[B].shortName}")
+          s"self-record-for-${Type[B].plainPrint}",
+          ValDefBuilder.ofVal[Schema](s"selfRecord_${sanitizedTypeName[B]}")
         )(_ => emptyRecord)
     }
 
     def getSelfRecordSchema[B: Type]: MIO[Option[Expr[Schema]]] = {
       implicit val SchemaT: Type[Schema] = SfTypes.Schema
-      cache.get0Ary[Schema](s"self-record-for-${Type[B].shortName}")
+      cache.get0Ary[Schema](s"self-record-for-${Type[B].plainPrint}")
     }
 
     override def toString: String =

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsEitherRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsEitherRule.scala
@@ -5,6 +5,7 @@ import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
 
+import hearth.kindlings.avroderivation.internal.runtime.AvroDerivationUtils
 import org.apache.avro.Schema
 
 trait AvroSchemaForHandleAsEitherRuleImpl {
@@ -22,7 +23,7 @@ trait AvroSchemaForHandleAsEitherRuleImpl {
               leftSchema <- deriveSchemaRecursively[LeftValue](using sfctx.nest[LeftValue])
               rightSchema <- deriveSchemaRecursively[RightValue](using sfctx.nest[RightValue])
             } yield Rule.matched(Expr.quote {
-              Schema.createUnion(
+              AvroDerivationUtils.createSafeUnion(
                 Expr.splice(leftSchema),
                 Expr.splice(rightSchema)
               )

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsEnumRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsEnumRule.scala
@@ -7,7 +7,8 @@ import hearth.fp.effect.*
 import hearth.fp.syntax.*
 import hearth.std.*
 
-import hearth.kindlings.avroderivation.annotations.{avroEnumDefault, avroSortPriority}
+import hearth.kindlings.avroderivation.AvroConfig
+import hearth.kindlings.avroderivation.annotations.{avroEnumDefault, avroNamespace, avroSortPriority}
 import hearth.kindlings.avroderivation.internal.runtime.AvroDerivationUtils
 import org.apache.avro.Schema
 
@@ -40,11 +41,19 @@ trait AvroSchemaForHandleAsEnumRuleImpl {
       implicit val SchemaT: Type[Schema] = SfTypes.Schema
       implicit val avroSortPriorityT: Type[avroSortPriority] = SfTypes.AvroSortPriority
       implicit val avroEnumDefaultT: Type[avroEnumDefault] = SfTypes.AvroEnumDefault
+      implicit val avroNamespaceT: Type[avroNamespace] = SfTypes.AvroNamespace
       implicit val StringT: Type[String] = SfTypes.String
+      implicit val AvroConfigT: Type[AvroConfig] = SfTypes.AvroConfig
 
       val childrenList = enumm.directChildren.toList
       val typeName = Type[A].shortName
       val enumDefault: Option[String] = getTypeAnnotationStringArg[avroEnumDefault, A]
+      val classNamespace: Option[String] = getTypeAnnotationStringArg[avroNamespace, A]
+
+      val namespaceExpr: Expr[String] = classNamespace match {
+        case Some(ns) => Expr(ns)
+        case None     => Expr.quote(Expr.splice(sfctx.config).namespace.getOrElse(""))
+      }
 
       NonEmptyList.fromList(childrenList) match {
         case None =>
@@ -82,7 +91,7 @@ trait AvroSchemaForHandleAsEnumRuleImpl {
                   symbols.foreach(javaSymbols.add)
                   AvroDerivationUtils.createEnumWithDefault(
                     Expr.splice(Expr(typeName)),
-                    Expr.splice(sfctx.config).namespace.getOrElse(""),
+                    Expr.splice(namespaceExpr),
                     javaSymbols,
                     Expr.splice(Expr(default))
                   )
@@ -94,7 +103,7 @@ trait AvroSchemaForHandleAsEnumRuleImpl {
                   symbols.foreach(javaSymbols.add)
                   AvroDerivationUtils.createEnum(
                     Expr.splice(Expr(typeName)),
-                    Expr.splice(sfctx.config).namespace.getOrElse(""),
+                    Expr.splice(namespaceExpr),
                     javaSymbols
                   )
                 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsOptionRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsOptionRule.scala
@@ -22,7 +22,7 @@ trait AvroSchemaForHandleAsOptionRuleImpl {
             for {
               innerSchema <- deriveSchemaRecursively[Inner](using sfctx.nest[Inner])
             } yield Rule.matched(Expr.quote {
-              AvroDerivationUtils.createUnion(
+              AvroDerivationUtils.createSafeUnion(
                 AvroDerivationUtils.nullSchema,
                 Expr.splice(innerSchema)
               )

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsSingletonRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsSingletonRule.scala
@@ -6,6 +6,7 @@ import hearth.fp.effect.*
 import hearth.std.*
 
 import hearth.kindlings.avroderivation.AvroConfig
+import hearth.kindlings.avroderivation.annotations.avroNamespace
 import hearth.kindlings.avroderivation.internal.runtime.AvroDerivationUtils
 import org.apache.avro.Schema
 
@@ -22,11 +23,17 @@ trait AvroSchemaForHandleAsSingletonRuleImpl {
             implicit val SchemaT: Type[Schema] = SfTypes.Schema
             implicit val StringT: Type[String] = SfTypes.String
             implicit val AvroConfigT: Type[AvroConfig] = SfTypes.AvroConfig
+            implicit val avroNamespaceT: Type[avroNamespace] = SfTypes.AvroNamespace
             val typeName = Type[A].shortName
+            val classNamespace: Option[String] = getTypeAnnotationStringArg[avroNamespace, A]
+            val namespaceExpr: Expr[String] = classNamespace match {
+              case Some(ns) => Expr(ns)
+              case None     => Expr.quote(Expr.splice(sfctx.config).namespace.getOrElse(""))
+            }
             val schemaExpr = Expr.quote {
               AvroDerivationUtils.createRecord(
                 Expr.splice(Expr(typeName)),
-                Expr.splice(sfctx.config).namespace.getOrElse(""),
+                Expr.splice(namespaceExpr),
                 java.util.Collections.emptyList[Schema.Field]()
               )
             }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/runtime/AvroDerivationUtils.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/runtime/AvroDerivationUtils.scala
@@ -132,6 +132,33 @@ object AvroDerivationUtils {
   def createUnion(schemas: Schema*): Schema =
     Schema.createUnion(schemas*)
 
+  /** Creates a union schema that flattens nested unions and deduplicates nulls. Avro does not allow nested unions, so
+    * when creating Option[SealedTrait] or Option[Either[A, B]], the inner union must be flattened into the outer one.
+    * Null schemas are deduplicated and moved to the front.
+    */
+  def createSafeUnion(schemas: Schema*): Schema = {
+    val flat = new java.util.ArrayList[Schema]()
+    schemas.foreach { s =>
+      if (s.getType == Schema.Type.UNION) {
+        val iter = s.getTypes.iterator()
+        while (iter.hasNext) { val _ = flat.add(iter.next()) }
+      } else {
+        val _ = flat.add(s)
+      }
+    }
+    // Deduplicate nulls and move null to front
+    val deduped = new java.util.ArrayList[Schema]()
+    var hasNull = false
+    val iter = flat.iterator()
+    while (iter.hasNext) {
+      val s = iter.next()
+      if (s.getType == Schema.Type.NULL) hasNull = true
+      else { val _ = deduped.add(s) }
+    }
+    if (hasNull) { val _ = deduped.add(0, Schema.create(Schema.Type.NULL)) }
+    Schema.createUnion(deduped)
+  }
+
   def nullSchema: Schema = Schema.create(Schema.Type.NULL)
 
   // Primitive schema constructors — Java enum constants don't reify inside Scala 2 macro quotes

--- a/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/AvroScala3Spec.scala
+++ b/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/AvroScala3Spec.scala
@@ -249,6 +249,47 @@ final class AvroScala3Spec extends MacroSuite {
     }
   }
 
+  group("Issue #80: @avroNamespace on Scala 3 enum") {
+
+    test("@avroNamespace on Scala 3 enum applies namespace to ENUM schema") {
+      val schema = AvroSchemaFor.schemaOf[NamespacedFruit]
+      schema.getType ==> Schema.Type.ENUM
+      schema.getNamespace ==> "com.example.fruit"
+      schema.getEnumSymbols.size() ==> 3
+    }
+
+    test("@avroNamespace on Scala 3 enum is preserved when used as field") {
+      val schema = AvroSchemaFor.schemaOf[MealWithNamespacedFruit]
+      schema.getType ==> Schema.Type.RECORD
+      schema.getNamespace ==> "com.example.meal"
+      val fruitSchema = schema.getField("fruit").schema()
+      fruitSchema.getType ==> Schema.Type.ENUM
+      fruitSchema.getNamespace ==> "com.example.fruit"
+    }
+  }
+
+  group("Issue #78: Option[Scala 3 enum] union flattening") {
+
+    test("Option[simple Scala 3 enum] wraps to UNION(null, ENUM)") {
+      val schema = AvroSchemaFor.schemaOf[WithOptionalFruit]
+      val fieldSchema = schema.getField("fruit").schema()
+      fieldSchema.getType ==> Schema.Type.UNION
+      fieldSchema.getTypes.size() ==> 2
+      fieldSchema.getTypes.get(0).getType ==> Schema.Type.NULL
+      fieldSchema.getTypes.get(1).getType ==> Schema.Type.ENUM
+    }
+
+    test("Option[parameterized Scala 3 enum] flattens to UNION(null, A, B)") {
+      val schema = AvroSchemaFor.schemaOf[WithOptionalVehicle]
+      val fieldSchema = schema.getField("vehicle").schema()
+      fieldSchema.getType ==> Schema.Type.UNION
+      fieldSchema.getTypes.size() ==> 3
+      fieldSchema.getTypes.get(0).getType ==> Schema.Type.NULL
+      fieldSchema.getTypes.get(1).getName ==> "Car"
+      fieldSchema.getTypes.get(2).getName ==> "Bike"
+    }
+  }
+
   group("union types (Scala 3)") {
 
     test("schema for case class union is UNION") {

--- a/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/scala3examples.scala
+++ b/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/scala3examples.scala
@@ -29,3 +29,16 @@ type StringOrInt = String | Int
 case class Parrot(name: String, vocabulary: Int)
 case class Hamster(name: String, wheelSize: Double)
 type ParrotOrHamster = Parrot | Hamster
+
+// Issue #80: @avroNamespace on Scala 3 enum
+@annotations.avroNamespace("com.example.fruit")
+enum NamespacedFruit {
+  case Apple, Banana, Cherry
+}
+
+@annotations.avroNamespace("com.example.meal")
+case class MealWithNamespacedFruit(fruit: NamespacedFruit)
+
+// Option[Scala 3 enum] — must flatten or wrap correctly
+case class WithOptionalFruit(fruit: Option[Fruit])
+case class WithOptionalVehicle(vehicle: Option[Vehicle])

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroSchemaForSpec.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroSchemaForSpec.scala
@@ -740,5 +740,115 @@ final class AvroSchemaForSpec extends MacroSuite {
         schema.getField("id").doc() ==> "The identifier"
       }
     }
+
+    group("Issue #78: Option[SealedTrait] union flattening") {
+
+      test("Option[sealed trait with case classes] flattens to UNION(null, A, B)") {
+        val schema = AvroSchemaFor.schemaOf[WithOptionalAnimal]
+        val fieldSchema = schema.getField("animal").schema()
+        fieldSchema.getType ==> Schema.Type.UNION
+        // Should be [null, Dog, Cat], not [null, [Dog, Cat]]
+        fieldSchema.getTypes.size() ==> 3
+        fieldSchema.getTypes.get(0).getType ==> Schema.Type.NULL
+        fieldSchema.getTypes.get(1).getName ==> "Dog"
+        fieldSchema.getTypes.get(2).getName ==> "Cat"
+      }
+
+      test("Option[sealed trait with case objects] wraps to UNION(null, ENUM)") {
+        val schema = AvroSchemaFor.schemaOf[WithOptionalColor]
+        val fieldSchema = schema.getField("color").schema()
+        fieldSchema.getType ==> Schema.Type.UNION
+        fieldSchema.getTypes.size() ==> 2
+        fieldSchema.getTypes.get(0).getType ==> Schema.Type.NULL
+        fieldSchema.getTypes.get(1).getType ==> Schema.Type.ENUM
+      }
+
+      test("Option[Either[L, R]] flattens to UNION(null, L, R)") {
+        val schema = AvroSchemaFor.schemaOf[WithOptionalEither]
+        val fieldSchema = schema.getField("value").schema()
+        fieldSchema.getType ==> Schema.Type.UNION
+        fieldSchema.getTypes.size() ==> 3
+        fieldSchema.getTypes.get(0).getType ==> Schema.Type.NULL
+        fieldSchema.getTypes.get(1).getType ==> Schema.Type.STRING
+        fieldSchema.getTypes.get(2).getType ==> Schema.Type.INT
+      }
+    }
+
+    group("Issue #79: same-name types in different namespaces") {
+
+      test("two classes with same name but different @avroNamespace get distinct schemas") {
+        val schema = AvroSchemaFor.schemaOf[BarWithDuplicateNames]
+        schema.getType ==> Schema.Type.RECORD
+        schema.getNamespace ==> "c"
+
+        val fooASchema = schema.getField("fooA").schema()
+        fooASchema.getType ==> Schema.Type.RECORD
+        fooASchema.getName ==> "Foo"
+        fooASchema.getNamespace ==> "a"
+        fooASchema.getField("int").schema().getType ==> Schema.Type.INT
+
+        val fooBSchema = schema.getField("fooB").schema()
+        fooBSchema.getType ==> Schema.Type.RECORD
+        fooBSchema.getName ==> "Foo"
+        fooBSchema.getNamespace ==> "b"
+        fooBSchema.getField("str").schema().getType ==> Schema.Type.STRING
+      }
+    }
+
+    group("Issue #80: @avroNamespace on enums") {
+
+      test("@avroNamespace on sealed trait enum applies namespace to ENUM schema") {
+        val schema = AvroSchemaFor.schemaOf[NamespacedColor]
+        schema.getType ==> Schema.Type.ENUM
+        schema.getNamespace ==> "com.example.colors"
+        schema.getEnumSymbols.size() ==> 3
+      }
+
+      test("@avroNamespace on sealed trait enum is preserved when used as field") {
+        val schema = AvroSchemaFor.schemaOf[WithNamespacedEnum]
+        val colorSchema = schema.getField("color").schema()
+        colorSchema.getType ==> Schema.Type.ENUM
+        colorSchema.getNamespace ==> "com.example.colors"
+      }
+
+      test("@avroNamespace combined with @avroEnumDefault works correctly") {
+        val schema = AvroSchemaFor.schemaOf[NamespacedSizeTypes.NamespacedSizeWithDefault]
+        schema.getType ==> Schema.Type.ENUM
+        schema.getNamespace ==> "com.example.sizes"
+        schema.getEnumDefault ==> "Mid"
+      }
+
+      test("@avroNamespace on sealed trait enum used as field preserves namespace") {
+        val schema = AvroSchemaFor.schemaOf[WithContinent]
+        val continentSchema = schema.getField("continent").schema()
+        continentSchema.getType ==> Schema.Type.ENUM
+        continentSchema.getNamespace ==> "com.example.continents"
+        continentSchema.getEnumSymbols.size() ==> 3
+      }
+    }
+
+    group("Ported from avro4s: union flattening edge cases") {
+
+      test("Either[T, Option[U]] flattens nested unions with null first") {
+        val schema = AvroSchemaFor.schemaOf[WithEitherAndOption]
+        val fieldSchema = schema.getField("value").schema()
+        fieldSchema.getType ==> Schema.Type.UNION
+        // Either[String, Option[Int]] should flatten to ["null", "string", "int"]
+        fieldSchema.getTypes.size() ==> 3
+        fieldSchema.getTypes.get(0).getType ==> Schema.Type.NULL
+        fieldSchema.getTypes.get(1).getType ==> Schema.Type.STRING
+        fieldSchema.getTypes.get(2).getType ==> Schema.Type.INT
+      }
+    }
+
+    group("Ported from avro4s: namespace on nested types") {
+
+      test("@avroNamespace on outer and inner types preserved independently") {
+        val schema = AvroSchemaFor.schemaOf[OuterNamespaced]
+        schema.getNamespace ==> "com.outer"
+        val innerSchema = schema.getField("inner").schema()
+        innerSchema.getNamespace ==> "com.inner"
+      }
+    }
   }
 }

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
@@ -197,5 +197,59 @@ case class Error(message: String) extends MixedEvent
 // Option[SealedTrait] test
 case class WithOptionalShape(shape: Option[Shape])
 
+// Issue #78: Option[SealedTrait] — must flatten union
+case class WithOptionalAnimal(animal: Option[Animal])
+case class WithOptionalColor(color: Option[Color])
+case class WithOptionalEither(value: Option[Either[String, Int]])
+
+// Issue #79: Same-name types in different namespaces
+object nsA {
+  @avroNamespace("a")
+  case class Foo(int: Int)
+}
+object nsB {
+  @avroNamespace("b")
+  case class Foo(str: String)
+}
+@avroNamespace("c")
+case class BarWithDuplicateNames(fooA: nsA.Foo, fooB: nsB.Foo)
+
+// Issue #80: @avroNamespace on sealed trait enum
+@avroNamespace("com.example.colors")
+sealed trait NamespacedColor
+case object NRed extends NamespacedColor
+case object NGreen extends NamespacedColor
+case object NBlue extends NamespacedColor
+
+@avroNamespace("com.example.container")
+case class WithNamespacedEnum(color: NamespacedColor)
+
+// @avroNamespace + @avroEnumDefault combined
+object NamespacedSizeTypes {
+  @avroNamespace("com.example.sizes")
+  @avroEnumDefault("Mid")
+  sealed trait NamespacedSizeWithDefault
+  case object Sm extends NamespacedSizeWithDefault
+  case object Mid extends NamespacedSizeWithDefault
+  case object Lg extends NamespacedSizeWithDefault
+}
+
+// Ported from avro4s: Either[T, Option[U]] union flattening
+case class WithEitherAndOption(value: Either[String, Option[Int]])
+
+// Ported from avro4s: @avroNamespace on nested types
+@avroNamespace("com.outer")
+case class OuterNamespaced(name: String, inner: InnerNamespaced)
+@avroNamespace("com.inner")
+case class InnerNamespaced(value: Int)
+
+// Ported from avro4s: sealed trait of case objects with @avroNamespace at trait level
+@avroNamespace("com.example.continents")
+sealed trait Continent
+case object Africa extends Continent
+case object Asia extends Continent
+case object Europe extends Continent
+case class WithContinent(continent: Continent)
+
 // Unhandled type for compile-time error tests
 class NotAnAvroType


### PR DESCRIPTION
…nd enum annotations (#78, #79, #80)

- Flatten nested unions in Option/Either rules via createSafeUnion so Option[SealedTrait] produces [null, A, B] instead of [null, [A, B]]
- Use fully-qualified type names (plainPrint) for schema cache keys to prevent collisions between same-named types in different packages
- Read @avroNamespace annotation in enum and singleton rules, matching the existing behavior of the case class rule
- Port test scenarios from avro4s covering these edge cases