### PR TITLE
Fix Avro schema bugs and close annotation gaps (#91, #92)

### DIFF
--- a/avro-derivation/src/main/scala-2/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/avro-derivation/src/main/scala-2/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -53,4 +53,10 @@ trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScal
       case Apply(_, List(Literal(Constant(v1: String)), Literal(Constant(v2: String)))) => Some((v1, v2))
       case _                                                                            => None
     }
+
+  override protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)] =
+    annotation match {
+      case Apply(_, List(Literal(Constant(v1: Int)), Literal(Constant(v2: Int)))) => Some((v1, v2))
+      case _                                                                      => None
+    }
 }

--- a/avro-derivation/src/main/scala-3/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/avro-derivation/src/main/scala-3/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -49,4 +49,10 @@ trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScal
       case Apply(_, List(Literal(StringConstant(v1)), Literal(StringConstant(v2)))) => Some((v1, v2))
       case _                                                                        => None
     }
+
+  override protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)] =
+    annotation match {
+      case Apply(_, List(Literal(IntConstant(v1)), Literal(IntConstant(v2)))) => Some((v1, v2))
+      case _                                                                  => None
+    }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/AvroConfig.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/AvroConfig.scala
@@ -14,6 +14,7 @@ final case class AvroConfig(
   def withTransformConstructorNames(f: String => String): AvroConfig = copy(transformConstructorNames = f)
   def withSnakeCaseFieldNames: AvroConfig = copy(transformFieldNames = AvroConfig.snakeCase)
   def withKebabCaseFieldNames: AvroConfig = copy(transformFieldNames = AvroConfig.kebabCase)
+  def withPascalCaseFieldNames: AvroConfig = copy(transformFieldNames = AvroConfig.pascalCase)
   def withDecimalConfig(precision: Int, scale: Int): AvroConfig =
     copy(decimalConfig = Some(DecimalConfig(precision, scale)))
 }
@@ -47,5 +48,10 @@ object AvroConfig {
       i += 1
     }
     sb.toString
+  }
+
+  private[avroderivation] val pascalCase: String => String = { s =>
+    if (s.isEmpty) s
+    else s.charAt(0).toUpper.toString + s.substring(1)
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/annotations/avroErasedName.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/annotations/avroErasedName.scala
@@ -5,8 +5,8 @@ import scala.annotation.StaticAnnotation
 /** Disables generic type parameter name encoding in the Avro schema name. When applied to a type, the schema name will
   * use only the base class name without type parameter suffixes.
   *
-  * Note: Kindlings currently uses erased names by default (e.g. `Box[Int]` gets schema name `"Box"`), so this
-  * annotation currently serves as explicit documentation of intent for compatibility with avro4s.
+  * By default, Kindlings encodes type parameters into the Avro record name (e.g. `Box[Int]` gets schema name
+  * `"Box__Int"`). This annotation suppresses that encoding, producing just `"Box"`.
   *
   * Example: `@avroErasedName case class Box[A](value: A)`
   */

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/annotations/avroFqnParamNames.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/annotations/avroFqnParamNames.scala
@@ -1,0 +1,16 @@
+package hearth.kindlings.avroderivation.annotations
+
+import scala.annotation.StaticAnnotation
+
+/** Encodes fully-qualified type parameter names into the Avro schema name, replacing dots with underscores. This
+  * prevents collisions when two types with the same short name but different packages are used as type parameters.
+  *
+  * By default, Kindlings uses short names: `GenericClass[com.foo.Value, com.bar.Value]` gets schema name
+  * `"GenericClass__Value__Value"` (collision). With this annotation, it becomes
+  * `"GenericClass__com_foo_Value__com_bar_Value"` (unambiguous).
+  *
+  * Overridden by `@avroErasedName`, which strips type parameters entirely.
+  *
+  * Example: `@avroFqnParamNames case class Wrapper[A, B](a: A, b: B)`
+  */
+final class avroFqnParamNames extends StaticAnnotation

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/annotations/avroName.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/annotations/avroName.scala
@@ -1,0 +1,10 @@
+package hearth.kindlings.avroderivation.annotations
+
+import scala.annotation.StaticAnnotation
+
+/** Overrides the Avro schema name for a type. Takes highest priority over all other naming annotations
+  * (`@avroErasedName`, `@avroFqnParamNames`, and the default type-parameter encoding).
+  *
+  * Example: `@avroName("MyCustomRecord") case class Foo(x: Int)`
+  */
+final class avroName(name: String) extends StaticAnnotation

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/annotations/avroScalePrecision.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/annotations/avroScalePrecision.scala
@@ -1,0 +1,10 @@
+package hearth.kindlings.avroderivation.annotations
+
+import scala.annotation.StaticAnnotation
+
+/** Overrides the decimal logical type configuration for a `BigDecimal` field, taking precedence over the global
+  * `DecimalConfig` in `AvroConfig`. Without this annotation (or `DecimalConfig`), `BigDecimal` maps to STRING.
+  *
+  * Example: `case class Invoice(@avroScalePrecision(10, 2) amount: BigDecimal)`
+  */
+final class avroScalePrecision(precision: Int, scale: Int) extends StaticAnnotation

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupport.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupport.scala
@@ -19,6 +19,8 @@ trait AnnotationSupport { this: MacroCommons & StdExtensions =>
 
   protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)]
 
+  protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)]
+
   final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
     findAnnotationOfType[Ann](param).isDefined
 
@@ -42,6 +44,9 @@ trait AnnotationSupport { this: MacroCommons & StdExtensions =>
 
   final def getAllTypeAnnotationStringArgs[Ann: Type, A: Type]: List[String] =
     findAllTypeAnnotationsOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
+
+  final def getAnnotationTwoIntArgs[Ann: Type](param: Parameter): Option[(Int, Int)] =
+    findAnnotationOfType[Ann](param).flatMap(extractTwoIntLiteralsFromAnnotation)
 
   final def getAllAnnotationTwoStringArgs[Ann: Type](param: Parameter): List[(String, String)] =
     findAllAnnotationsOfType[Ann](param).flatMap(extractTwoStringLiteralsFromAnnotation)

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -14,9 +14,11 @@ import hearth.kindlings.avroderivation.annotations.{
   avroError,
   avroFixed,
   avroFqnParamNames,
+  avroName,
   avroNamespace,
   avroNoDefault,
   avroProp,
+  avroScalePrecision,
   avroSortPriority,
   fieldName,
   transientField
@@ -300,37 +302,39 @@ trait SchemaForMacrosImpl
 
   @scala.annotation.nowarn("msg=is never used")
   protected def computeAvroNameExpr[A: SchemaForCtx]: Expr[String] = {
+    implicit val avroNameT: Type[avroName] = SfTypes.AvroName
     implicit val avroErasedNameT: Type[avroErasedName] = SfTypes.AvroErasedName
-    if (hasTypeAnnotation[avroErasedName, A]) {
-      Expr(Type[A].shortName)
-    } else {
-      implicit val SchemaT: Type[Schema] = SfTypes.Schema
-      implicit val StringT: Type[String] = SfTypes.String
-      implicit val avroFqnParamNamesT: Type[avroFqnParamNames] = SfTypes.AvroFqnParamNames
-      val useFqn = hasTypeAnnotation[avroFqnParamNames, A]
-      val ignoredImplicits = AvroSchemaForUseImplicitWhenAvailableRule.ignoredImplicits
-      val fullNameExpr: Expr[String] = Type[A].runtimePlainPrint { tpe =>
-        import tpe.Underlying
-        if (tpe.Underlying =:= Type[A]) None
-        else if (sfctx.derivedType.exists(_.Underlying =:= tpe.Underlying)) None
-        else {
-          implicit val AvroSchemaForT: Type[AvroSchemaFor[tpe.Underlying]] = SfTypes.AvroSchemaFor[tpe.Underlying]
-          Type[AvroSchemaFor[tpe.Underlying]].summonExprIgnoring(ignoredImplicits*).toEither match {
-            case Right(schemaForExpr) =>
-              val fallback = Expr(Type.plainPrint[tpe.Underlying])
-              Some(Expr.quote {
-                val s = Expr.splice(schemaForExpr).schema
-                val t = s.getType
-                if (t == Schema.Type.RECORD || t == Schema.Type.ENUM || t == Schema.Type.FIXED)
-                  s.getFullName
-                else Expr.splice(fallback)
-              })
-            case Left(_) => None
+    getTypeAnnotationStringArg[avroName, A] match {
+      case Some(explicitName)                           => Expr(explicitName)
+      case None if hasTypeAnnotation[avroErasedName, A] => Expr(Type[A].shortName)
+      case None                                         =>
+        implicit val SchemaT: Type[Schema] = SfTypes.Schema
+        implicit val StringT: Type[String] = SfTypes.String
+        implicit val avroFqnParamNamesT: Type[avroFqnParamNames] = SfTypes.AvroFqnParamNames
+        val useFqn = hasTypeAnnotation[avroFqnParamNames, A]
+        val ignoredImplicits = AvroSchemaForUseImplicitWhenAvailableRule.ignoredImplicits
+        val fullNameExpr: Expr[String] = Type[A].runtimePlainPrint { tpe =>
+          import tpe.Underlying
+          if (tpe.Underlying =:= Type[A]) None
+          else if (sfctx.derivedType.exists(_.Underlying =:= tpe.Underlying)) None
+          else {
+            implicit val AvroSchemaForT: Type[AvroSchemaFor[tpe.Underlying]] = SfTypes.AvroSchemaFor[tpe.Underlying]
+            Type[AvroSchemaFor[tpe.Underlying]].summonExprIgnoring(ignoredImplicits*).toEither match {
+              case Right(schemaForExpr) =>
+                val fallback = Expr(Type.plainPrint[tpe.Underlying])
+                Some(Expr.quote {
+                  val s = Expr.splice(schemaForExpr).schema
+                  val t = s.getType
+                  if (t == Schema.Type.RECORD || t == Schema.Type.ENUM || t == Schema.Type.FIXED)
+                    s.getFullName
+                  else Expr.splice(fallback)
+                })
+              case Left(_) => None
+            }
           }
         }
-      }
-      if (useFqn) Expr.quote(AvroDerivationUtils.parseAvroNameFqn(Expr.splice(fullNameExpr)))
-      else Expr.quote(AvroDerivationUtils.parseAvroName(Expr.splice(fullNameExpr)))
+        if (useFqn) Expr.quote(AvroDerivationUtils.parseAvroNameFqn(Expr.splice(fullNameExpr)))
+        else Expr.quote(AvroDerivationUtils.parseAvroName(Expr.splice(fullNameExpr)))
     }
   }
 
@@ -359,5 +363,7 @@ trait SchemaForMacrosImpl
     val AvroEnumDefault: Type[avroEnumDefault] = Type.of[avroEnumDefault]
     val AvroErasedName: Type[avroErasedName] = Type.of[avroErasedName]
     val AvroFqnParamNames: Type[avroFqnParamNames] = Type.of[avroFqnParamNames]
+    val AvroName: Type[avroName] = Type.of[avroName]
+    val AvroScalePrecision: Type[avroScalePrecision] = Type.of[avroScalePrecision]
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -10,6 +10,7 @@ import hearth.kindlings.avroderivation.annotations.{
   avroDefault,
   avroDoc,
   avroEnumDefault,
+  avroErasedName,
   avroError,
   avroFixed,
   avroNamespace,
@@ -19,6 +20,7 @@ import hearth.kindlings.avroderivation.annotations.{
   fieldName,
   transientField
 }
+import hearth.kindlings.avroderivation.internal.runtime.AvroDerivationUtils
 import org.apache.avro.Schema
 
 trait SchemaForMacrosImpl
@@ -293,6 +295,41 @@ trait SchemaForMacrosImpl
         }
       }
 
+  // Avro name computation
+
+  @scala.annotation.nowarn("msg=is never used")
+  protected def computeAvroNameExpr[A: SchemaForCtx]: Expr[String] = {
+    implicit val avroErasedNameT: Type[avroErasedName] = SfTypes.AvroErasedName
+    if (hasTypeAnnotation[avroErasedName, A]) {
+      Expr(Type[A].shortName)
+    } else {
+      implicit val SchemaT: Type[Schema] = SfTypes.Schema
+      implicit val StringT: Type[String] = SfTypes.String
+      val ignoredImplicits = AvroSchemaForUseImplicitWhenAvailableRule.ignoredImplicits
+      val fullNameExpr: Expr[String] = Type[A].runtimePlainPrint { tpe =>
+        import tpe.Underlying
+        if (tpe.Underlying =:= Type[A]) None
+        else if (sfctx.derivedType.exists(_.Underlying =:= tpe.Underlying)) None
+        else {
+          implicit val AvroSchemaForT: Type[AvroSchemaFor[tpe.Underlying]] = SfTypes.AvroSchemaFor[tpe.Underlying]
+          Type[AvroSchemaFor[tpe.Underlying]].summonExprIgnoring(ignoredImplicits*).toEither match {
+            case Right(schemaForExpr) =>
+              val fallback = Expr(Type.plainPrint[tpe.Underlying])
+              Some(Expr.quote {
+                val s = Expr.splice(schemaForExpr).schema
+                val t = s.getType
+                if (t == Schema.Type.RECORD || t == Schema.Type.ENUM || t == Schema.Type.FIXED)
+                  s.getFullName
+                else Expr.splice(fallback)
+              })
+            case Left(_) => None
+          }
+        }
+      }
+      Expr.quote(AvroDerivationUtils.parseAvroName(Expr.splice(fullNameExpr)))
+    }
+  }
+
   // Types
 
   private[compiletime] object SfTypes {
@@ -316,5 +353,6 @@ trait SchemaForMacrosImpl
     val AvroSortPriority: Type[avroSortPriority] = Type.of[avroSortPriority]
     val AvroNoDefault: Type[avroNoDefault] = Type.of[avroNoDefault]
     val AvroEnumDefault: Type[avroEnumDefault] = Type.of[avroEnumDefault]
+    val AvroErasedName: Type[avroErasedName] = Type.of[avroErasedName]
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -13,6 +13,7 @@ import hearth.kindlings.avroderivation.annotations.{
   avroErasedName,
   avroError,
   avroFixed,
+  avroFqnParamNames,
   avroNamespace,
   avroNoDefault,
   avroProp,
@@ -305,6 +306,8 @@ trait SchemaForMacrosImpl
     } else {
       implicit val SchemaT: Type[Schema] = SfTypes.Schema
       implicit val StringT: Type[String] = SfTypes.String
+      implicit val avroFqnParamNamesT: Type[avroFqnParamNames] = SfTypes.AvroFqnParamNames
+      val useFqn = hasTypeAnnotation[avroFqnParamNames, A]
       val ignoredImplicits = AvroSchemaForUseImplicitWhenAvailableRule.ignoredImplicits
       val fullNameExpr: Expr[String] = Type[A].runtimePlainPrint { tpe =>
         import tpe.Underlying
@@ -326,7 +329,8 @@ trait SchemaForMacrosImpl
           }
         }
       }
-      Expr.quote(AvroDerivationUtils.parseAvroName(Expr.splice(fullNameExpr)))
+      if (useFqn) Expr.quote(AvroDerivationUtils.parseAvroNameFqn(Expr.splice(fullNameExpr)))
+      else Expr.quote(AvroDerivationUtils.parseAvroName(Expr.splice(fullNameExpr)))
     }
   }
 
@@ -354,5 +358,6 @@ trait SchemaForMacrosImpl
     val AvroNoDefault: Type[avroNoDefault] = Type.of[avroNoDefault]
     val AvroEnumDefault: Type[avroEnumDefault] = Type.of[avroEnumDefault]
     val AvroErasedName: Type[avroErasedName] = Type.of[avroErasedName]
+    val AvroFqnParamNames: Type[avroFqnParamNames] = Type.of[avroFqnParamNames]
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsCaseClassRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsCaseClassRule.scala
@@ -66,7 +66,7 @@ trait AvroSchemaForHandleAsCaseClassRuleImpl {
 
       val constructor = caseClass.primaryConstructor
       val fieldsList = constructor.parameters.flatten.toList
-      val typeName = Type[A].shortName
+      val typeNameExpr = computeAvroNameExpr[A]
 
       // Validate: @transientField on fields without defaults is a compile error
       fieldsList.collectFirst {
@@ -109,7 +109,7 @@ trait AvroSchemaForHandleAsCaseClassRuleImpl {
       // Recursive field derivation finds this via SfCheckSelfRecordRule.
       val emptyRecordExpr: Expr[Schema] = Expr.quote {
         AvroDerivationUtils.createEmptyRecord(
-          Expr.splice(Expr(typeName)),
+          Expr.splice(typeNameExpr),
           Expr.splice(docExprOrNull),
           Expr.splice(namespaceExpr),
           Expr.splice(Expr(isError))

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsCaseClassRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsCaseClassRule.scala
@@ -17,6 +17,7 @@ import hearth.kindlings.avroderivation.annotations.{
   avroNamespace,
   avroNoDefault,
   avroProp,
+  avroScalePrecision,
   fieldName,
   transientField
 }
@@ -51,6 +52,7 @@ trait AvroSchemaForHandleAsCaseClassRuleImpl {
       implicit val avroNamespaceT: Type[avroNamespace] = SfTypes.AvroNamespace
       implicit val avroDefaultT: Type[avroDefault] = SfTypes.AvroDefault
       implicit val avroFixedT: Type[avroFixed] = SfTypes.AvroFixed
+      implicit val avroScalePrecisionT: Type[avroScalePrecision] = SfTypes.AvroScalePrecision
       implicit val avroErrorT: Type[avroError] = SfTypes.AvroError
       implicit val avroPropT: Type[avroProp] = SfTypes.AvroProp
       implicit val avroAliasT: Type[avroAlias] = SfTypes.AvroAlias
@@ -146,18 +148,19 @@ trait AvroSchemaForHandleAsCaseClassRuleImpl {
                   if (hasAnnotationType[avroNoDefault](param)) None
                   else getAnnotationStringArg[avroDefault](param)
                 val avroFixedSize = getAnnotationIntArg[avroFixed](param)
+                val decimalOverride = getAnnotationTwoIntArgs[avroScalePrecision](param)
                 val fieldProps = getAllAnnotationTwoStringArgs[avroProp](param)
                 val fieldAliases = getAllAnnotationStringArgs[avroAlias](param)
                 Log.namedScope(s"Deriving schema for field $fName: ${Type[Field].prettyPrint}") {
-                  avroFixedSize match {
-                    case Some(_) if !(Type[Field] =:= Type.of[Array[Byte]]) =>
+                  (avroFixedSize, decimalOverride) match {
+                    case (Some(_), _) if !(Type[Field] =:= Type.of[Array[Byte]]) =>
                       val err = SchemaDerivationError.AvroFixedOnNonByteArray(
                         fName,
                         Type[A].prettyPrint,
                         Type[Field].prettyPrint
                       )
                       Log.error(err.message) >> MIO.fail(err)
-                    case Some(size) =>
+                    case (Some(size), _) =>
                       val fixedName = nameOverride.getOrElse(fName)
                       MIO.pure {
                         val fieldSchema = Expr.quote {
@@ -169,7 +172,17 @@ trait AvroSchemaForHandleAsCaseClassRuleImpl {
                         }
                         (fName, fieldSchema, nameOverride, fieldDoc, fieldDefault, fieldProps, fieldAliases)
                       }
-                    case None =>
+                    case (_, Some((precision, scale))) =>
+                      MIO.pure {
+                        val fieldSchema = Expr.quote {
+                          AvroDerivationUtils.decimalSchema(
+                            Expr.splice(Expr(precision)),
+                            Expr.splice(Expr(scale))
+                          )
+                        }
+                        (fName, fieldSchema, nameOverride, fieldDoc, fieldDefault, fieldProps, fieldAliases)
+                      }
+                    case _ =>
                       deriveSchemaRecursively[Field](using sfctx.nest[Field]).map { fieldSchema =>
                         (fName, fieldSchema, nameOverride, fieldDoc, fieldDefault, fieldProps, fieldAliases)
                       }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsEnumRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsEnumRule.scala
@@ -46,7 +46,7 @@ trait AvroSchemaForHandleAsEnumRuleImpl {
       implicit val AvroConfigT: Type[AvroConfig] = SfTypes.AvroConfig
 
       val childrenList = enumm.directChildren.toList
-      val typeName = Type[A].shortName
+      val typeNameExpr = computeAvroNameExpr[A]
       val enumDefault: Option[String] = getTypeAnnotationStringArg[avroEnumDefault, A]
       val classNamespace: Option[String] = getTypeAnnotationStringArg[avroNamespace, A]
 
@@ -90,7 +90,7 @@ trait AvroSchemaForHandleAsEnumRuleImpl {
                   val javaSymbols = new java.util.ArrayList[String](symbols.size)
                   symbols.foreach(javaSymbols.add)
                   AvroDerivationUtils.createEnumWithDefault(
-                    Expr.splice(Expr(typeName)),
+                    Expr.splice(typeNameExpr),
                     Expr.splice(namespaceExpr),
                     javaSymbols,
                     Expr.splice(Expr(default))
@@ -102,7 +102,7 @@ trait AvroSchemaForHandleAsEnumRuleImpl {
                   val javaSymbols = new java.util.ArrayList[String](symbols.size)
                   symbols.foreach(javaSymbols.add)
                   AvroDerivationUtils.createEnum(
-                    Expr.splice(Expr(typeName)),
+                    Expr.splice(typeNameExpr),
                     Expr.splice(namespaceExpr),
                     javaSymbols
                   )

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsNamedTupleRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsNamedTupleRule.scala
@@ -42,13 +42,13 @@ trait AvroSchemaForHandleAsNamedTupleRuleImpl {
       implicit val AvroConfigT: Type[AvroConfig] = SfTypes.AvroConfig
 
       val fields = constructor.parameters.flatten.toList
-      val typeName = Type[A].shortName
+      val typeNameExpr = computeAvroNameExpr[A]
 
       NonEmptyList.fromList(fields) match {
         case None =>
           MIO.pure(Expr.quote {
             AvroDerivationUtils.createRecord(
-              Expr.splice(Expr(typeName)),
+              Expr.splice(typeNameExpr),
               Expr.splice(sfctx.config).namespace.getOrElse(""),
               java.util.Collections.emptyList[Schema.Field]()
             )
@@ -86,7 +86,7 @@ trait AvroSchemaForHandleAsNamedTupleRuleImpl {
               }
               Expr.quote {
                 AvroDerivationUtils.createRecord(
-                  Expr.splice(Expr(typeName)),
+                  Expr.splice(typeNameExpr),
                   Expr.splice(sfctx.config).namespace.getOrElse(""),
                   Expr.splice(fieldsExpr)
                 )

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsSingletonRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsSingletonRule.scala
@@ -24,7 +24,7 @@ trait AvroSchemaForHandleAsSingletonRuleImpl {
             implicit val StringT: Type[String] = SfTypes.String
             implicit val AvroConfigT: Type[AvroConfig] = SfTypes.AvroConfig
             implicit val avroNamespaceT: Type[avroNamespace] = SfTypes.AvroNamespace
-            val typeName = Type[A].shortName
+            val typeNameExpr = computeAvroNameExpr[A]
             val classNamespace: Option[String] = getTypeAnnotationStringArg[avroNamespace, A]
             val namespaceExpr: Expr[String] = classNamespace match {
               case Some(ns) => Expr(ns)
@@ -32,7 +32,7 @@ trait AvroSchemaForHandleAsSingletonRuleImpl {
             }
             val schemaExpr = Expr.quote {
               AvroDerivationUtils.createRecord(
-                Expr.splice(Expr(typeName)),
+                Expr.splice(typeNameExpr),
                 Expr.splice(namespaceExpr),
                 java.util.Collections.emptyList[Schema.Field]()
               )

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/runtime/AvroDerivationUtils.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/runtime/AvroDerivationUtils.scala
@@ -416,10 +416,38 @@ object AvroDerivationUtils {
     result.result()
   }
 
+  def parseAvroNameFqn(fullTypeName: String): String = {
+    val bracketIdx = fullTypeName.indexOf('[')
+    if (bracketIdx < 0) shortenToAvroName(fullTypeName)
+    else {
+      val baseName = shortenToAvroName(fullTypeName.substring(0, bracketIdx))
+      val paramsStr = fullTypeName.substring(bracketIdx + 1, fullTypeName.length - 1)
+      val params = splitTopLevelTypeParams(paramsStr).map(parseAvroParamFqn)
+      if (params.isEmpty) baseName else (baseName :: params).mkString("__")
+    }
+  }
+
+  private def parseAvroParamFqn(fullTypeName: String): String = {
+    val bracketIdx = fullTypeName.indexOf('[')
+    if (bracketIdx < 0) fqnToAvroName(fullTypeName)
+    else {
+      val baseFqn = fqnToAvroName(fullTypeName.substring(0, bracketIdx))
+      val paramsStr = fullTypeName.substring(bracketIdx + 1, fullTypeName.length - 1)
+      val params = splitTopLevelTypeParams(paramsStr).map(parseAvroParamFqn)
+      if (params.isEmpty) baseFqn else (baseFqn :: params).mkString("__")
+    }
+  }
+
+  private def stripTypeSuffix(name: String): String =
+    if (name.endsWith(".type")) name.substring(0, name.length - 5) else name
+
   private def shortenToAvroName(fullName: String): String = {
-    val stripped = if (fullName.endsWith(".type")) fullName.substring(0, fullName.length - 5) else fullName
+    val stripped = stripTypeSuffix(fullName)
     val dotIdx = stripped.lastIndexOf('.')
     val name = if (dotIdx < 0) stripped else stripped.substring(dotIdx + 1)
     name.replaceAll("[^A-Za-z0-9_]", "_")
   }
+
+  private def fqnToAvroName(fullName: String): String =
+    stripTypeSuffix(fullName).replaceAll("[^A-Za-z0-9_]", "_")
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/runtime/AvroDerivationUtils.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/runtime/AvroDerivationUtils.scala
@@ -104,7 +104,7 @@ object AvroDerivationUtils {
   private def jsonNodeToObject(node: com.fasterxml.jackson.databind.JsonNode): Any = {
     import com.fasterxml.jackson.databind.node.*
     node match {
-      case _: NullNode                                        => org.apache.avro.Schema.Field.NULL_DEFAULT_VALUE
+      case _: NullNode                                        => org.apache.avro.JsonProperties.NULL_VALUE
       case n: BooleanNode                                     => java.lang.Boolean.valueOf(n.booleanValue())
       case n: IntNode                                         => java.lang.Integer.valueOf(n.intValue())
       case n: LongNode                                        => java.lang.Long.valueOf(n.longValue())
@@ -382,4 +382,44 @@ object AvroDerivationUtils {
     throw new IllegalArgumentException(
       s"Unknown Avro record type: $name. Expected one of: ${knownSubtypes.mkString(", ")}"
     )
+
+  // --- Type name helpers ---
+
+  def parseAvroName(fullTypeName: String): String = {
+    val bracketIdx = fullTypeName.indexOf('[')
+    if (bracketIdx < 0) shortenToAvroName(fullTypeName)
+    else {
+      val baseName = shortenToAvroName(fullTypeName.substring(0, bracketIdx))
+      val paramsStr = fullTypeName.substring(bracketIdx + 1, fullTypeName.length - 1)
+      val params = splitTopLevelTypeParams(paramsStr).map(parseAvroName)
+      if (params.isEmpty) baseName else (baseName :: params).mkString("__")
+    }
+  }
+
+  private def splitTopLevelTypeParams(s: String): List[String] = {
+    val result = List.newBuilder[String]
+    var depth = 0
+    var start = 0
+    var i = 0
+    while (i < s.length) {
+      s.charAt(i) match {
+        case '['               => depth += 1
+        case ']'               => depth -= 1
+        case ',' if depth == 0 =>
+          result += s.substring(start, i).trim
+          start = i + 1
+        case _ =>
+      }
+      i += 1
+    }
+    if (start < s.length) result += s.substring(start).trim
+    result.result()
+  }
+
+  private def shortenToAvroName(fullName: String): String = {
+    val stripped = if (fullName.endsWith(".type")) fullName.substring(0, fullName.length - 5) else fullName
+    val dotIdx = stripped.lastIndexOf('.')
+    val name = if (dotIdx < 0) stripped else stripped.substring(dotIdx + 1)
+    name.replaceAll("[^A-Za-z0-9_]", "_")
+  }
 }

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroSchemaForSpec.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroSchemaForSpec.scala
@@ -976,6 +976,48 @@ final class AvroSchemaForSpec extends MacroSuite {
       }
     }
 
+    group("@avroName annotation") {
+
+      test("@avroName overrides schema name") {
+        val schema = AvroSchemaFor.schemaOf[NamedRecord]
+        schema.getName ==> "CustomRecord"
+      }
+    }
+
+    group("@avroScalePrecision annotation") {
+
+      test("per-field @avroScalePrecision overrides global config") {
+        val schema = AvroSchemaFor.schemaOf[WithPerFieldDecimal]
+        val priceSchema = schema.getField("price").schema()
+        priceSchema.getType ==> Schema.Type.BYTES
+        priceSchema.getLogicalType.getName ==> "decimal"
+        val decimal = priceSchema.getLogicalType.asInstanceOf[org.apache.avro.LogicalTypes.Decimal]
+        decimal.getPrecision ==> 12
+        decimal.getScale ==> 4
+        // label is a regular string field
+        schema.getField("label").schema().getType ==> Schema.Type.STRING
+      }
+
+      test("@avroScalePrecision works without global DecimalConfig") {
+        // No implicit AvroConfig with decimalConfig — BigDecimal defaults to STRING
+        // but @avroScalePrecision on a field should produce decimal anyway
+        val schema = AvroSchemaFor.schemaOf[WithPerFieldDecimal]
+        val priceSchema = schema.getField("price").schema()
+        priceSchema.getType ==> Schema.Type.BYTES
+        priceSchema.getLogicalType.getName ==> "decimal"
+      }
+    }
+
+    group("PascalCase field names") {
+
+      test("withPascalCaseFieldNames capitalizes first letter") {
+        implicit val config: AvroConfig = AvroConfig().withPascalCaseFieldNames
+        val schema = AvroSchemaFor.schemaOf[SimplePerson]
+        (schema.getField("Name") != null) ==> true
+        (schema.getField("Age") != null) ==> true
+      }
+    }
+
     group("Issue #92: nested null in @avroDefault") {
 
       test("@avroDefault with nested null in JSON object") {

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroSchemaForSpec.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroSchemaForSpec.scala
@@ -951,6 +951,29 @@ final class AvroSchemaForSpec extends MacroSuite {
         val schema = AvroSchemaFor.schemaOf[SimplePerson]
         schema.getName ==> "SimplePerson"
       }
+
+      test("@avroFqnParamNames uses fully-qualified type parameter names") {
+        val schema = AvroSchemaFor.schemaOf[FqnWrapper[fqnA.Value, fqnB.Value]]
+        val name = schema.getName
+        assert(name.contains("fqnA"), s"Expected FQN containing 'fqnA' but got: $name")
+        assert(name.contains("fqnB"), s"Expected FQN containing 'fqnB' but got: $name")
+      }
+
+      test("@avroFqnParamNames disambiguates same-short-name types") {
+        val schema = AvroSchemaFor.schemaOf[FqnWrapper[fqnA.Value, fqnB.Value]]
+        val name = schema.getName
+        // Without FQN, both would shorten to "Value" causing collision
+        // With FQN, package paths are preserved as underscores
+        assert(name.startsWith("FqnWrapper__"), s"Expected FqnWrapper__ prefix but got: $name")
+        val params = name.stripPrefix("FqnWrapper__").split("__").toList
+        assert(params.size == 2, s"Expected 2 type params but got: $params")
+        assert(params(0) != params(1), s"Type params should be distinct but got: $params")
+      }
+
+      test("@avroErasedName takes priority over @avroFqnParamNames") {
+        val schema = AvroSchemaFor.schemaOf[ErasedBox[Int]]
+        schema.getName ==> "ErasedBox"
+      }
     }
 
     group("Issue #92: nested null in @avroDefault") {

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroSchemaForSpec.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroSchemaForSpec.scala
@@ -920,5 +920,46 @@ final class AvroSchemaForSpec extends MacroSuite {
         schema.getName ==> "EitherNode"
       }
     }
+
+    group("Issue #91: generic type name encoding") {
+
+      test("Box[Int] schema name includes type parameter") {
+        val schema = AvroSchemaFor.schemaOf[Box[Int]]
+        schema.getName ==> "Box__Int"
+      }
+
+      test("Pair[String, Int] schema name includes both type parameters") {
+        val schema = AvroSchemaFor.schemaOf[Pair[String, Int]]
+        schema.getName ==> "Pair__String__Int"
+      }
+
+      test("two instantiations of same generic produce distinct schemas") {
+        val schema = AvroSchemaFor.schemaOf[Message]
+        val fooSchema = schema.getField("foo").schema()
+        val barSchema = schema.getField("bar").schema()
+        fooSchema.getName ==> "Audited__SimplePerson"
+        barSchema.getName ==> "Audited__Address"
+        barSchema.getField("data").schema().getName ==> "Address"
+      }
+
+      test("@avroErasedName suppresses type parameter encoding") {
+        val schema = AvroSchemaFor.schemaOf[ErasedBox[Int]]
+        schema.getName ==> "ErasedBox"
+      }
+
+      test("non-generic types keep simple names") {
+        val schema = AvroSchemaFor.schemaOf[SimplePerson]
+        schema.getName ==> "SimplePerson"
+      }
+    }
+
+    group("Issue #92: nested null in @avroDefault") {
+
+      test("@avroDefault with nested null in JSON object") {
+        val schema = AvroSchemaFor.schemaOf[OuterWithNestedNullDefault]
+        val field = schema.getField("b")
+        assert(field.hasDefaultValue)
+      }
+    }
   }
 }

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
@@ -264,5 +264,15 @@ case class WithListDefault(@avroDefault("[1,2,3]") items: List[Int] = List(1, 2,
 // Custom SchemaFor override test
 case class CustomSchemaType(value: String)
 
+// Issue #91: Generic type name encoding
+case class Audited[T](data: T, createdBy: String)
+case class Message(foo: Audited[SimplePerson], bar: Audited[Address])
+
+// Issue #92: Nested null in @avroDefault
+case class InnerWithOption(a: Option[String])
+case class OuterWithNestedNullDefault(
+    @avroDefault("""{"a": null}""") b: InnerWithOption = InnerWithOption(a = None)
+)
+
 // Unhandled type for compile-time error tests
 class NotAnAvroType

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
@@ -280,5 +280,15 @@ case class OuterWithNestedNullDefault(
     @avroDefault("""{"a": null}""") b: InnerWithOption = InnerWithOption(a = None)
 )
 
+// @avroName test types
+@annotations.avroName("CustomRecord")
+case class NamedRecord(x: Int)
+
+// @avroScalePrecision test types
+case class WithPerFieldDecimal(
+    @annotations.avroScalePrecision(12, 4) price: BigDecimal,
+    label: String
+)
+
 // Unhandled type for compile-time error tests
 class NotAnAvroType

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
@@ -268,6 +268,12 @@ case class CustomSchemaType(value: String)
 case class Audited[T](data: T, createdBy: String)
 case class Message(foo: Audited[SimplePerson], bar: Audited[Address])
 
+// @avroFqnParamNames test types
+object fqnA { case class Value(x: Int) }
+object fqnB { case class Value(y: String) }
+@annotations.avroFqnParamNames
+case class FqnWrapper[A, B](a: A, b: B)
+
 // Issue #92: Nested null in @avroDefault
 case class InnerWithOption(a: Option[String])
 case class OuterWithNestedNullDefault(


### PR DESCRIPTION
## Summary

- **Fix #91**: Generic types like `Audited[Foo]` and `Audited[Bar]` now get distinct Avro record names (`Audited__Foo`, `Audited__Bar`) using runtime-aware type name printing with implicit summoning, matching avro4s behavior
- **Fix #92**: Nested null values in `@avroDefault` JSON (e.g. `{"a": null}`) no longer throw `AvroRuntimeException` — fixed by using `JsonProperties.NULL_VALUE` instead of `Schema.Field.NULL_DEFAULT_VALUE`
- **New `@avroName("X")`**: Explicitly override the Avro schema name for a type (highest priority)
- **New `@avroFqnParamNames`**: Encode fully-qualified type parameter names to disambiguate same-short-name types from different packages
- **New `@avroScalePrecision(p, s)`**: Per-field BigDecimal precision/scale override, independent of global `DecimalConfig`
- **New `withPascalCaseFieldNames`**: PascalCase field name transform on `AvroConfig`

### Naming annotation priority

| Priority | Annotation | Effect |
|---|---|---|
| 1 | `@avroName("X")` | Explicit name, overrides everything |
| 2 | `@avroErasedName` | Short name only, strips type params |
| 3 | `@avroFqnParamNames` | FQN type params (dots → underscores) |
| 4 | *(default)* | Short type params, avro4s-compatible |

## Test plan

- [x] 118 schema tests pass on both Scala 2.13 and 3 (up from 104)
- [x] All 297 avro-derivation tests pass (schema + encoder + decoder + round-trip + Scala 3-specific)
- [x] Full JVM test suite passes for both Scala versions
- [x] Generic type names: `Box[Int]` → `Box__Int`, `Pair[String, Int]` → `Pair__String__Int`
- [x] Two instantiations of same generic (`Audited[Foo]`, `Audited[Bar]`) produce distinct schemas in a parent type
- [x] `@avroErasedName` suppresses type param encoding
- [x] `@avroFqnParamNames` disambiguates same-short-name types
- [x] `@avroName` overrides schema name entirely
- [x] `@avroScalePrecision` produces decimal logical type per-field without global config
- [x] PascalCase transforms `name` → `Name`, `age` → `Age`
- [x] Nested null default `{"a": null}` produces valid schema
- [x] Existing `@avroDefault("null")` test still passes