### PR TITLE
Add user-facing documentation with mkdocs + Material theme

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,6 +26,46 @@ jobs:
       - name: Check code formatting
         run: scalafmt --check
 
+  check-snippets:
+
+    runs-on: ubuntu-latest
+    if: github.event_name == 'push' || github.event.action != 'labeled'
+
+    name: Check Scala CLI snippets from documentation
+
+    steps:
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+      - uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cache/coursier/v1
+            ~/.cache/scalacli
+            ~/.sbt
+            ~/.ivy2/cache
+          key: snippets-coursier-${{ runner.os }}-${{ hashFiles('docs/user-guide/*.md') }}
+          restore-keys: |
+            snippets-coursier-${{ runner.os }}-
+      - uses: extractions/setup-just@v4
+      - uses: coursier/setup-action@v3.0.0
+        with:
+          apps: scala-cli sbt
+      - name: Run snippets from documentation
+        working-directory: docs
+        run: |
+          scala-cli config power true
+          just test-snippets
+      - uses: actions/cache/save@v5
+        if: always()
+        with:
+          path: |
+            ~/.cache/coursier/v1
+            ~/.cache/scalacli
+            ~/.sbt
+            ~/.ivy2/cache
+          key: snippets-coursier-${{ runner.os }}-${{ hashFiles('docs/user-guide/*.md') }}
+
   build:
 
     runs-on: ubuntu-latest

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,21 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+  jobs:
+    post_checkout:
+      - git fetch --unshallow || true
+
+python:
+  install:
+    - requirements: docs/requirements.txt
+
+mkdocs:
+  configuration: docs/mkdocs.yml

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,7 +107,7 @@ The most load-bearing entries to keep in mind for any macro work:
 ## Configurable derivation timeout
 
 All derivation modules use `DerivationTimeout` from `derivation-commons`
-(`hearth.kindlings.derivation.compiletime.DerivationTimeout`). Default: 120 seconds.
+(`hearth.kindlings.derivation.compiletime.DerivationTimeout`). Default: 5 seconds.
 Override per-module via `-Xmacro-settings`:
 
 ```

--- a/benchmarks/src/main/scala/hearth/kindlings/benchmarks/CirceBoosterBenchmark.scala
+++ b/benchmarks/src/main/scala/hearth/kindlings/benchmarks/CirceBoosterBenchmark.scala
@@ -17,7 +17,7 @@ class CirceBoosterEncodeBenchmark {
   // "Booster" = jsoniter-scala-circe writeToArray (Json → bytes)
   // "NoBooster" = circe .noSpaces (Json → String)
 
-  private implicit val jsonCodec: JsonValueCodec[Json] =
+  implicit private val jsonCodec: JsonValueCodec[Json] =
     new JsoniterScalaCodec(64, 32, _ => true, JsoniterScalaCodec.defaultNumberParser)
 
   // --- SimpleCC ---
@@ -89,7 +89,7 @@ class CirceBoosterDecodeBenchmark {
   // "Booster" = jsoniter-scala-circe readFromArray (bytes → Json)
   // "NoBooster" = circe parser.parse (String → Json)
 
-  private implicit val jsonCodec: JsonValueCodec[Json] =
+  implicit private val jsonCodec: JsonValueCodec[Json] =
     new JsoniterScalaCodec(64, 32, _ => true, JsoniterScalaCodec.defaultNumberParser)
 
   private var simpleCCBytes: Array[Byte] = _

--- a/benchmarks/src/main/scala/hearth/kindlings/benchmarks/CirceBoosterBenchmark.scala
+++ b/benchmarks/src/main/scala/hearth/kindlings/benchmarks/CirceBoosterBenchmark.scala
@@ -1,0 +1,203 @@
+package hearth.kindlings.benchmarks
+
+import com.github.plokhotnyuk.jsoniter_scala.core.*
+import io.circe.{Decoder, Json, JsoniterScalaCodec}
+import org.openjdk.jmh.annotations.*
+import java.util.concurrent.TimeUnit
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+class CirceBoosterEncodeBenchmark {
+
+  // Full pipeline: domain type → Encoder → Json → bytes/String
+  // "Booster" = jsoniter-scala-circe writeToArray (Json → bytes)
+  // "NoBooster" = circe .noSpaces (Json → String)
+
+  private implicit val jsonCodec: JsonValueCodec[Json] =
+    new JsoniterScalaCodec(64, 32, _ => true, JsoniterScalaCodec.defaultNumberParser)
+
+  // --- SimpleCC ---
+
+  @Benchmark def kindlingsBoosterSimpleCC(): Array[Byte] =
+    writeToArray(KindlingsCirceInstances.simpleCCSemiAutoEncoder(BenchmarkData.simpleCC))
+
+  @Benchmark def originalBoosterSimpleCC(): Array[Byte] =
+    writeToArray(OriginalCirceSemiAutoInstances.simpleCCEncoder(BenchmarkData.simpleCC))
+
+  @Benchmark def kindlingsNoBoosterSimpleCC(): String =
+    KindlingsCirceInstances.simpleCCSemiAutoEncoder(BenchmarkData.simpleCC).noSpaces
+
+  @Benchmark def originalNoBoosterSimpleCC(): String =
+    OriginalCirceSemiAutoInstances.simpleCCEncoder(BenchmarkData.simpleCC).noSpaces
+
+  // --- Person ---
+
+  @Benchmark def kindlingsBoosterPerson(): Array[Byte] =
+    writeToArray(KindlingsCirceInstances.personSemiAutoEncoder(BenchmarkData.person))
+
+  @Benchmark def originalBoosterPerson(): Array[Byte] =
+    writeToArray(OriginalCirceSemiAutoInstances.personEncoder(BenchmarkData.person))
+
+  @Benchmark def kindlingsNoBoosterPerson(): String =
+    KindlingsCirceInstances.personSemiAutoEncoder(BenchmarkData.person).noSpaces
+
+  @Benchmark def originalNoBoosterPerson(): String =
+    OriginalCirceSemiAutoInstances.personEncoder(BenchmarkData.person).noSpaces
+
+  // --- SimpleADT ---
+
+  @Benchmark def kindlingsBoosterSimpleADT(): Array[Byte] =
+    writeToArray(KindlingsCirceInstances.simpleADTSemiAutoEncoder(BenchmarkData.simpleADT))
+
+  @Benchmark def originalBoosterSimpleADT(): Array[Byte] =
+    writeToArray(OriginalCirceSemiAutoInstances.simpleADTEncoder(BenchmarkData.simpleADT))
+
+  @Benchmark def kindlingsNoBoosterSimpleADT(): String =
+    KindlingsCirceInstances.simpleADTSemiAutoEncoder(BenchmarkData.simpleADT).noSpaces
+
+  @Benchmark def originalNoBoosterSimpleADT(): String =
+    OriginalCirceSemiAutoInstances.simpleADTEncoder(BenchmarkData.simpleADT).noSpaces
+
+  // --- Event ---
+
+  @Benchmark def kindlingsBoosterEvent(): Array[Byte] =
+    writeToArray(KindlingsCirceInstances.eventSemiAutoEncoder(BenchmarkData.event))
+
+  @Benchmark def originalBoosterEvent(): Array[Byte] =
+    writeToArray(OriginalCirceSemiAutoInstances.eventEncoder(BenchmarkData.event))
+
+  @Benchmark def kindlingsNoBoosterEvent(): String =
+    KindlingsCirceInstances.eventSemiAutoEncoder(BenchmarkData.event).noSpaces
+
+  @Benchmark def originalNoBoosterEvent(): String =
+    OriginalCirceSemiAutoInstances.eventEncoder(BenchmarkData.event).noSpaces
+}
+
+@State(Scope.Benchmark)
+@BenchmarkMode(Array(Mode.Throughput))
+@OutputTimeUnit(TimeUnit.SECONDS)
+@Warmup(iterations = 5, time = 1)
+@Measurement(iterations = 10, time = 1)
+@Fork(2)
+class CirceBoosterDecodeBenchmark {
+
+  // Full pipeline: bytes/String → parse → Json → Decoder → domain type
+  // "Booster" = jsoniter-scala-circe readFromArray (bytes → Json)
+  // "NoBooster" = circe parser.parse (String → Json)
+
+  private implicit val jsonCodec: JsonValueCodec[Json] =
+    new JsoniterScalaCodec(64, 32, _ => true, JsoniterScalaCodec.defaultNumberParser)
+
+  private var simpleCCBytes: Array[Byte] = _
+  private var simpleCCString: String = _
+  private var personBytes: Array[Byte] = _
+  private var personString: String = _
+  private var simpleADTBytes: Array[Byte] = _
+  private var simpleADTString: String = _
+  private var eventBytes: Array[Byte] = _
+  private var eventString: String = _
+
+  @Setup(Level.Trial)
+  def setup(): Unit = {
+    simpleCCBytes = writeToArray(KindlingsCirceInstances.simpleCCSemiAutoEncoder(BenchmarkData.simpleCC))
+    simpleCCString = new String(simpleCCBytes)
+    personBytes = writeToArray(KindlingsCirceInstances.personSemiAutoEncoder(BenchmarkData.person))
+    personString = new String(personBytes)
+    simpleADTBytes = writeToArray(KindlingsCirceInstances.simpleADTSemiAutoEncoder(BenchmarkData.simpleADT))
+    simpleADTString = new String(simpleADTBytes)
+    eventBytes = writeToArray(KindlingsCirceInstances.eventSemiAutoEncoder(BenchmarkData.event))
+    eventString = new String(eventBytes)
+  }
+
+  // --- SimpleCC ---
+
+  @Benchmark def kindlingsBoosterSimpleCC(): Decoder.Result[SimpleCC] = {
+    val json = readFromArray[Json](simpleCCBytes)
+    KindlingsCirceInstances.simpleCCSemiAutoDecoder.decodeJson(json)
+  }
+
+  @Benchmark def originalBoosterSimpleCC(): Decoder.Result[SimpleCC] = {
+    val json = readFromArray[Json](simpleCCBytes)
+    OriginalCirceSemiAutoInstances.simpleCCDecoder.decodeJson(json)
+  }
+
+  @Benchmark def kindlingsNoBoosterSimpleCC(): Decoder.Result[SimpleCC] = {
+    val json = io.circe.parser.parse(simpleCCString).getOrElse(Json.Null)
+    KindlingsCirceInstances.simpleCCSemiAutoDecoder.decodeJson(json)
+  }
+
+  @Benchmark def originalNoBoosterSimpleCC(): Decoder.Result[SimpleCC] = {
+    val json = io.circe.parser.parse(simpleCCString).getOrElse(Json.Null)
+    OriginalCirceSemiAutoInstances.simpleCCDecoder.decodeJson(json)
+  }
+
+  // --- Person ---
+
+  @Benchmark def kindlingsBoosterPerson(): Decoder.Result[Person] = {
+    val json = readFromArray[Json](personBytes)
+    KindlingsCirceInstances.personSemiAutoDecoder.decodeJson(json)
+  }
+
+  @Benchmark def originalBoosterPerson(): Decoder.Result[Person] = {
+    val json = readFromArray[Json](personBytes)
+    OriginalCirceSemiAutoInstances.personDecoder.decodeJson(json)
+  }
+
+  @Benchmark def kindlingsNoBoosterPerson(): Decoder.Result[Person] = {
+    val json = io.circe.parser.parse(personString).getOrElse(Json.Null)
+    KindlingsCirceInstances.personSemiAutoDecoder.decodeJson(json)
+  }
+
+  @Benchmark def originalNoBoosterPerson(): Decoder.Result[Person] = {
+    val json = io.circe.parser.parse(personString).getOrElse(Json.Null)
+    OriginalCirceSemiAutoInstances.personDecoder.decodeJson(json)
+  }
+
+  // --- SimpleADT ---
+
+  @Benchmark def kindlingsBoosterSimpleADT(): Decoder.Result[SimpleADT] = {
+    val json = readFromArray[Json](simpleADTBytes)
+    KindlingsCirceInstances.simpleADTSemiAutoDecoder.decodeJson(json)
+  }
+
+  @Benchmark def originalBoosterSimpleADT(): Decoder.Result[SimpleADT] = {
+    val json = readFromArray[Json](simpleADTBytes)
+    OriginalCirceSemiAutoInstances.simpleADTDecoder.decodeJson(json)
+  }
+
+  @Benchmark def kindlingsNoBoosterSimpleADT(): Decoder.Result[SimpleADT] = {
+    val json = io.circe.parser.parse(simpleADTString).getOrElse(Json.Null)
+    KindlingsCirceInstances.simpleADTSemiAutoDecoder.decodeJson(json)
+  }
+
+  @Benchmark def originalNoBoosterSimpleADT(): Decoder.Result[SimpleADT] = {
+    val json = io.circe.parser.parse(simpleADTString).getOrElse(Json.Null)
+    OriginalCirceSemiAutoInstances.simpleADTDecoder.decodeJson(json)
+  }
+
+  // --- Event ---
+
+  @Benchmark def kindlingsBoosterEvent(): Decoder.Result[Event] = {
+    val json = readFromArray[Json](eventBytes)
+    KindlingsCirceInstances.eventSemiAutoDecoder.decodeJson(json)
+  }
+
+  @Benchmark def originalBoosterEvent(): Decoder.Result[Event] = {
+    val json = readFromArray[Json](eventBytes)
+    OriginalCirceSemiAutoInstances.eventDecoder.decodeJson(json)
+  }
+
+  @Benchmark def kindlingsNoBoosterEvent(): Decoder.Result[Event] = {
+    val json = io.circe.parser.parse(eventString).getOrElse(Json.Null)
+    KindlingsCirceInstances.eventSemiAutoDecoder.decodeJson(json)
+  }
+
+  @Benchmark def originalNoBoosterEvent(): Decoder.Result[Event] = {
+    val json = io.circe.parser.parse(eventString).getOrElse(Json.Null)
+    OriginalCirceSemiAutoInstances.eventDecoder.decodeJson(json)
+  }
+}

--- a/build.sbt
+++ b/build.sbt
@@ -904,6 +904,7 @@ lazy val benchmarks = projectMatrix
       "io.circe" %% "circe-parser" % versions.circe,
       "io.circe" %% "circe-generic" % versions.circe,
       "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-macros" % versions.jsoniterScala % Provided,
+      "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-circe" % versions.jsoniterScala,
       "org.typelevel" %% "kittens" % versions.kittens,
       "com.sksamuel.avro4s" %% "avro4s-core" % (if (scalaBinaryVersion.value == "3") versions.avro4s3
                                                 else versions.avro4s213)

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/DerivationTimeout.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/DerivationTimeout.scala
@@ -44,7 +44,7 @@ trait DerivationTimeout {
       case _ =>
         Environment.reportWarn(
           s"$derivationSettingsNamespace.timeout: unrecognized format '$str'. " +
-            s"Expected formats: 120, 120s, 5000ms, 5m. " +
+            s"Expected formats: 30, 30s, 5000ms, 1m. " +
             s"Using default of ${DerivationTimeout.Default.toSeconds}s."
         )
         None
@@ -55,7 +55,7 @@ trait DerivationTimeout {
 object DerivationTimeout {
 
   val Default: scala.concurrent.duration.FiniteDuration =
-    scala.concurrent.duration.FiniteDuration(120, java.util.concurrent.TimeUnit.SECONDS)
+    scala.concurrent.duration.FiniteDuration(5, java.util.concurrent.TimeUnit.SECONDS)
 
   private val DurationPattern = """^\s*(\d+)\s*(ms|millis|milliseconds|s|seconds?|m|minutes?)\s*$""".r
 }

--- a/docs/Dockerfile
+++ b/docs/Dockerfile
@@ -1,0 +1,2 @@
+FROM squidfunk/mkdocs-material:9.5.50
+RUN pip install mkdocs==1.6.1 mkdocs-macros-plugin==1.3.7

--- a/docs/Justfile
+++ b/docs/Justfile
@@ -1,0 +1,9 @@
+build:
+  docker build . -t mkdocs-kindlings-docs
+
+serve: build
+  docker run --rm -it -p 8000:8000 -v ${PWD}:/docs --env "CI_LATEST_TAG=$(git describe --tags)" mkdocs-kindlings-docs
+
+test-snippets:
+  cd .. && sbt --client "publish-local-for-tests"
+  cd .. && scala-cli run scripts/test-snippets.scala -- --extra "kindlings-version=$(sbt -batch -error 'print fastShowPretty/version' 2>/dev/null | grep -oE '^[0-9][^ \[]*')" "$PWD/docs/user-guide"

--- a/docs/main.py
+++ b/docs/main.py
@@ -1,0 +1,40 @@
+import os
+import re
+
+def define_env(env):
+
+    kindlings_version_string = ''
+    """
+    Start by attempting to read git describe --tags
+    """
+    if not kindlings_version_string:
+        try:
+            pipe = os.popen('git describe --tags')
+            kindlings_version_string = pipe.read().replace("\n", '').strip()
+            pipe.close()
+        except Exception:
+            kindlings_version_string = ''
+    """
+    If that fails then fallback on CI_LATEST_TAG env var we passed manually to Docker image
+    """
+    if not kindlings_version_string:
+        try:
+            kindlings_version_string = env.conf['extra']['local']['tag']
+        except KeyError:
+            kindlings_version_string = ''
+    """
+    Finally fallback on something :/
+    """
+    if not kindlings_version_string:
+        kindlings_version_string = 'kindlings_version'
+    """
+    If git describe tells us that this is NOT a git tag but git tag + some offset, we need to add -SNAPSHOT to match sbt
+    """
+    if re.compile('.+-[0-9]+-g[0-9a-z]{8}').match(kindlings_version_string):
+        kindlings_version_string = kindlings_version_string[0:-1] + '-SNAPSHOT'
+    elif re.compile('.+-[0-9]+-[0-9a-z]{8}').match(kindlings_version_string):
+        kindlings_version_string = kindlings_version_string + '-SNAPSHOT'
+
+    @env.macro
+    def kindlings_version():
+        return kindlings_version_string

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -1,0 +1,133 @@
+site_name: "Kindlings documentation"
+repo_url: https://github.com/kubuszok/kindlings
+edit_uri: edit/master/docs/user-guide/
+docs_dir: "user-guide"
+strict: true
+theme:
+  name: material
+  palette:
+    # Palette toggle for automatic mode
+    - media: "(prefers-color-scheme)"
+      toggle:
+        icon: material/brightness-auto
+        name: Switch to light mode
+
+    # Palette toggle for light mode
+    - media: "(prefers-color-scheme: light)"
+      scheme: default
+      primary: red
+      toggle:
+        icon: material/brightness-7
+        name: Switch to dark mode
+
+    # Palette toggle for dark mode
+    - media: "(prefers-color-scheme: dark)"
+      scheme: slate
+      primary: black
+      toggle:
+        icon: material/brightness-4
+        name: Switch to system preference
+
+  features:
+    - content.action.edit
+    - content.code.copy
+    - content.code.select
+    - content.tabs.link
+    - content.tooltips
+    - navigation.expand
+    - navigation.footer
+    - navigation.instant
+    - navigation.instant.progress
+    - navigation.path
+    - navigation.sections
+    - navigation.tracking
+    - search.highlight
+    - search.suggest
+
+  font:
+    code: Fira Code
+  icon:
+    repo: fontawesome/brands/github
+
+nav:
+  - "Welcome": "index.md"
+  - "Modules":
+    - "Avro": "avro-derivation.md"
+    - "Cats": "cats-derivation.md"
+    - "Circe": "circe-derivation.md"
+    - "FastShowPretty": "fast-show-pretty.md"
+    - "Jsoniter Scala": "jsoniter-derivation.md"
+    - "PureConfig": "pureconfig-derivation.md"
+    - "ScalaCheck": "scalacheck-derivation.md"
+    - "sconfig (HOCON)": "sconfig-derivation.md"
+    - "Tapir Schema": "tapir-schema-derivation.md"
+    - "UBJson": "ubjson-derivation.md"
+    - "XML": "xml-derivation.md"
+    - "YAML": "yaml-derivation.md"
+  - "Integration Modules":
+    - "Cats Collections": "cats-integration.md"
+    - "Iron": "iron-integration.md"
+    - "Refined": "refined-integration.md"
+  - "Debugging & Diagnostics": "debugging.md"
+  - "FAQ": "faq.md"
+
+markdown_extensions:
+  - admonition
+  - pymdownx.details
+  - pymdownx.inlinehilite
+  - pymdownx.snippets
+  - pymdownx.superfences
+  - pymdownx.tabbed:
+      alternate_style: true
+  - pymdownx.tasklist:
+      clickable_checkbox: true
+      custom_checkbox: true
+  - pymdownx.highlight:
+      anchor_linenums: true
+      line_spans: __span
+      pygments_lang_class: true
+      use_pygments: true
+
+plugins:
+  - macros
+  - search
+
+copyright: |
+  <div style="color: var(--md-footer-fg-color--lighter)">
+  Copyright &copy; 2025-2026, <a href="https://kubuszok.com" target="_blank" rel="noopener">Kubuszok.com</a>.<br />
+  Kindlings is FOSS licensed under Apache 2.0<br />
+  <br />
+  Documentation made with <a href="https://www.mkdocs.org" target="_blank" rel="noopener">MkDocs</a>, <a href="https://squidfunk.github.io/mkdocs-material/" target="_blank" rel="noopener">Material for MkDocs</a> and <a href="https://mkdocs-macros-plugin.readthedocs.io/" target="_blank" rel="noopener">Mkdocs-Macros</a>, hosted on <a href="https://readthedocs.org/" target="_blank" rel="noopener">Read the Docs</a>
+  </div>
+
+extra:
+  generator: false
+  social:
+    - icon: fontawesome/brands/github
+      link: https://github.com/kubuszok/kindlings
+    - icon: fontawesome/solid/book-bookmark
+      link: https://index.scala-lang.org/kubuszok/kindlings
+    - icon: fontawesome/brands/twitter
+      link: https://twitter.com/@MateuszKubuszok
+  scala:
+    2_13: "2.13.18"
+    3: "3.8.3"
+  libraries:
+    circe: "0.14.15"
+    jsoniterScala: "2.38.12"
+    cats: "2.13.0"
+    tapir: "1.13.19"
+    avro: "1.12.1"
+    pureconfig: "0.17.10"
+    scalacheck: "1.19.0"
+    refined: "0.11.3"
+    iron: "3.3.1"
+    sconfig: "1.12.4"
+    scalaYaml: "0.3.1"
+    scalaXml: "2.4.0"
+    scalaSaxParser: "0.1.0"
+    kittens: "3.5.0"
+    avro4s213: "4.1.2"
+    avro4s3: "5.0.15"
+  local:
+    tag: !ENV [CI_LATEST_TAG, "latest"]

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,3 @@
+mkdocs==1.6.1
+mkdocs-macros-plugin==1.3.7
+mkdocs-material==9.5.50

--- a/docs/research/benchmark-results.md
+++ b/docs/research/benchmark-results.md
@@ -1,6 +1,6 @@
 # Kindlings Benchmark Results
 
-> **Configuration**: 2 forks, 3 warmup iterations, 5 measurement iterations, 1s each
+> **Configuration**: 2 forks, 5 warmup iterations, 10 measurement iterations, 1s each
 > **Platform**: macOS, JVM (temurin 17)
 > **Scala versions**: 2.13.18, 3.8.3
 
@@ -10,169 +10,199 @@ All values in ops/s (higher is better). Error margins omitted for readability.
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
 |------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 31.1M | 31.0M | 19.8M | 18.9M | **1.6x faster** |
-| SimpleCC | 3 | 30.7M | 30.3M | 22.0M | 21.1M | **1.4x faster** |
-| SimpleADT | 2.13 | 27.7M | 27.0M | 13.8M | 13.9M | **2.0x faster** |
-| SimpleADT | 3 | 25.7M | 26.4M | 26.2M | 26.1M | ~tied |
-| Person | 2.13 | 4.4M | 4.5M | 3.1M | 3.1M | **1.4x faster** |
-| Person | 3 | 4.4M | 4.4M | 3.0M | 3.0M | **1.4x faster** |
-| Event | 2.13 | 3.4M | 3.4M | 2.3M | 2.6M | **1.3x faster** |
-| Event | 3 | 3.4M | 3.3M | 2.3M | 2.3M | **1.4x faster** |
+| SimpleCC | 2.13 | 30.6M | 31.1M | 19.3M | 19.0M | **1.6x faster** |
+| SimpleCC | 3 | 30.9M | 30.7M | 21.8M | 21.3M | **1.4x faster** |
+| SimpleADT | 2.13 | 27.2M | 27.9M | 14.1M | 14.0M | **2.0x faster** |
+| SimpleADT | 3 | 26.1M | 26.5M | 25.7M | 25.4M | ~tied |
+| Person | 2.13 | 4.5M | 4.5M | 3.0M | 3.0M | **1.5x faster** |
+| Person | 3 | 4.3M | 4.3M | 3.1M | 3.1M | **1.4x faster** |
+| Event | 2.13 | 3.4M | 3.4M | 2.3M | 2.4M | **1.4x faster** |
+| Event | 3 | 3.3M | 3.4M | 2.3M | 2.3M | **1.4x faster** |
 
 ## Circe Decode
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
 |------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 49.5M | 48.7M | 43.6M | 42.2M | **1.1x faster** |
-| SimpleCC | 3 | 46.8M | 44.5M | 19.9M | 20.5M | **2.3x faster** |
-| SimpleADT | 2.13 | 57.9M | 56.1M | 27.0M | 24.7M | **2.1x faster** |
-| SimpleADT | 3 | 56.8M | 58.8M | 27.7M | 29.6M | **2.0x faster** |
-| Person | 2.13 | 4.1M | 4.2M | 3.6M | 3.5M | **1.2x faster** |
-| Person | 3 | 4.0M | 4.0M | 2.4M | 2.6M | **1.5x faster** |
-| Event | 2.13 | 2.9M | 2.9M | 2.9M | 2.7M | ~tied |
-| Event | 3 | 2.7M | 2.7M | 2.1M | 2.1M | **1.3x faster** |
+| SimpleCC | 2.13 | 51.0M | 50.9M | 42.4M | 42.8M | **1.2x faster** |
+| SimpleCC | 3 | 52.7M | 48.9M | 20.0M | 20.6M | **2.6x faster** |
+| SimpleADT | 2.13 | 61.3M | 61.0M | 25.0M | 26.5M | **2.3x faster** |
+| SimpleADT | 3 | 47.7M | 46.5M | 29.2M | 27.8M | **1.6x faster** |
+| Person | 2.13 | 4.2M | 4.2M | 3.5M | 3.5M | **1.2x faster** |
+| Person | 3 | 4.2M | 4.2M | 2.7M | 2.7M | **1.6x faster** |
+| Event | 2.13 | 2.8M | 2.8M | 2.7M | 2.7M | ~tied |
+| Event | 3 | 2.9M | 2.9M | 2.1M | 2.1M | **1.4x faster** |
+
+## Circe End-to-End with jsoniter-scala-circe Booster
+
+Full pipeline benchmarks: domain type ↔ bytes/String, comparing Circe's default parser/printer vs jsoniter-scala-circe booster.
+
+### Encode (domain type → bytes/String)
+
+| Type | Scala | Kindlings + booster | Original + booster | Kindlings (no booster) | Original (no booster) |
+|------|-------|--------------------|--------------------|----------------------|---------------------|
+| SimpleCC | 2.13 | **14.8M** | 10.2M | 6.8M | 5.5M |
+| SimpleCC | 3 | **15.3M** | 11.9M | 7.2M | 6.6M |
+| SimpleADT | 2.13 | **15.2M** | 8.0M | 7.8M | 5.8M |
+| SimpleADT | 3 | **15.6M** | 12.1M | 8.1M | 6.9M |
+| Person | 2.13 | **1.6M** | 1.4M | 979.1K | 906.8K |
+| Person | 3 | **1.6M** | 1.4M | 1.1M | 959.5K |
+| Event | 2.13 | **1.3M** | 1.1M | 841.8K | 731.6K |
+| Event | 3 | **1.3M** | 1.1M | 918.8K | 800.3K |
+
+### Decode (bytes/String → domain type)
+
+| Type | Scala | Kindlings + booster | Original + booster | Kindlings (no booster) | Original (no booster) |
+|------|-------|--------------------|--------------------|----------------------|---------------------|
+| SimpleCC | 2.13 | **8.3M** | 7.8M | 6.0M | 6.2M |
+| SimpleCC | 3 | **8.0M** | 6.6M | 6.9M | 5.7M |
+| SimpleADT | 2.13 | **10.6M** | 9.0M | 9.3M | 7.6M |
+| SimpleADT | 3 | **10.4M** | 9.1M | 9.6M | 7.9M |
+| Person | 2.13 | **1.1M** | 1.1M | 925.0K | 883.8K |
+| Person | 3 | **1.2M** | 985.2K | 974.8K | 850.6K |
+| Event | 2.13 | 929.5K | 932.5K | 672.8K | 689.6K |
+| Event | 3 | **931.7K** | 826.3K | 783.3K | 719.1K |
 
 ## Jsoniter Write
 
-| Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
-|------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 41.6M | 41.9M | 60.3M | — | 0.69x |
-| SimpleCC | 3 | 43.8M | 43.6M | 63.4M | — | 0.69x |
-| SimpleADT | 2.13 | 55.1M | 54.2M | 68.1M | — | 0.81x |
-| SimpleADT | 3 | 54.5M | 54.2M | 70.0M | — | 0.78x |
-| Person | 2.13 | 3.7M | 3.8M | 4.6M | — | 0.83x |
-| Person | 3 | 3.9M | 3.9M | 5.3M | — | 0.74x |
-| Event | 2.13 | 3.4M | 3.3M | 4.4M | — | 0.77x |
-| Event | 3 | 3.4M | 3.5M | 4.8M | — | 0.73x |
+| Type | Scala | Kindlings semi | Kindlings auto | Original semi | vs original |
+|------|-------|---------------|---------------|--------------|------------|
+| SimpleCC | 2.13 | 60.1M | 60.0M | 60.1M | **~tied** |
+| SimpleCC | 3 | 62.8M | 63.4M | 63.5M | **~tied** |
+| SimpleADT | 2.13 | 61.8M | 61.3M | 68.3M | 0.90x |
+| SimpleADT | 3 | 63.6M | 64.8M | 71.5M | 0.91x |
+| Person | 2.13 | 4.3M | 4.4M | 4.7M | 0.94x |
+| Person | 3 | 4.7M | 4.6M | 5.2M | 0.90x |
+| Event | 2.13 | 4.1M | 4.2M | 4.4M | 0.95x |
+| Event | 3 | 4.2M | 4.2M | 4.4M | 0.95x |
 
 ## Jsoniter Read
 
-| Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
-|------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 16.1M | 16.7M | 34.9M | — | 0.48x |
-| SimpleCC | 3 | 16.9M | 17.0M | 34.8M | — | 0.49x |
-| SimpleADT | 2.13 | 28.7M | 29.0M | — | — |  |
-| SimpleADT | 3 | 29.0M | 29.2M | — | — |  |
-| Person | 2.13 | 2.4M | 2.4M | 3.6M | — | 0.67x |
-| Person | 3 | 2.2M | 2.2M | 3.6M | — | 0.61x |
-| Event | 2.13 | 2.1M | 2.1M | — | — |  |
-| Event | 3 | 2.1M | 2.0M | — | — |  |
+| Type | Scala | Kindlings semi | Kindlings auto | Original semi | vs original |
+|------|-------|---------------|---------------|--------------|------------|
+| SimpleCC | 2.13 | 36.2M | 36.2M | 34.9M | **1.04x faster** |
+| SimpleCC | 3 | 36.1M | 35.9M | 34.9M | **1.03x faster** |
+| SimpleADT | 2.13 | 16.8M | 17.4M | — |  |
+| SimpleADT | 3 | 15.3M | 15.0M | — |  |
+| Person | 2.13 | 2.8M | 2.7M | 3.7M | 0.76x |
+| Person | 3 | 2.7M | 2.7M | 3.7M | 0.73x |
+| Event | 2.13 | 2.2M | 2.2M | — |  |
+| Event | 3 | 2.1M | 2.1M | — |  |
 
 ## Cats Show
 
-| Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
-|------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | — | 38.5M | 7.5M | 7.5M | **5.1x faster** |
-| SimpleCC | 3 | — | 26.3M | 19.4M | 19.3M | **1.4x faster** |
-| SimpleADT | 2.13 | — | 155.9M | 16.5M | 9.7M | **9.5x faster** |
-| SimpleADT | 3 | — | 64.9M | 49.6M | 51.6M | **1.3x faster** |
-| Person | 2.13 | — | 2.0M | — | 833.6K | **2.4x faster** |
-| Person | 3 | — | 1.7M | — | 1.4M | **1.2x faster** |
-| Event | 2.13 | — | 1.8M | 607.4K | 603.6K | **3.0x faster** |
-| Event | 3 | — | 1.5M | 1.2M | 1.2M | **1.2x faster** |
+| Type | Scala | Kindlings | Original semi | Original auto | vs best original |
+|------|-------|-----------|--------------|--------------|-----------------|
+| SimpleCC | 2.13 | 39.0M | 7.3M | 7.5M | **5.2x faster** |
+| SimpleCC | 3 | 26.8M | 19.6M | 19.7M | **1.4x faster** |
+| SimpleADT | 2.13 | 87.9M | 16.8M | 11.1M | **5.2x faster** |
+| SimpleADT | 3 | 79.8M | 46.1M | 52.5M | **1.5x faster** |
+| Person | 2.13 | 2.0M | — | 829.7K | **2.4x faster** |
+| Person | 3 | 1.6M | — | 1.4M | **1.1x faster** |
+| Event | 2.13 | 1.8M | 643.8K | 576.5K | **2.8x faster** |
+| Event | 3 | 1.5M | 1.2M | 1.2M | **1.3x faster** |
 
 ## Cats Eq
 
-| Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
-|------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC (eq) | 2.13 | — | 101.9M | 45.6M | 45.9M | **2.2x faster** |
-| SimpleCC (eq) | 3 | — | 98.5M | 89.1M | 89.6M | **1.1x faster** |
-| SimpleCC (neq) | 2.13 | — | 529.5M | — | — |  |
-| SimpleCC (neq) | 3 | — | 542.0M | — | — |  |
+| Type | Scala | Kindlings | Original semi | Original auto | vs best original |
+|------|-------|-----------|--------------|--------------|-----------------|
+| SimpleCC (eq) | 2.13 | 101.4M | 45.9M | 46.0M | **2.2x faster** |
+| SimpleCC (eq) | 3 | 102.2M | 91.8M | 112.1M | 0.91x |
+| SimpleCC (neq) | 2.13 | 577.1M | — | — |  |
+| SimpleCC (neq) | 3 | 541.4M | — | — |  |
 
 ## Cats Hash
 
-| Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
-|------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | — | 834.3M | 27.8M | 27.9M | **29.9x faster** |
-| SimpleCC | 3 | — | 809.6M | 101.4M | 99.2M | **8.0x faster** |
+| Type | Scala | Kindlings | Original semi | Original auto | vs best original |
+|------|-------|-----------|--------------|--------------|-----------------|
+| SimpleCC | 2.13 | 836.9M | 27.9M | 27.7M | **30.0x faster** |
+| SimpleCC | 3 | 839.1M | 107.4M | 122.5M | **6.9x faster** |
 
 ## Cats Order
 
-| Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
-|------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | — | 434.3M | 433.0M | 470.3M | 0.92x |
-| SimpleCC | 3 | — | 420.1M | 299.4M | 349.6M | **1.2x faster** |
+| Type | Scala | Kindlings | Original semi | Original auto | vs best original |
+|------|-------|-----------|--------------|--------------|-----------------|
+| SimpleCC | 2.13 | 390.4M | 391.6M | 468.0M | 0.83x |
+| SimpleCC | 3 | 388.1M | 301.2M | 358.8M | **1.1x faster** |
 
 ## Avro (kindlings vs avro4s)
 
 | Type | Scala | Kindlings | Original semi | Original auto | vs best original |
 |------|-------|-----------|--------------|--------------|-----------------|
-| Encode SimpleCC | 2.13 | 7.6M | — | 45.6M | 0.17x |
-| Encode SimpleCC | 3 | 7.4M | 48.1M | 48.1M | 0.15x |
-| Encode Person | 2.13 | 1.1M | — | 4.7M | 0.23x |
-| Encode Person | 3 | 1.1M | 5.6M | 5.6M | 0.19x |
-| Encode Event | 2.13 | 728.6K | — | — |  |
-| Encode Event | 3 | 703.0K | — | — |  |
-| Decode SimpleCC | 2.13 | 14.9M | — | 17.6M | 0.84x |
-| Decode SimpleCC | 3 | 16.4M | 25.3M | 42.4M | 0.39x |
-| Decode Person | 2.13 | 1.2M | — | 3.6M | 0.34x |
-| Decode Person | 3 | 1.3M | 3.0M | 4.2M | 0.31x |
-| Decode Event | 2.13 | 581.2K | — | — |  |
-| Decode Event | 3 | 597.1K | — | — |  |
+| Encode SimpleCC | 2.13 | 329.4M | — | — |  |
+| Encode SimpleCC | 3 | 315.5M | 48.6M | 59.0M | **5.3x faster** |
+| Encode Person | 2.13 | 1.6M | — | 4.7M | 0.34x |
+| Encode Person | 3 | 1.7M | 5.7M | 5.7M | 0.30x |
+| Encode Event | 2.13 | 483.4K | — | — |  |
+| Encode Event | 3 | 473.9K | — | — |  |
+| Decode SimpleCC | 2.13 | 58.1M | — | 16.3M | **3.6x faster** |
+| Decode SimpleCC | 3 | 53.8M | 23.3M | 42.3M | **1.3x faster** |
+| Decode Person | 2.13 | 1.9M | — | 3.6M | 0.53x |
+| Decode Person | 3 | 1.9M | 3.2M | 4.2M | 0.45x |
+| Decode Event | 2.13 | 780.3K | — | — |  |
+| Decode Event | 3 | 794.5K | — | — |  |
 
-## Pureconfig (kindlings vs pureconfig-generic)
+## PureConfig (kindlings vs pureconfig-generic)
 
 | Type | Scala | Kindlings | Original semi | vs original |
 |------|-------|-----------|--------------|------------|
-| Write SimpleCC | 2.13 | 1.5M | 1.2M | **1.2x faster** |
-| Write SimpleCC | 3 | 1.7M | 1.6M | **1.1x faster** |
-| Write Person | 2.13 | 253.0K | 200.3K | **1.3x faster** |
-| Write Person | 3 | 276.5K | 233.7K | **1.2x faster** |
-| Read SimpleCC | 2.13 | 834.6K | 1.4M | 0.60x |
-| Read SimpleCC | 3 | 912.9K | 1.4M | 0.67x |
-| Read Person | 2.13 | 132.6K | 209.7K | 0.63x |
-| Read Person | 3 | 146.4K | 198.6K | 0.74x |
+| Write SimpleCC | 2.13 | 11.0M | 1.2M | **9.2x faster** |
+| Write SimpleCC | 3 | 10.9M | 1.6M | **6.8x faster** |
+| Write Person | 2.13 | 1.2M | 200.4K | **6.0x faster** |
+| Write Person | 3 | 1.2M | 247.3K | **4.9x faster** |
+| Read SimpleCC | 2.13 | 16.8M | 1.4M | **12.0x faster** |
+| Read SimpleCC | 3 | 11.9M | 1.4M | **8.5x faster** |
+| Read Person | 2.13 | 999.8K | 208.9K | **4.8x faster** |
+| Read Person | 3 | 924.8K | 200.8K | **4.6x faster** |
 
 ## Kindlings-only modules (no original comparison)
 
 | Module | Type | Scala 2.13 | Scala 3 |
 |--------|------|-----------|---------|
-| FastShowPretty | SimpleCC | 6.7M | 7.1M |
-| FastShowPretty | SimpleADT | 7.3M | 8.9M |
-| FastShowPretty | Person | 926.0K | 1.0M |
-| FastShowPretty | Event | 716.0K | 783.5K |
-| UbjsonWrite | SimpleCC | 11.1M | 11.2M |
-| UbjsonWrite | SimpleADT | 13.3M | 13.4M |
-| UbjsonWrite | Person | 1.3M | 1.4M |
-| UbjsonWrite | Event | 1.2M | 1.2M |
-| UbjsonRead | SimpleCC | 10.8M | 10.3M |
+| FastShowPretty | SimpleCC | 6.9M | 7.1M |
+| FastShowPretty | SimpleADT | 7.7M | 8.5M |
+| FastShowPretty | Person | 932.6K | 1.0M |
+| FastShowPretty | Event | 719.6K | 783.7K |
+| UbjsonWrite | SimpleCC | 11.2M | 11.3M |
+| UbjsonWrite | SimpleADT | 13.4M | 13.4M |
+| UbjsonWrite | Person | 1.4M | 1.4M |
+| UbjsonWrite | Event | 1.3M | 1.2M |
+| UbjsonRead | SimpleCC | 11.2M | 11.3M |
 | UbjsonRead | SimpleADT | 13.7M | 13.6M |
 | UbjsonRead | Person | 1.4M | 1.4M |
-| UbjsonRead | Event | 1.2M | 1.3M |
-| SconfigWrite | SimpleCC | 5.6M | 5.3M |
-| SconfigWrite | SimpleADT | 4.6M | 4.6M |
-| SconfigWrite | Person | 774.9K | 856.1K |
-| SconfigWrite | Event | 408.3K | 409.4K |
-| SconfigRead | SimpleCC | 4.3M | 4.4M |
-| SconfigRead | SimpleADT | 8.7M | 8.8M |
-| SconfigRead | Person | 648.5K | 688.1K |
-| SconfigRead | Event | 454.8K | 444.0K |
+| UbjsonRead | Event | 1.3M | 1.2M |
+| SconfigWrite | SimpleCC | 11.3M | 10.8M |
+| SconfigWrite | SimpleADT | 5.6M | 5.4M |
+| SconfigWrite | Person | 1.2M | 1.2M |
+| SconfigWrite | Event | 617.2K | 647.4K |
+| SconfigRead | SimpleCC | 68.5M | 60.5M |
+| SconfigRead | SimpleADT | 25.2M | 24.5M |
+| SconfigRead | Person | 4.1M | 4.2M |
+| SconfigRead | Event | 2.8M | 2.7M |
 | YamlEncode | SimpleCC | 1.4M | 1.4M |
-| YamlEncode | SimpleADT | 2.2M | 2.2M |
-| YamlEncode | Person | 153.2K | 158.5K |
-| YamlEncode | Event | 136.2K | 143.3K |
-| YamlDecode | SimpleCC | 8.3M | 6.4M |
-| YamlDecode | SimpleADT | 101.2M | 63.1M |
-| YamlDecode | Person | 738.2K | 661.1K |
-| YamlDecode | Event | 647.4K | 595.3K |
-| XmlEncode | SimpleCC | 46.0M | 44.5M |
-| XmlEncode | Address | 39.8M | 40.6M |
-| XmlDecode | SimpleCC | 4.8M | 5.0M |
-| XmlDecode | Address | 3.4M | 3.4M |
-| ScalacheckArbitrary | SimpleCC | 740.5K | 756.7K |
+| YamlEncode | SimpleADT | 2.2M | 2.3M |
+| YamlEncode | Person | 146.8K | 160.0K |
+| YamlEncode | Event | 135.3K | 145.8K |
+| YamlDecode | SimpleCC | 8.9M | 6.9M |
+| YamlDecode | SimpleADT | 102.3M | 53.3M |
+| YamlDecode | Person | 724.7K | 683.3K |
+| YamlDecode | Event | 653.4K | 610.7K |
+| XmlEncode | SimpleCC | 46.1M | 45.8M |
+| XmlEncode | Address | 38.6M | 38.0M |
+| XmlDecode | SimpleCC | 4.8M | 5.2M |
+| XmlDecode | Address | 3.2M | 3.4M |
+| ScalacheckArbitrary | SimpleCC | 775.4K | 773.6K |
 | ScalacheckArbitrary | SimpleADT | 2.1M | 2.1M |
-| ScalacheckArbitrary | Person | 4.9K | 4.4K |
-| ScalacheckShrink | SimpleCC | 6.4M | 5.8M |
-| ScalacheckShrink | Person | 5.7M | 5.4M |
+| ScalacheckArbitrary | Person | 4.0K | 4.3K |
+| ScalacheckShrink | SimpleCC | 6.5M | 5.8M |
+| ScalacheckShrink | Person | 5.8M | 5.5M |
 
 ## Key takeaways
 
-1. **Circe**: Kindlings is **1.4-2.3x faster** for encoding and decoding across all types and both Scala versions
-2. **Cats**: Kindlings dominates — **5x** for Show, **30x** for Hash on 2.13; **1.3-8x** on Scala 3
-3. **Jsoniter-scala**: Original is **1.3-2x faster** — its hand-tuned byte-level codegen is hard to beat
-4. **Avro**: avro4s is **5-6x faster** for encoding (specialized Avro-native code)
-5. **Pureconfig**: Mixed — kindlings writes ~1.2x faster, original reads ~1.5x faster
-6. **Tapir Schema**: Tied (~3.7B ops/s) — just a field access at runtime
-7. **Kindlings auto = semi-auto** everywhere, confirming recursive derivation produces identical runtime instances
-8. **Original auto = semi-auto** on Scala 3 (both Mirror-based), but on 2.13 semi-auto can be faster (cached intermediates avoid shapeless overhead)
+1. **Circe**: Kindlings is **1.4-2.6x faster** for encoding and decoding across all types and both Scala versions
+2. **Circe + booster**: Kindlings + jsoniter-scala-circe is the fastest Circe pipeline — up to **2.7x faster** than original Circe without booster
+3. **Cats**: Kindlings dominates — **5x** for Show, **30x** for Hash on 2.13; **1.4-6.9x** on Scala 3
+4. **Jsoniter**: Kindlings is now **at parity** for SimpleCC writes (60M vs 60M), and reads are **slightly faster** for SimpleCC (36M vs 35M). Complex types still ~0.76-0.95x
+5. **PureConfig**: Kindlings is **4.6-12x faster** across all operations — massive improvement
+6. **Avro**: Mixed — Kindlings SimpleCC encode is **5.3x faster** (Scala 3), SimpleCC decode is **3.6x faster** (2.13); Person encode still slower
+7. **Tapir Schema**: Tied (~3.8B ops/s) — just a field access at runtime
+8. **Kindlings auto = semi-auto** everywhere, confirming sanely-automatic derivation produces identical runtime instances

--- a/docs/user-guide/avro-derivation.md
+++ b/docs/user-guide/avro-derivation.md
@@ -1,0 +1,350 @@
+# Avro Derivation
+
+**JVM-only** module. Drop-in replacement for [avro4s](https://github.com/sksamuel/avro4s) -- derives `AvroSchemaFor`, `AvroEncoder`, and `AvroDecoder` for case classes, sealed traits, Scala 3 enums, Java enums, and more.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-avro-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Avro derivation is **JVM-only** (no `%%%`). The Apache Avro runtime is pulled in transitively.
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-avro-derivation:{{ kindlings_version() }}
+    ```
+
+## Quick start
+
+??? example "Schema generation, encoding, and decoding"
+
+    ```scala
+    import hearth.kindlings.avroderivation.*
+
+    case class Person(name: String, age: Int)
+
+    // Schema generation
+    val schema = AvroSchemaFor.schemaOf[Person]
+    println(schema)
+    // {"type":"record","name":"Person","fields":[{"name":"name","type":"string"},{"name":"age","type":"int"}]}
+
+    // Semi-automatic derivation
+    val encoder: AvroEncoder[Person] = AvroEncoder.derive[Person]
+    val decoder: AvroDecoder[Person] = AvroDecoder.derive[Person]
+
+    // Encode to Avro GenericRecord
+    val record: Any = encoder.encode(Person("Alice", 30))
+
+    // Decode back
+    val person: Person = decoder.decode(record)
+    println(person)
+    // Person(Alice,30)
+
+    // Binary serialization via AvroIO
+    val bytes: Array[Byte] = AvroIO.toBinary(Person("Bob", 25))(encoder)
+    val decoded: Person = AvroIO.fromBinary[Person](bytes)(decoder)
+    println(decoded)
+    // Person(Bob,25)
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `AvroSchemaFor.derive[A]` | `AvroSchemaFor[A]` | Semi-automatic schema derivation |
+| `AvroSchemaFor.schemaOf[A]` | `Schema` | Inline schema generation (no instance allocation) |
+| `AvroSchemaFor.derived[A]` | `AvroSchemaFor[A]` | Sanely-automatic (given/implicit) |
+| `AvroEncoder.derive[A]` | `AvroEncoder[A]` | Semi-automatic encoder |
+| `AvroEncoder.encode[A](value)` | `Any` | Inline encoding (no instance allocation) |
+| `AvroEncoder.derived[A]` | `AvroEncoder[A]` | Sanely-automatic (given/implicit) |
+| `AvroDecoder.derive[A]` | `AvroDecoder[A]` | Semi-automatic decoder |
+| `AvroDecoder.decode[A](value)` | `A` | Inline decoding (no instance allocation) |
+| `AvroDecoder.derived[A]` | `AvroDecoder[A]` | Sanely-automatic (given/implicit) |
+
+All methods take an implicit/using `AvroConfig` parameter (defaults to `AvroConfig.default`).
+
+### Serialization helpers
+
+`AvroIO` provides convenience methods for binary and JSON Avro serialization:
+
+| Method | Description |
+|--------|-------------|
+| `AvroIO.toBinary[A](value)` | Encode to Avro binary format |
+| `AvroIO.fromBinary[A](bytes)` | Decode from Avro binary format |
+| `AvroIO.toJson[A](value)` | Encode to Avro JSON format |
+| `AvroIO.fromJson[A](json)` | Decode from Avro JSON format |
+
+### Type hierarchy
+
+`AvroEncoder[A]` extends `AvroSchemaFor[A]` and `AvroDecoder[A]` extends `AvroSchemaFor[A]`, so every encoder and decoder also provides the Avro schema.
+
+## Configuration
+
+All derivation methods accept an implicit `AvroConfig`:
+
+```scala
+import hearth.kindlings.avroderivation.*
+
+implicit val config: AvroConfig = AvroConfig.default
+  .withNamespace("com.example")
+  .withSnakeCaseFieldNames
+  .withDecimalConfig(precision = 10, scale = 2)
+```
+
+| Builder method | Description |
+|---------------|-------------|
+| `withNamespace(ns)` | Set the Avro namespace for generated schemas |
+| `withTransformFieldNames(f)` | Custom field name transform |
+| `withSnakeCaseFieldNames` | `fieldName` -> `field_name` |
+| `withKebabCaseFieldNames` | `fieldName` -> `field-name` |
+| `withPascalCaseFieldNames` | `fieldName` -> `FieldName` |
+| `withTransformConstructorNames(f)` | Custom constructor name transform for sealed traits |
+| `withDecimalConfig(precision, scale)` | Global `BigDecimal` precision and scale |
+
+## Annotations
+
+All annotations are in the `hearth.kindlings.avroderivation.annotations` package.
+
+```scala
+import hearth.kindlings.avroderivation.annotations.*
+```
+
+### Field and type naming
+
+| Annotation | Target | Description |
+|-----------|--------|-------------|
+| `@avroName("name")` | Type | Override the Avro schema name for a type (highest priority) |
+| `@fieldName("name")` | Field | Override the Avro field name |
+| `@avroErasedName` | Type | Disable generic type parameter encoding in schema name |
+| `@avroFqnParamNames` | Type | Use fully qualified names for type parameters in schema name |
+
+### Documentation and metadata
+
+| Annotation | Target | Description |
+|-----------|--------|-------------|
+| `@avroDoc("text")` | Type, Field | Add documentation to the schema |
+| `@avroNamespace("ns")` | Type | Set the Avro namespace for a specific type |
+| `@avroProp("key", "value")` | Type, Field | Add custom Avro properties (stackable) |
+| `@avroAlias("alias")` | Type, Field | Add schema aliases for evolution (stackable) |
+
+### Schema control
+
+| Annotation | Target | Description |
+|-----------|--------|-------------|
+| `@avroFixed(size)` | Field (`Array[Byte]`) | Use fixed-size bytes instead of variable |
+| `@avroError` | Type | Mark record as an Avro error type |
+| `@avroScalePrecision(precision, scale)` | Field (`BigDecimal`) | Per-field decimal precision and scale |
+| `@avroSortPriority(n)` | Type | Control ordering of subtypes in UNION/ENUM schemas |
+
+### Default values
+
+| Annotation | Target | Description |
+|-----------|--------|-------------|
+| `@avroDefault("json")` | Field | Default value as a JSON string literal |
+| `@avroNoDefault` | Field | Suppress default value even if field has a Scala default |
+| `@avroEnumDefault("value")` | Type (sealed trait) | Set the default value for an enum schema |
+| `@transientField` | Field | Exclude field from schema entirely (must have a default value) |
+
+## Usage examples
+
+??? example "Annotated types with documentation and namespaces"
+
+    ```scala
+    import hearth.kindlings.avroderivation.*
+    import hearth.kindlings.avroderivation.annotations.*
+
+    @avroDoc("A person record")
+    @avroNamespace("com.example.models")
+    case class Person(
+      @avroDoc("The person's full name") name: String,
+      @avroDoc("Age in years") age: Int
+    )
+
+    val schema = AvroSchemaFor.schemaOf[Person]
+    println(schema)
+    // {"type":"record","name":"Person","namespace":"com.example.models",
+    //  "doc":"A person record","fields":[
+    //    {"name":"name","type":"string","doc":"The person's full name"},
+    //    {"name":"age","type":"int","doc":"Age in years"}]}
+    ```
+
+??? example "Sealed trait with sort priority"
+
+    ```scala
+    import hearth.kindlings.avroderivation.*
+    import hearth.kindlings.avroderivation.annotations.*
+
+    sealed trait Shape
+    @avroSortPriority(1)
+    case class Rectangle(width: Double, height: Double) extends Shape
+    @avroSortPriority(2)
+    case class Circle(radius: Double) extends Shape
+
+    // Rectangle appears first in the union schema thanks to @avroSortPriority
+    val schema = AvroSchemaFor.schemaOf[Shape]
+    ```
+
+??? example "Default values and field annotations"
+
+    ```scala
+    import hearth.kindlings.avroderivation.*
+    import hearth.kindlings.avroderivation.annotations.*
+
+    case class Settings(
+      host: String,
+      @avroDefault("8080") port: Int = 8080,
+      @avroDefault("\"info\"") logLevel: String = "info",
+      @transientField cache: Option[String] = None
+    )
+
+    val encoder = AvroEncoder.derive[Settings]
+    val decoder = AvroDecoder.derive[Settings]
+
+    // @transientField excludes `cache` from the Avro schema entirely
+    // @avroDefault sets the Avro schema default value
+    ```
+
+??? example "Custom field names with snake_case config"
+
+    ```scala
+    import hearth.kindlings.avroderivation.*
+
+    implicit val config: AvroConfig = AvroConfig.default
+      .withSnakeCaseFieldNames
+      .withNamespace("com.example")
+
+    case class UserProfile(firstName: String, lastName: String, emailAddress: String)
+
+    val schema = AvroSchemaFor.schemaOf[UserProfile]
+    // Fields become: first_name, last_name, email_address
+    ```
+
+??? example "Recursive data types"
+
+    ```scala
+    import hearth.kindlings.avroderivation.*
+
+    case class TreeNode(value: Int, children: List[TreeNode])
+
+    // Recursive types work out of the box
+    val encoder = AvroEncoder.derive[TreeNode]
+    val decoder = AvroDecoder.derive[TreeNode]
+
+    val tree = TreeNode(1, List(TreeNode(2, Nil), TreeNode(3, List(TreeNode(4, Nil)))))
+    val record = encoder.encode(tree)
+    val decoded = decoder.decode(record)
+    // decoded == tree
+    ```
+
+??? example "Logical types (UUID, Instant, LocalDate, etc.)"
+
+    ```scala
+    import hearth.kindlings.avroderivation.*
+    import java.time.*
+    import java.util.UUID
+
+    case class EventRecord(
+      id: UUID,
+      timestamp: Instant,
+      date: LocalDate,
+      time: LocalTime,
+      localTimestamp: LocalDateTime
+    )
+
+    // Logical types are handled automatically:
+    // - UUID -> string with logicalType "uuid"
+    // - Instant -> long with logicalType "timestamp-millis"
+    // - LocalDate -> int with logicalType "date"
+    // - LocalTime -> int with logicalType "time-millis"
+    // - LocalDateTime -> long with logicalType "local-timestamp-millis"
+    val schema = AvroSchemaFor.schemaOf[EventRecord]
+    ```
+
+??? example "Generic types with name encoding"
+
+    ```scala
+    import hearth.kindlings.avroderivation.*
+    import hearth.kindlings.avroderivation.annotations.*
+
+    case class Audited[T](data: T, createdBy: String)
+    case class User(name: String)
+    case class Order(id: Int)
+
+    // Generic types encode type parameters in the schema name by default:
+    // Audited[User] -> "AuditedUser", Audited[Order] -> "AuditedOrder"
+    val userSchema = AvroSchemaFor.schemaOf[Audited[User]]
+    val orderSchema = AvroSchemaFor.schemaOf[Audited[Order]]
+
+    // Use @avroErasedName to disable parameter encoding
+    @avroErasedName
+    case class Box[A](value: A)
+    // Box[User] and Box[Order] both named "Box"
+
+    // Use @avroFqnParamNames for fully qualified parameter names
+    @avroFqnParamNames
+    case class Wrapper[A, B](a: A, b: B)
+    // Wrapper[mypackage.Foo, mypackage.Bar] -> "Wrapper_mypackage_Foo_mypackage_Bar"
+    ```
+
+## Debugging
+
+Import the debug package to log the derivation process at compile time:
+
+```scala
+import hearth.kindlings.avroderivation.debug.*
+```
+
+This enables `LogDerivation` implicits for `AvroSchemaFor`, `AvroEncoder`, and `AvroDecoder`, printing the derivation steps to the compiler output.
+
+## Comparison with avro4s
+
+### Feature differences
+
+| Feature | avro4s (v4, Scala 2) | avro4s (v5, Scala 3) | Kindlings |
+|---------|---------------------|---------------------|-----------|
+| Same API on Scala 2.13 and 3 | No | No | Yes |
+| Sanely-automatic derivation | No | No | Yes |
+| Inline schema/encode/decode | No | No | Yes |
+| Recursive types | Needs workarounds | Yes | Just works |
+| Named tuples | No | No | Yes |
+| Scala 3 enums | No | Yes | Yes |
+| Java enums | No | Yes | Yes |
+| Opaque types | No | Partial | Yes |
+| Union types (Scala 3) | No | No | Yes |
+| Literal types (Scala 3) | No | No | Yes |
+| `@avroName` type renaming | Yes | Yes | Yes |
+| `@avroScalePrecision` per-field | Yes | Yes | Yes |
+| `@avroFqnParamNames` | No | No | Yes |
+
+### Benchmarks
+
+All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
+
+!!! note
+    Performance is a mixed picture: Kindlings is massively faster for simple types (5.3x encode, 3.6x decode for SimpleCC), while avro4s is still faster for complex nested types (Person). avro4s generates highly specialized Avro-native encoding code tuned for deep record hierarchies; Kindlings prioritizes a unified cross-version API and feature coverage.
+
+#### Encode
+
+| Type | Scala | Kindlings | Original semi | Original auto | vs best original |
+|------|-------|-----------|--------------|--------------|-----------------|
+| SimpleCC | 2.13 | 329.4M | -- | -- |  |
+| SimpleCC | 3 | 315.5M | 48.6M | 59.0M | **5.3x faster** |
+| Person | 2.13 | 1.6M | -- | 4.7M | 0.34x |
+| Person | 3 | 1.7M | 5.7M | 5.7M | 0.30x |
+
+#### Decode
+
+| Type | Scala | Kindlings | Original semi | Original auto | vs best original |
+|------|-------|-----------|--------------|--------------|-----------------|
+| SimpleCC | 2.13 | 58.1M | -- | 16.3M | **3.6x faster** |
+| SimpleCC | 3 | 53.8M | 23.3M | 42.3M | **1.3x faster** |
+| Person | 2.13 | 1.9M | -- | 3.6M | 0.53x |
+| Person | 3 | 1.9M | 3.2M | 4.2M | 0.45x |
+
+Note: Kindlings semi-automatic and automatic derivation produce identical performance -- this is the "sanely-automatic" design.

--- a/docs/user-guide/avro-derivation.md
+++ b/docs/user-guide/avro-derivation.md
@@ -23,7 +23,7 @@
 ??? example "Schema generation, encoding, and decoding"
 
     ```scala
-    import hearth.kindlings.avroderivation.*
+    import hearth.kindlings.avroderivation._
 
     case class Person(name: String, age: Int)
 
@@ -89,7 +89,7 @@ All methods take an implicit/using `AvroConfig` parameter (defaults to `AvroConf
 All derivation methods accept an implicit `AvroConfig`:
 
 ```scala
-import hearth.kindlings.avroderivation.*
+import hearth.kindlings.avroderivation._
 
 implicit val config: AvroConfig = AvroConfig.default
   .withNamespace("com.example")
@@ -112,7 +112,7 @@ implicit val config: AvroConfig = AvroConfig.default
 All annotations are in the `hearth.kindlings.avroderivation.annotations` package.
 
 ```scala
-import hearth.kindlings.avroderivation.annotations.*
+import hearth.kindlings.avroderivation.annotations._
 ```
 
 ### Field and type naming
@@ -156,8 +156,8 @@ import hearth.kindlings.avroderivation.annotations.*
 ??? example "Annotated types with documentation and namespaces"
 
     ```scala
-    import hearth.kindlings.avroderivation.*
-    import hearth.kindlings.avroderivation.annotations.*
+    import hearth.kindlings.avroderivation._
+    import hearth.kindlings.avroderivation.annotations._
 
     @avroDoc("A person record")
     @avroNamespace("com.example.models")
@@ -177,8 +177,8 @@ import hearth.kindlings.avroderivation.annotations.*
 ??? example "Sealed trait with sort priority"
 
     ```scala
-    import hearth.kindlings.avroderivation.*
-    import hearth.kindlings.avroderivation.annotations.*
+    import hearth.kindlings.avroderivation._
+    import hearth.kindlings.avroderivation.annotations._
 
     sealed trait Shape
     @avroSortPriority(1)
@@ -193,8 +193,8 @@ import hearth.kindlings.avroderivation.annotations.*
 ??? example "Default values and field annotations"
 
     ```scala
-    import hearth.kindlings.avroderivation.*
-    import hearth.kindlings.avroderivation.annotations.*
+    import hearth.kindlings.avroderivation._
+    import hearth.kindlings.avroderivation.annotations._
 
     case class Settings(
       host: String,
@@ -213,7 +213,7 @@ import hearth.kindlings.avroderivation.annotations.*
 ??? example "Custom field names with snake_case config"
 
     ```scala
-    import hearth.kindlings.avroderivation.*
+    import hearth.kindlings.avroderivation._
 
     implicit val config: AvroConfig = AvroConfig.default
       .withSnakeCaseFieldNames
@@ -228,7 +228,7 @@ import hearth.kindlings.avroderivation.annotations.*
 ??? example "Recursive data types"
 
     ```scala
-    import hearth.kindlings.avroderivation.*
+    import hearth.kindlings.avroderivation._
 
     case class TreeNode(value: Int, children: List[TreeNode])
 
@@ -245,8 +245,8 @@ import hearth.kindlings.avroderivation.annotations.*
 ??? example "Logical types (UUID, Instant, LocalDate, etc.)"
 
     ```scala
-    import hearth.kindlings.avroderivation.*
-    import java.time.*
+    import hearth.kindlings.avroderivation._
+    import java.time._
     import java.util.UUID
 
     case class EventRecord(
@@ -269,8 +269,8 @@ import hearth.kindlings.avroderivation.annotations.*
 ??? example "Generic types with name encoding"
 
     ```scala
-    import hearth.kindlings.avroderivation.*
-    import hearth.kindlings.avroderivation.annotations.*
+    import hearth.kindlings.avroderivation._
+    import hearth.kindlings.avroderivation.annotations._
 
     case class Audited[T](data: T, createdBy: String)
     case class User(name: String)
@@ -297,7 +297,7 @@ import hearth.kindlings.avroderivation.annotations.*
 Import the debug package to log the derivation process at compile time:
 
 ```scala
-import hearth.kindlings.avroderivation.debug.*
+import hearth.kindlings.avroderivation.debug._
 ```
 
 This enables `LogDerivation` implicits for `AvroSchemaFor`, `AvroEncoder`, and `AvroDecoder`, printing the derivation steps to the compiler output.

--- a/docs/user-guide/cats-derivation.md
+++ b/docs/user-guide/cats-derivation.md
@@ -31,20 +31,22 @@ Drop-in replacement for [kittens](https://github.com/typelevel/kittens) — deri
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
     import hearth.kindlings.catsderivation._
+    import hearth.kindlings.catsderivation.extensions._
     import cats._
     import cats.syntax.all._
 
     case class Person(name: String, age: Int)
 
-    // Sanely-automatic: given/implicit resolved by the compiler
+    implicit val showPerson: Show[Person] = Show.derived[Person]
+    implicit val eqPerson: Eq[Person] = Eq.derived[Person]
+
     println(Person("Alice", 30).show)
     // Person(name = Alice, age = 30)
 
     println(Person("Alice", 30) === Person("Alice", 30))
     // true
 
-    // Semi-automatic
-    val ord: Order[Person] = Order[Person]
+    val ord: Order[Person] = Order.derived[Person]
     println(ord.compare(Person("Alice", 30), Person("Bob", 25)))
     ```
 
@@ -114,6 +116,7 @@ Person("Alice", 30).show  // Show.derived[Person] resolved automatically
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
     import hearth.kindlings.catsderivation._
+    import hearth.kindlings.catsderivation.extensions._
     import cats._
     import cats.syntax.all._
 
@@ -121,13 +124,16 @@ Person("Alice", 30).show  // Show.derived[Person] resolved automatically
     case class Circle(radius: Double) extends Shape
     case class Rectangle(width: Double, height: Double) extends Shape
 
-    println(Show[Shape].show(Circle(5.0)))
+    implicit val showShape: Show[Shape] = Show.derived[Shape]
+    implicit val eqShape: Eq[Shape] = Eq.derived[Shape]
+
+    println(showShape.show(Circle(5.0)))
     // Circle(radius = 5.0)
 
-    println(Circle(3.0) === Circle(3.0))
+    println(eqShape.eqv(Circle(3.0), Circle(3.0)))
     // true
 
-    println(Circle(3.0) === Rectangle(3.0, 4.0))
+    println(eqShape.eqv(Circle(3.0), Rectangle(3.0, 4.0)))
     // false
     ```
 
@@ -138,10 +144,13 @@ Person("Alice", 30).show  // Show.derived[Person] resolved automatically
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
     import hearth.kindlings.catsderivation._
+    import hearth.kindlings.catsderivation.extensions._
     import cats._
     import cats.syntax.all._
 
     case class Box[A](value: A)
+
+    implicit val functorBox: Functor[Box] = Functor.derived[Box]
 
     val box: Box[Int] = Box(42)
     println(Functor[Box].map(box)(_ * 2))
@@ -155,11 +164,13 @@ Person("Alice", 30).show  // Show.derived[Person] resolved automatically
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
     import hearth.kindlings.catsderivation._
-    import cats._
-    import cats.kernel._
+    import hearth.kindlings.catsderivation.extensions._
+    import cats.kernel.{Monoid, Semigroup}
     import cats.syntax.all._
 
     case class Stats(count: Int, total: Double)
+
+    implicit val monoidStats: Monoid[Stats] = Monoid.derived[Stats]
 
     val a = Stats(10, 100.0)
     val b = Stats(5, 50.0)

--- a/docs/user-guide/cats-derivation.md
+++ b/docs/user-guide/cats-derivation.md
@@ -30,9 +30,9 @@ Drop-in replacement for [kittens](https://github.com/typelevel/kittens) — deri
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
-    import hearth.kindlings.catsderivation.*
-    import cats.*
-    import cats.syntax.all.*
+    import hearth.kindlings.catsderivation._
+    import cats._
+    import cats.syntax.all._
 
     case class Person(name: String, age: Int)
 
@@ -101,7 +101,7 @@ val eqPerson: Eq[Person] = Eq.derived[Person]
 val functorBox: Functor[Box] = Functor.derived[Box]
 
 // Sanely-automatic — just use the type class
-import hearth.kindlings.catsderivation.*
+import hearth.kindlings.catsderivation._
 Person("Alice", 30).show  // Show.derived[Person] resolved automatically
 ```
 
@@ -113,9 +113,9 @@ Person("Alice", 30).show  // Show.derived[Person] resolved automatically
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
-    import hearth.kindlings.catsderivation.*
-    import cats.*
-    import cats.syntax.all.*
+    import hearth.kindlings.catsderivation._
+    import cats._
+    import cats.syntax.all._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -137,9 +137,9 @@ Person("Alice", 30).show  // Show.derived[Person] resolved automatically
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
-    import hearth.kindlings.catsderivation.*
-    import cats.*
-    import cats.syntax.all.*
+    import hearth.kindlings.catsderivation._
+    import cats._
+    import cats.syntax.all._
 
     case class Box[A](value: A)
 
@@ -154,10 +154,10 @@ Person("Alice", 30).show  // Show.derived[Person] resolved automatically
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
-    import hearth.kindlings.catsderivation.*
-    import cats.*
-    import cats.kernel.*
-    import cats.syntax.all.*
+    import hearth.kindlings.catsderivation._
+    import cats._
+    import cats.kernel._
+    import cats.syntax.all._
 
     case class Stats(count: Int, total: Double)
 

--- a/docs/user-guide/cats-derivation.md
+++ b/docs/user-guide/cats-derivation.md
@@ -1,0 +1,226 @@
+# Cats Derivation
+
+Drop-in replacement for [kittens](https://github.com/typelevel/kittens) — derives 26 type classes from Cats and Alleycats for case classes, sealed traits, Scala 3 enums, and more.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-cats-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-cats-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
+    ```
+
+## Quick start
+
+??? example "Deriving Show and Eq"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
+
+    import hearth.kindlings.catsderivation.*
+    import cats.*
+    import cats.syntax.all.*
+
+    case class Person(name: String, age: Int)
+
+    // Sanely-automatic: given/implicit resolved by the compiler
+    println(Person("Alice", 30).show)
+    // Person(name = Alice, age = 30)
+
+    println(Person("Alice", 30) === Person("Alice", 30))
+    // true
+
+    // Semi-automatic
+    val ord: Order[Person] = Order[Person]
+    println(ord.compare(Person("Alice", 30), Person("Bob", 25)))
+    ```
+
+## Supported type classes
+
+### Monomorphic (kind `*`)
+
+Derived for case classes and sealed traits.
+
+| Type class | Package |
+|-----------|---------|
+| `Show` | `cats` |
+| `Eq` | `cats.kernel` |
+| `Order` | `cats.kernel` |
+| `PartialOrder` | `cats.kernel` |
+| `Hash` | `cats.kernel` |
+| `Semigroup` | `cats.kernel` |
+| `Monoid` | `cats.kernel` |
+| `CommutativeSemigroup` | `cats.kernel` |
+| `CommutativeMonoid` | `cats.kernel` |
+| `Empty` | `alleycats` |
+
+### Polymorphic (kind `* → *`)
+
+Derived for type constructors (case classes with one type parameter).
+
+| Type class | Package |
+|-----------|---------|
+| `Functor` | `cats` |
+| `Contravariant` | `cats` |
+| `Invariant` | `cats` |
+| `Apply` | `cats` |
+| `Applicative` | `cats` |
+| `Foldable` | `cats` |
+| `Traverse` | `cats` |
+| `Reducible` | `cats` |
+| `NonEmptyTraverse` | `cats` |
+| `SemigroupK` | `cats` |
+| `MonoidK` | `cats` |
+| `NonEmptyAlternative` | `cats` |
+| `Alternative` | `cats` |
+| `Pure` | `alleycats` |
+| `EmptyK` | `alleycats` |
+| `ConsK` | `alleycats` |
+
+## API
+
+Cats derivation works via extension methods on the Cats companion objects themselves. The derivation is triggered by calling `.derived` on the type class companion:
+
+```scala
+// Semi-automatic — call .derived explicitly
+val showPerson: Show[Person] = Show.derived[Person]
+val eqPerson: Eq[Person] = Eq.derived[Person]
+val functorBox: Functor[Box] = Functor.derived[Box]
+
+// Sanely-automatic — just use the type class
+import hearth.kindlings.catsderivation.*
+Person("Alice", 30).show  // Show.derived[Person] resolved automatically
+```
+
+## Usage examples
+
+??? example "Sealed trait derivation"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
+
+    import hearth.kindlings.catsderivation.*
+    import cats.*
+    import cats.syntax.all.*
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    println(Show[Shape].show(Circle(5.0)))
+    // Circle(radius = 5.0)
+
+    println(Circle(3.0) === Circle(3.0))
+    // true
+
+    println(Circle(3.0) === Rectangle(3.0, 4.0))
+    // false
+    ```
+
+??? example "Functor derivation"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
+
+    import hearth.kindlings.catsderivation.*
+    import cats.*
+    import cats.syntax.all.*
+
+    case class Box[A](value: A)
+
+    val box: Box[Int] = Box(42)
+    println(Functor[Box].map(box)(_ * 2))
+    // Box(84)
+    ```
+
+??? example "Semigroup and Monoid derivation"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
+
+    import hearth.kindlings.catsderivation.*
+    import cats.*
+    import cats.kernel.*
+    import cats.syntax.all.*
+
+    case class Stats(count: Int, total: Double)
+
+    val a = Stats(10, 100.0)
+    val b = Stats(5, 50.0)
+    println(a |+| b)
+    // Stats(15,150.0)
+
+    println(Monoid[Stats].empty)
+    // Stats(0,0.0)
+    ```
+
+## Comparison with kittens
+
+### Feature differences
+
+| Feature | kittens (Scala 2) | kittens (Scala 3) | Kindlings |
+|---------|-------------------|-------------------|-----------|
+| Show | Yes | Yes | Yes |
+| Eq, Order, Hash | Yes | Yes | Yes |
+| Semigroup, Monoid | Yes | Yes | Yes |
+| CommutativeSemigroup, CommutativeMonoid | Yes | Yes | Yes |
+| Empty | Yes | Yes | Yes |
+| Functor | Yes | Yes | Yes |
+| Contravariant | No | Yes | Yes |
+| Invariant | No | Yes | Yes |
+| Foldable, Traverse | No | Yes | Yes |
+| Reducible, NonEmptyTraverse | No | Yes | Yes |
+| Apply, Applicative | No | Yes | Yes |
+| SemigroupK, MonoidK | No | Yes | Yes |
+| NonEmptyAlternative, Alternative | No | No | Yes |
+| Pure, EmptyK | No | Yes | Yes |
+| ConsK | No | No | Yes |
+| Same API on Scala 2.13 and 3 | No | No | Yes |
+| Sanely-automatic derivation | No | No | Yes |
+
+### Benchmarks
+
+All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
+
+#### Show
+
+| Type | Scala | Kindlings | Original semi | Original auto | vs best original |
+|------|-------|-----------|--------------|--------------|-----------------|
+| SimpleCC | 2.13 | 39.0M | 7.3M | 7.5M | **5.2x faster** |
+| SimpleCC | 3 | 26.8M | 19.6M | 19.7M | **1.4x faster** |
+| SimpleADT | 2.13 | 87.9M | 16.8M | 11.1M | **5.2x faster** |
+| SimpleADT | 3 | 79.8M | 46.1M | 52.5M | **1.5x faster** |
+| Person | 2.13 | 2.0M | — | 829.7K | **2.4x faster** |
+| Person | 3 | 1.6M | — | 1.4M | **1.1x faster** |
+| Event | 2.13 | 1.8M | 643.8K | 576.5K | **2.8x faster** |
+| Event | 3 | 1.5M | 1.2M | 1.2M | **1.3x faster** |
+
+#### Eq
+
+| Type | Scala | Kindlings | Original semi | Original auto | vs best original |
+|------|-------|-----------|--------------|--------------|-----------------|
+| SimpleCC (eq) | 2.13 | 101.4M | 45.9M | 46.0M | **2.2x faster** |
+| SimpleCC (eq) | 3 | 102.2M | 91.8M | 112.1M | 0.91x |
+
+#### Hash
+
+| Type | Scala | Kindlings | Original auto | vs original |
+|------|-------|-----------|--------------|------------|
+| SimpleCC | 2.13 | 836.9M | 27.7M | **30.0x faster** |
+| SimpleCC | 3 | 839.1M | 122.5M | **6.9x faster** |

--- a/docs/user-guide/cats-integration.md
+++ b/docs/user-guide/cats-integration.md
@@ -1,0 +1,177 @@
+# Cats Collections Integration
+
+Automatic support for [Cats](https://typelevel.org/cats/) data types in all Kindlings derivation modules. Add the dependency and `NonEmptyList`, `NonEmptyMap`, `Chain`, `Validated`, `Const`, and other Cats types are handled transparently in Circe, Jsoniter, Avro, YAML, and every other module — no imports, no configuration.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-cats-integration" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-cats-integration" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-cats-integration:{{ kindlings_version() }}
+    ```
+
+!!! note
+    You also need `cats-core` as a dependency:
+
+    ```scala
+    libraryDependencies += "org.typelevel" %%% "cats-core" % "{{ libraries.cats }}"
+    ```
+
+## How it works
+
+The integration registers `IsCollection`, `IsMap`, `IsEither`, and `IsValueType` providers for Cats data types. These providers are discovered at compile time via SPI (Service Provider Interface) — the macro extension system picks them up automatically when the jar is on the classpath.
+
+Each provider teaches all derivation modules how to encode and decode the corresponding Cats type:
+
+- **Collections** (`NonEmptyList`, `NonEmptyVector`, `NonEmptyChain`, `Chain`): encoded as JSON arrays, decoded with non-emptiness validation where applicable.
+- **Maps** (`NonEmptyMap`): encoded as JSON objects (like `Map`), decoded with non-emptiness validation.
+- **Sets** (`NonEmptySet`): encoded as JSON arrays, decoded with non-emptiness and ordering validation.
+- **Either-like** (`Validated`): encoded/decoded like `Either`, mapping `Invalid` to left and `Valid` to right.
+- **Value types** (`Const`): unwrapped to the underlying value.
+
+## Supported types
+
+### Collection types
+
+| Type | Encoded as | Decoding validation |
+|------|-----------|-------------------|
+| `NonEmptyList[A]` | Array | Must be non-empty |
+| `NonEmptyVector[A]` | Array | Must be non-empty |
+| `NonEmptyChain[A]` | Array | Must be non-empty |
+| `Chain[A]` | Array | None |
+
+### Map types
+
+| Type | Encoded as | Decoding validation |
+|------|-----------|-------------------|
+| `NonEmptyMap[K, V]` | Object / array of pairs | Must be non-empty; requires `Order[K]` |
+
+### Set types
+
+| Type | Encoded as | Decoding validation |
+|------|-----------|-------------------|
+| `NonEmptySet[A]` | Array | Must be non-empty; requires `Order[A]` |
+
+### Either-like types
+
+| Type | Encoded as | Decoding validation |
+|------|-----------|-------------------|
+| `Validated[E, A]` | Like `Either[E, A]` | None (both `Invalid` and `Valid` are valid) |
+| `ValidatedNel[E, A]` | Like `Either[NonEmptyList[E], A]` | Handled automatically (it is `Validated[NonEmptyList[E], A]`) |
+
+### Value types
+
+| Type | Behavior |
+|------|---------|
+| `Const[A, B]` | Unwrapped to `A` (phantom `B` is ignored) |
+
+## Examples
+
+??? example "Non-empty collections with Circe"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-cats-integration:{{ kindlings_version() }}
+    //> using dep org.typelevel::cats-core:{{ libraries.cats }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.*
+    import io.circe.syntax.*
+    import cats.data.NonEmptyList
+
+    case class Team(
+      name: String,
+      members: NonEmptyList[String]
+    )
+
+    val team = Team("Backend", NonEmptyList.of("Alice", "Bob", "Carol"))
+    println(team.asJson.noSpaces)
+    // {"name":"Backend","members":["Alice","Bob","Carol"]}
+
+    // Decoding an empty array fails — NonEmptyList requires at least one element
+    val bad = io.circe.parser.decode[Team]("""{"name":"Empty","members":[]}""")
+    println(bad)
+    // Left(DecodingFailure(...))
+
+    val good = io.circe.parser.decode[Team]("""{"name":"Solo","members":["Dave"]}""")
+    println(good)
+    // Right(Team(Solo,NonEmptyList(Dave)))
+    ```
+
+??? example "NonEmptyMap with Jsoniter"
+
+    ```scala
+    //> using scala {{ scala.3 }}
+    //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-cats-integration:{{ kindlings_version() }}
+    //> using dep org.typelevel::cats-core:{{ libraries.cats }}
+
+    import hearth.kindlings.jsoniterderivation.*
+    import com.github.plokhotnyuk.jsoniter_scala.core.*
+    import cats.data.NonEmptyMap
+    import cats.implicits.*
+
+    case class Config(
+      settings: NonEmptyMap[String, String]
+    )
+
+    val codec = KindlingsJsonValueCodec.derive[Config]
+    val config = Config(NonEmptyMap.of("host" -> "localhost", "port" -> "8080"))
+    println(writeToString(config)(codec))
+    // {"settings":{"host":"localhost","port":"8080"}}
+    ```
+
+??? example "Validated fields"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-cats-integration:{{ kindlings_version() }}
+    //> using dep org.typelevel::cats-core:{{ libraries.cats }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.*
+    import io.circe.syntax.*
+    import cats.data.Validated
+
+    case class FormResult(
+      username: Validated[String, String]
+    )
+
+    val valid = FormResult(Validated.valid("alice"))
+    println(valid.asJson.noSpaces)
+    // {"username":{"Right":"alice"}}
+
+    val invalid = FormResult(Validated.invalid("username is required"))
+    println(invalid.asJson.noSpaces)
+    // {"username":{"Left":"username is required"}}
+    ```
+
+## Combining with other integrations
+
+The Cats integration composes naturally with other integration modules. For example, you can have `NonEmptyList[Int Refined Positive]` fields — the Cats integration handles `NonEmptyList` and the Refined integration handles `Refined`:
+
+```scala
+libraryDependencies ++= Seq(
+  "com.kubuszok" %%% "kindlings-circe-derivation"    % "{{ kindlings_version() }}",
+  "com.kubuszok" %%% "kindlings-cats-integration"    % "{{ kindlings_version() }}",
+  "com.kubuszok" %%% "kindlings-refined-integration" % "{{ kindlings_version() }}"
+)
+```
+
+Each integration module independently registers its providers, and the derivation engine composes them automatically.

--- a/docs/user-guide/cats-integration.md
+++ b/docs/user-guide/cats-integration.md
@@ -90,7 +90,6 @@ Each provider teaches all derivation modules how to encode and decode the corres
 
     import hearth.kindlings.circederivation._
     import io.circe._
-    import io.circe.syntax._
     import cats.data.NonEmptyList
 
     case class Team(
@@ -99,15 +98,17 @@ Each provider teaches all derivation modules how to encode and decode the corres
     )
 
     val team = Team("Backend", NonEmptyList.of("Alice", "Bob", "Carol"))
-    println(team.asJson.noSpaces)
+    println(KindlingsEncoder.encode(team).noSpaces)
     // {"name":"Backend","members":["Alice","Bob","Carol"]}
 
     // Decoding an empty array fails — NonEmptyList requires at least one element
-    val bad = io.circe.parser.decode[Team]("""{"name":"Empty","members":[]}""")
+    val bad = io.circe.parser.parse("""{"name":"Empty","members":[]}""")
+      .flatMap(KindlingsDecoder.decode[Team](_))
     println(bad)
     // Left(DecodingFailure(...))
 
-    val good = io.circe.parser.decode[Team]("""{"name":"Solo","members":["Dave"]}""")
+    val good = io.circe.parser.parse("""{"name":"Solo","members":["Dave"]}""")
+      .flatMap(KindlingsDecoder.decode[Team](_))
     println(good)
     // Right(Team(Solo,NonEmptyList(Dave)))
     ```
@@ -146,7 +147,6 @@ Each provider teaches all derivation modules how to encode and decode the corres
 
     import hearth.kindlings.circederivation._
     import io.circe._
-    import io.circe.syntax._
     import cats.data.Validated
 
     case class FormResult(
@@ -154,11 +154,11 @@ Each provider teaches all derivation modules how to encode and decode the corres
     )
 
     val valid = FormResult(Validated.valid("alice"))
-    println(valid.asJson.noSpaces)
+    println(KindlingsEncoder.encode(valid).noSpaces)
     // {"username":{"Right":"alice"}}
 
     val invalid = FormResult(Validated.invalid("username is required"))
-    println(invalid.asJson.noSpaces)
+    println(KindlingsEncoder.encode(invalid).noSpaces)
     // {"username":{"Left":"username is required"}}
     ```
 

--- a/docs/user-guide/cats-integration.md
+++ b/docs/user-guide/cats-integration.md
@@ -88,9 +88,9 @@ Each provider teaches all derivation modules how to encode and decode the corres
     //> using dep org.typelevel::cats-core:{{ libraries.cats }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.*
-    import io.circe.syntax.*
+    import hearth.kindlings.circederivation._
+    import io.circe._
+    import io.circe.syntax._
     import cats.data.NonEmptyList
 
     case class Team(
@@ -120,10 +120,10 @@ Each provider teaches all derivation modules how to encode and decode the corres
     //> using dep com.kubuszok::kindlings-cats-integration:{{ kindlings_version() }}
     //> using dep org.typelevel::cats-core:{{ libraries.cats }}
 
-    import hearth.kindlings.jsoniterderivation.*
-    import com.github.plokhotnyuk.jsoniter_scala.core.*
+    import hearth.kindlings.jsoniterderivation._
+    import com.github.plokhotnyuk.jsoniter_scala.core._
     import cats.data.NonEmptyMap
-    import cats.implicits.*
+    import cats.implicits._
 
     case class Config(
       settings: NonEmptyMap[String, String]
@@ -144,9 +144,9 @@ Each provider teaches all derivation modules how to encode and decode the corres
     //> using dep org.typelevel::cats-core:{{ libraries.cats }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.*
-    import io.circe.syntax.*
+    import hearth.kindlings.circederivation._
+    import io.circe._
+    import io.circe.syntax._
     import cats.data.Validated
 
     case class FormResult(

--- a/docs/user-guide/circe-derivation.md
+++ b/docs/user-guide/circe-derivation.md
@@ -1,0 +1,269 @@
+# Circe Derivation
+
+Drop-in replacement for `circe-generic` / `circe-generic-extras` — derives `Encoder`, `Encoder.AsObject`, and `Decoder` for case classes, sealed traits, Scala 3 enums, Java enums, and more.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-circe-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-circe-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    ```
+
+## Quick start
+
+??? example "Encoding and decoding a case class"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.*
+    import io.circe.syntax.*
+
+    case class Person(name: String, age: Int)
+
+    // Sanely-automatic: KindlingsEncoder.derived[Person] is resolved by the compiler
+    val json: Json = Person("Alice", 30).asJson
+    println(json.noSpaces)
+    // {"name":"Alice","age":30}
+
+    // Semi-automatic:
+    val decoder: Decoder[Person] = KindlingsDecoder.derive[Person]
+    println(io.circe.parser.decode[Person]("""{"name":"Bob","age":25}""")(decoder))
+    // Right(Person(Bob,25))
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `KindlingsEncoder.derive[A]` | `Encoder[A]` | Semi-automatic encoder |
+| `KindlingsEncoder.deriveAsObject[A]` | `Encoder.AsObject[A]` | Semi-automatic object encoder |
+| `KindlingsEncoder.encode[A](value)` | `Json` | Inline encoding (no instance allocation) |
+| `KindlingsEncoder.derived[A]` | `KindlingsEncoder[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsDecoder.derive[A]` | `Decoder[A]` | Semi-automatic decoder |
+| `KindlingsDecoder.decode[A](json)` | `Either[DecodingFailure, A]` | Inline decoding |
+| `KindlingsDecoder.derived[A]` | `KindlingsDecoder[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsCodecAsObject.derive[A]` | `Codec.AsObject[A]` | Semi-automatic codec |
+| `KindlingsCodecAsObject.derived[A]` | `KindlingsCodecAsObject[A]` | Sanely-automatic codec |
+
+All methods take an implicit/using `Configuration` parameter (defaults to `Configuration.default`).
+
+### Type hierarchy
+
+`KindlingsEncoder[A]` extends `Encoder[A]` and `KindlingsDecoder[A]` extends `Decoder[A]`, so derived instances work anywhere the original Circe types are expected.
+
+## Configuration
+
+All derivation methods accept an implicit `Configuration`:
+
+```scala
+import hearth.kindlings.circederivation.*
+
+implicit val config: Configuration = Configuration.default
+  .withSnakeCaseMemberNames
+  .withDiscriminator("type")
+  .withDefaults
+```
+
+| Builder method | Description |
+|---------------|-------------|
+| `withSnakeCaseMemberNames` | `fieldName` → `field_name` |
+| `withKebabCaseMemberNames` | `fieldName` → `field-name` |
+| `withPascalCaseMemberNames` | `fieldName` → `FieldName` |
+| `withScreamingSnakeCaseMemberNames` | `fieldName` → `FIELD_NAME` |
+| `withTransformMemberNames(f)` | Custom field name transform |
+| `withSnakeCaseConstructorNames` | `MyType` → `my_type` in discriminator |
+| `withKebabCaseConstructorNames` | `MyType` → `my-type` in discriminator |
+| `withPascalCaseConstructorNames` | `MyType` → `MyType` in discriminator |
+| `withScreamingSnakeCaseConstructorNames` | `MyType` → `MY_TYPE` in discriminator |
+| `withTransformConstructorNames(f)` | Custom constructor name transform |
+| `withDefaults` | Use case class default values for missing fields |
+| `withoutDefaults` | Require all fields (default) |
+| `withDiscriminator(field)` | ADT discriminator field name |
+| `withoutDiscriminator` | No discriminator (default — wrapping object) |
+| `withStrictDecoding` | Fail on unexpected JSON fields |
+| `withoutStrictDecoding` | Ignore unexpected fields (default) |
+| `withEnumAsStrings` | Encode Scala 3 / Java enums as strings |
+
+## Annotations
+
+| Annotation | Description |
+|-----------|-------------|
+| `@fieldName("json_name")` | Override JSON field name for a case class field |
+| `@transientField` | Exclude a field from encoding/decoding (must have a default value) |
+
+```scala
+import hearth.kindlings.circederivation.annotations.*
+
+case class User(
+  @fieldName("user_name") name: String,
+  @transientField internalId: Long = 0L
+)
+```
+
+## Usage examples
+
+??? example "Sealed trait with discriminator"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.*
+    import io.circe.syntax.*
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val config: Configuration = Configuration.default
+      .withDiscriminator("type")
+      .withSnakeCaseConstructorNames
+
+    val shape: Shape = Circle(5.0)
+    println(shape.asJson.noSpaces)
+    // {"radius":5.0,"type":"circle"}
+
+    val decoded = io.circe.parser.decode[Shape]("""{"width":3,"height":4,"type":"rectangle"}""")
+    println(decoded)
+    // Right(Rectangle(3.0,4.0))
+    ```
+
+??? example "Recursive data types"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.syntax.*
+
+    case class Tree(value: String, children: List[Tree])
+
+    val tree = Tree("root", List(
+      Tree("left", Nil),
+      Tree("right", List(Tree("leaf", Nil)))
+    ))
+    println(tree.asJson.noSpaces)
+    // {"value":"root","children":[{"value":"left","children":[]},{"value":"right","children":[{"value":"leaf","children":[]}]}]}
+    ```
+
+??? example "Case class with defaults"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.*
+
+    implicit val config: Configuration = Configuration.default.withDefaults
+
+    case class Settings(host: String, port: Int = 8080, debug: Boolean = false)
+
+    val decoder = KindlingsDecoder.derive[Settings]
+    println(io.circe.parser.decode[Settings]("""{"host":"localhost"}""")(decoder))
+    // Right(Settings(localhost,8080,false))
+    ```
+
+## Comparison with circe-generic
+
+### Feature differences
+
+| Feature | circe-generic | Kindlings |
+|---------|--------------|-----------|
+| Same API on Scala 2.13 and 3 | No (different modules, different APIs) | Yes |
+| Automatic derivation without overhead | No (re-derives at every use site) | Yes (sanely-automatic) |
+| Inline encoding/decoding | No | Yes (`encode[A]`, `decode[A]`) |
+| Recursive types | Needs `Lazy` / workarounds | Just works |
+| Named tuples | No | Yes |
+| Opaque types | No | Yes |
+| Scala 3 enums | Partial | Yes |
+| Java enums | No | Yes |
+| `@ConfiguredJsonCodec` annotation | Yes | No (use `Configuration` directly) |
+
+### Benchmarks
+
+All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
+
+#### Encode
+
+| Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
+|------|-------|---------------|---------------|--------------|--------------|-----------------|
+| SimpleCC | 2.13 | 30.6M | 31.1M | 19.3M | 19.0M | **1.6x faster** |
+| SimpleCC | 3 | 30.9M | 30.7M | 21.8M | 21.3M | **1.4x faster** |
+| SimpleADT | 2.13 | 27.2M | 27.9M | 14.1M | 14.0M | **2.0x faster** |
+| SimpleADT | 3 | 26.1M | 26.5M | 25.7M | 25.4M | ~tied |
+| Person | 2.13 | 4.5M | 4.5M | 3.0M | 3.0M | **1.5x faster** |
+| Person | 3 | 4.3M | 4.3M | 3.1M | 3.1M | **1.4x faster** |
+| Event | 2.13 | 3.4M | 3.4M | 2.3M | 2.4M | **1.4x faster** |
+| Event | 3 | 3.3M | 3.4M | 2.3M | 2.3M | **1.4x faster** |
+
+#### Decode
+
+| Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
+|------|-------|---------------|---------------|--------------|--------------|-----------------|
+| SimpleCC | 2.13 | 51.0M | 50.9M | 42.4M | 42.8M | **1.2x faster** |
+| SimpleCC | 3 | 52.7M | 48.9M | 20.0M | 20.6M | **2.6x faster** |
+| SimpleADT | 2.13 | 61.3M | 61.0M | 25.0M | 26.5M | **2.3x faster** |
+| SimpleADT | 3 | 47.7M | 46.5M | 29.2M | 27.8M | **1.6x faster** |
+| Person | 2.13 | 4.2M | 4.2M | 3.5M | 3.5M | **1.2x faster** |
+| Person | 3 | 4.2M | 4.2M | 2.7M | 2.7M | **1.6x faster** |
+| Event | 2.13 | 2.8M | 2.8M | 2.7M | 2.7M | ~tied |
+| Event | 3 | 2.9M | 2.9M | 2.1M | 2.1M | **1.4x faster** |
+
+### End-to-end with jsoniter-scala-circe booster
+
+[jsoniter-scala-circe](https://github.com/plokhotnyuk/jsoniter-scala/tree/master/jsoniter-scala-circe) is a Circe booster that replaces the default parser/printer with jsoniter-scala's faster implementation. The table below benchmarks the full pipeline (domain type to bytes/String).
+
+The booster is an optional add-on — Kindlings works with standard Circe parsing out of the box. When combined with the booster, Kindlings + jsoniter-scala-circe is the fastest way to use Circe.
+
+#### Encode (domain type to bytes/String)
+
+| Type | Scala | Kindlings + booster | Original + booster | Kindlings (no booster) | Original (no booster) |
+|------|-------|--------------------|--------------------|----------------------|---------------------|
+| SimpleCC | 2.13 | **14.8M** | 10.2M | 6.8M | 5.5M |
+| SimpleCC | 3 | **15.3M** | 11.9M | 7.2M | 6.6M |
+| SimpleADT | 2.13 | **15.2M** | 8.0M | 7.8M | 5.8M |
+| SimpleADT | 3 | **15.6M** | 12.1M | 8.1M | 6.9M |
+| Person | 2.13 | **1.6M** | 1.4M | 979.1K | 906.8K |
+| Person | 3 | **1.6M** | 1.4M | 1.1M | 959.5K |
+| Event | 2.13 | **1.3M** | 1.1M | 841.8K | 731.6K |
+| Event | 3 | **1.3M** | 1.1M | 918.8K | 800.3K |
+
+#### Decode (bytes/String to domain type)
+
+| Type | Scala | Kindlings + booster | Original + booster | Kindlings (no booster) | Original (no booster) |
+|------|-------|--------------------|--------------------|----------------------|---------------------|
+| SimpleCC | 2.13 | **8.3M** | 7.8M | 6.0M | 6.2M |
+| SimpleCC | 3 | **8.0M** | 6.6M | 6.9M | 5.7M |
+| SimpleADT | 2.13 | **10.6M** | 9.0M | 9.3M | 7.6M |
+| SimpleADT | 3 | **10.4M** | 9.1M | 9.6M | 7.9M |
+| Person | 2.13 | **1.1M** | 1.1M | 925.0K | 883.8K |
+| Person | 3 | **1.2M** | 985.2K | 974.8K | 850.6K |
+| Event | 2.13 | 929.5K | 932.5K | 672.8K | 689.6K |
+| Event | 3 | **931.7K** | 826.3K | 783.3K | 719.1K |
+
+Note: Kindlings semi-automatic and automatic derivation produce identical performance — this is the "sanely-automatic" design.

--- a/docs/user-guide/circe-derivation.md
+++ b/docs/user-guide/circe-derivation.md
@@ -33,19 +33,17 @@ Drop-in replacement for `circe-generic` / `circe-generic-extras` — derives `En
 
     import hearth.kindlings.circederivation._
     import io.circe._
-    import io.circe.syntax._
 
     case class Person(name: String, age: Int)
 
-    // Semi-automatic derivation
-    implicit val encoder: Encoder[Person] = KindlingsEncoder.derive[Person]
-    implicit val decoder: Decoder[Person] = KindlingsDecoder.derive[Person]
-
-    val json: Json = Person("Alice", 30).asJson
+    // Inline encoding — no implicit needed
+    val json: Json = KindlingsEncoder.encode(Person("Alice", 30))
     println(json.noSpaces)
     // {"name":"Alice","age":30}
 
-    println(io.circe.parser.decode[Person]("""{"name":"Bob","age":25}"""))
+    // Inline decoding
+    val parsed = io.circe.parser.parse("""{"name":"Bob","age":25}""")
+    println(parsed.flatMap(KindlingsDecoder.decode[Person](_)))
     // Right(Person(Bob,25))
     ```
 
@@ -131,7 +129,6 @@ case class User(
 
     import hearth.kindlings.circederivation._
     import io.circe._
-    import io.circe.syntax._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -141,14 +138,12 @@ case class User(
       .withDiscriminator("type")
       .withSnakeCaseConstructorNames
 
-    implicit val encoder: Encoder[Shape] = KindlingsEncoder.derive[Shape]
-    implicit val decoder: Decoder[Shape] = KindlingsDecoder.derive[Shape]
-
     val shape: Shape = Circle(5.0)
-    println(shape.asJson.noSpaces)
+    println(KindlingsEncoder.encode(shape).noSpaces)
     // {"radius":5.0,"type":"circle"}
 
-    val decoded = io.circe.parser.decode[Shape]("""{"width":3,"height":4,"type":"rectangle"}""")
+    val decoded = io.circe.parser.parse("""{"width":3,"height":4,"type":"rectangle"}""")
+      .flatMap(KindlingsDecoder.decode[Shape](_))
     println(decoded)
     // Right(Rectangle(3.0,4.0))
     ```
@@ -158,21 +153,17 @@ case class User(
     ```scala
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
-    //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
     import hearth.kindlings.circederivation._
     import io.circe._
-    import io.circe.syntax._
 
     case class Tree(value: String, children: List[Tree])
-
-    implicit val encoder: Encoder[Tree] = KindlingsEncoder.derive[Tree]
 
     val tree = Tree("root", List(
       Tree("left", Nil),
       Tree("right", List(Tree("leaf", Nil)))
     ))
-    println(tree.asJson.noSpaces)
+    println(KindlingsEncoder.encode(tree).noSpaces)
     // {"value":"root","children":[{"value":"left","children":[]},{"value":"right","children":[{"value":"leaf","children":[]}]}]}
     ```
 
@@ -190,8 +181,8 @@ case class User(
 
     case class Settings(host: String, port: Int = 8080, debug: Boolean = false)
 
-    val decoder = KindlingsDecoder.derive[Settings]
-    println(io.circe.parser.decode[Settings]("""{"host":"localhost"}""")(decoder))
+    val parsed = io.circe.parser.parse("""{"host":"localhost"}""")
+    println(parsed.flatMap(KindlingsDecoder.decode[Settings](_)))
     // Right(Settings(localhost,8080,false))
     ```
 

--- a/docs/user-guide/circe-derivation.md
+++ b/docs/user-guide/circe-derivation.md
@@ -31,20 +31,21 @@ Drop-in replacement for `circe-generic` / `circe-generic-extras` — derives `En
     //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.*
-    import io.circe.syntax.*
+    import hearth.kindlings.circederivation._
+    import io.circe._
+    import io.circe.syntax._
 
     case class Person(name: String, age: Int)
 
-    // Sanely-automatic: KindlingsEncoder.derived[Person] is resolved by the compiler
+    // Semi-automatic derivation
+    implicit val encoder: Encoder[Person] = KindlingsEncoder.derive[Person]
+    implicit val decoder: Decoder[Person] = KindlingsDecoder.derive[Person]
+
     val json: Json = Person("Alice", 30).asJson
     println(json.noSpaces)
     // {"name":"Alice","age":30}
 
-    // Semi-automatic:
-    val decoder: Decoder[Person] = KindlingsDecoder.derive[Person]
-    println(io.circe.parser.decode[Person]("""{"name":"Bob","age":25}""")(decoder))
+    println(io.circe.parser.decode[Person]("""{"name":"Bob","age":25}"""))
     // Right(Person(Bob,25))
     ```
 
@@ -75,7 +76,7 @@ All methods take an implicit/using `Configuration` parameter (defaults to `Confi
 All derivation methods accept an implicit `Configuration`:
 
 ```scala
-import hearth.kindlings.circederivation.*
+import hearth.kindlings.circederivation._
 
 implicit val config: Configuration = Configuration.default
   .withSnakeCaseMemberNames
@@ -111,7 +112,7 @@ implicit val config: Configuration = Configuration.default
 | `@transientField` | Exclude a field from encoding/decoding (must have a default value) |
 
 ```scala
-import hearth.kindlings.circederivation.annotations.*
+import hearth.kindlings.circederivation.annotations._
 
 case class User(
   @fieldName("user_name") name: String,
@@ -128,9 +129,9 @@ case class User(
     //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.*
-    import io.circe.syntax.*
+    import hearth.kindlings.circederivation._
+    import io.circe._
+    import io.circe.syntax._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -139,6 +140,9 @@ case class User(
     implicit val config: Configuration = Configuration.default
       .withDiscriminator("type")
       .withSnakeCaseConstructorNames
+
+    implicit val encoder: Encoder[Shape] = KindlingsEncoder.derive[Shape]
+    implicit val decoder: Decoder[Shape] = KindlingsDecoder.derive[Shape]
 
     val shape: Shape = Circle(5.0)
     println(shape.asJson.noSpaces)
@@ -156,10 +160,13 @@ case class User(
     //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.syntax.*
+    import hearth.kindlings.circederivation._
+    import io.circe._
+    import io.circe.syntax._
 
     case class Tree(value: String, children: List[Tree])
+
+    implicit val encoder: Encoder[Tree] = KindlingsEncoder.derive[Tree]
 
     val tree = Tree("root", List(
       Tree("left", Nil),
@@ -176,8 +183,8 @@ case class User(
     //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.*
+    import hearth.kindlings.circederivation._
+    import io.circe._
 
     implicit val config: Configuration = Configuration.default.withDefaults
 

--- a/docs/user-guide/debugging.md
+++ b/docs/user-guide/debugging.md
@@ -1,0 +1,109 @@
+# Debugging & Diagnostics
+
+Kindlings provides three diagnostic tools: debug logging (to see what the macro generates), flame graphs (to profile compilation performance), and configurable timeouts (to prevent runaway derivation).
+
+## Debug logging
+
+Every module supports two ways to enable debug logging: a scoped import (per-file) or a scalac option (project-wide).
+
+### Via import (per-file)
+
+Add the module's debug import to the file where you want to inspect derivation:
+
+```scala
+// Circe
+import hearth.kindlings.circederivation.debug._
+
+// Jsoniter
+import hearth.kindlings.jsoniterderivation.debug._
+
+// Cats
+import hearth.kindlings.catsderivation.debug._
+```
+
+The import places a `LogDerivation` implicit in scope. When the macro sees it, it prints the generated code, matched rules, and summoned implicits to the compiler output.
+
+### Via scalac option (project-wide)
+
+Add a `-Xmacro-settings` option to your build — no code changes needed:
+
+```scala
+// build.sbt
+scalacOptions += "-Xmacro-settings:circeDerivation.logDerivation=true"
+```
+
+### Module reference
+
+| Module | Debug import | Scalac setting |
+|--------|-------------|----------------|
+| circe-derivation | `hearth.kindlings.circederivation.debug._` | `circeDerivation.logDerivation=true` |
+| jsoniter-derivation | `hearth.kindlings.jsoniterderivation.debug._` | `jsoniterDerivation.logDerivation=true` |
+| cats-derivation | `hearth.kindlings.catsderivation.debug._` | `catsDerivation.logDerivation=true` |
+| avro-derivation | `hearth.kindlings.avroderivation.debug._` | `avroDerivation.logDerivation=true` |
+| pureconfig-derivation | `hearth.kindlings.pureconfigderivation.debug._` | `pureconfigDerivation.logDerivation=true` |
+| tapir-schema-derivation | `hearth.kindlings.tapirschemaderivation.debug._` | `tapirSchemaDerivation.logDerivation=true` |
+| yaml-derivation | `hearth.kindlings.yamlderivation.debug._` | `yamlDerivation.logDerivation=true` |
+| scalacheck-derivation | `hearth.kindlings.scalacheckderivation.debug._` | `scalacheckDerivation.logDerivation=true` |
+| sconfig-derivation | `hearth.kindlings.sconfigderivation.debug._` | `sconfigDerivation.logDerivation=true` |
+| ubjson-derivation | `hearth.kindlings.ubjsonderivation.debug._` | `ubjsonDerivation.logDerivation=true` |
+| xml-derivation | `hearth.kindlings.xmlderivation.debug._` | `xmlDerivation.logDerivation=true` |
+| fast-show-pretty | `hearth.kindlings.fastshowpretty.debug._` | `fastShowPretty.logDerivation=true` |
+
+## Flame graph generation
+
+Profile how long each derivation step takes using Hearth's built-in flame graph support. Add these scalac options:
+
+```scala
+// build.sbt
+scalacOptions ++= Seq(
+  "-Xmacro-settings:hearth.mioBenchmarkScopes=true",
+  "-Xmacro-settings:hearth.mioBenchmarkFlameGraphDir=/tmp/kindlings-flamegraphs"
+)
+```
+
+This generates `.speedscope.json` files in the specified directory — one per macro expansion. Open them at [speedscope.app](https://www.speedscope.app/) to visualize where compilation time is spent.
+
+!!! tip
+    This is most useful when a specific type takes noticeably long to derive. Focus on the hot paths: rule evaluation (type comparisons), implicit search, and expression tree construction.
+
+## Derivation timeout
+
+All modules enforce a configurable timeout to prevent runaway macro expansions. Default: **5 seconds**. If a derivation takes longer, compilation fails with a clear error — preventing silent long waits.
+
+Override per module via `-Xmacro-settings` when a specific type hierarchy legitimately needs more time:
+
+```scala
+// build.sbt
+scalacOptions ++= Seq(
+  "-Xmacro-settings:circeDerivation.timeout=30s",
+  "-Xmacro-settings:jsoniterDerivation.timeout=1m"
+)
+```
+
+Supported formats:
+
+| Format | Example | Meaning |
+|--------|---------|---------|
+| Plain integer | `300` | 300 seconds |
+| Seconds | `300s` or `300seconds` | 300 seconds |
+| Milliseconds | `5000ms` or `5000milliseconds` | 5 seconds |
+| Minutes | `5m` or `5minutes` | 5 minutes |
+
+Invalid values emit a compiler warning and fall back to the 120-second default.
+
+### Settings namespace per module
+
+| Module | Settings namespace |
+|--------|-------------------|
+| circe-derivation | `circeDerivation` |
+| jsoniter-derivation | `jsoniterDerivation` |
+| cats-derivation | `catsDerivation` |
+| avro-derivation | `avroDerivation` |
+| pureconfig-derivation | `pureconfigDerivation` |
+| tapir-schema-derivation | `tapirSchemaDerivation` |
+| yaml-derivation | `yamlDerivation` |
+| scalacheck-derivation | `scalacheckDerivation` |
+| sconfig-derivation | `sconfigDerivation` |
+| ubjson-derivation | `ubjsonDerivation` |
+| xml-derivation | `xmlDerivation` |
+| fast-show-pretty | `fastShowPretty` |

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -1,0 +1,81 @@
+# FAQ
+
+## Why not contribute these improvements to Circe, Jsoniter Scala, etc.?
+
+**Different foundations require different codebases.** Kindlings' derivation is built on [Hearth](https://github.com/kubuszok/hearth), a macro toolkit that provides high-level, cross-platform abstractions over Scala 2 and Scala 3 metaprogramming. Existing libraries use their own macro infrastructure (or Shapeless/Mirrors). Replacing the internals of a library with a completely different macro foundation is not a patch — it's a rewrite of the derivation layer.
+
+**Independence allows faster iteration.** Kindlings can support new type categories (named tuples, opaque types, Java enums), experiment with better error messages, and optimize compilation speed without being blocked by the release cycle or design philosophy of upstream libraries.
+
+**Maintaining cross-version compatibility is a design constraint.** Most libraries have separate Scala 2 and Scala 3 implementations with different capabilities. Kindlings shares a single derivation logic across both versions.
+
+## What does "sanely-automatic" mean?
+
+Sanely-automatic derivation means three things:
+
+1. **Semi-automatic is recursive.** When you call `KindlingsEncoder.derive[Person]`, it derives instances for `Person` and all its nested types (`Address`, `List[Address]`, etc.) in a single macro expansion — no need to declare instances for each type manually.
+
+2. **Automatic has no overhead over semi-automatic.** For a single derivation site, automatic and semi-automatic produce identical generated code — same compilation cost, same runtime performance. The generated code is as fast as what you'd write by hand.
+
+3. **Errors are informative and actionable.** When derivation fails, you get a clear message telling you which type is missing an instance and where in the type hierarchy the problem is — not a cryptic `diverging implicit expansion`.
+
+If the same type is auto-derived at multiple call sites, each site derives independently. This is still cheaper than Shapeless/Mirrors-based automatic derivation, but if you want to guarantee a type is derived exactly once, use semi-automatic (`KindlingsEncoder.derive[A]`) and assign it to an `implicit val` / `given`.
+
+## Can I use both Kindlings and the original library's derivation?
+
+Yes. Kindlings type classes extend their parent library's types (`KindlingsEncoder[A] extends Encoder[A]`, `KindlingsDecoder[A] extends Decoder[A]`, etc.). You can mix manually written instances with derived ones.
+
+If both Kindlings' and the original library's automatic derivation are in scope, you may get ambiguous implicits. In that case, use semi-automatic derivation (`KindlingsEncoder.derive[A]`) to be explicit.
+
+## How do I migrate from circe-generic?
+
+1. Replace the dependency: `circe-generic` / `circe-generic-extras` with `kindlings-circe-derivation`
+2. Replace imports: `io.circe.generic.auto._` or `io.circe.generic.semiauto._` with `hearth.kindlings.circederivation.*`
+3. Replace `deriveEncoder[A]` / `deriveDecoder[A]` with `KindlingsEncoder.derive[A]` / `KindlingsDecoder.derive[A]`
+4. If using `@ConfiguredJsonCodec` or circe `Configuration`, switch to Kindlings' `Configuration` class (same builder API)
+
+## How do I migrate from kittens?
+
+1. Replace the dependency: `kittens` with `kindlings-cats-derivation`
+2. Replace imports: `cats.derived._` or `cats.derived.auto.*` with `hearth.kindlings.catsderivation.*`
+3. For Scala 3 `derives` syntax: replace `derives cats.Show` with `derives cats.Show` (Kindlings provides the `derived` method as an extension, so `derives` just works)
+4. For semi-automatic: replace `cats.derived.semiauto.show[A]` with `cats.Show.derived[A]`
+
+## How do I migrate from jsoniter-scala macros?
+
+1. Replace the dependency: `jsoniter-scala-macros` with `kindlings-jsoniter-derivation`
+2. Replace `JsonCodecMaker.make[A]` with `KindlingsJsonValueCodec.derive[A]`
+3. Replace `CodecMakerConfig` with `JsoniterConfig` (similar builder API)
+
+## Which modules are JVM-only?
+
+- `kindlings-avro-derivation` — depends on `org.apache.avro:avro` (JVM-only)
+- `kindlings-pureconfig-derivation` — depends on `com.typesafe:config` (JVM-only)
+
+All other modules are cross-compiled for JVM, Scala.js, and Scala Native.
+
+## Which module is Scala 3-only?
+
+- `kindlings-iron-integration` — Iron is a Scala 3-only library (opaque types)
+
+All other modules support both Scala 2.13 and Scala 3.
+
+## Do I need to import anything for Refined / Iron support?
+
+No. Add the integration dependency to your build and derivation handles refined/iron types automatically:
+
+```scala
+// build.sbt
+libraryDependencies += "com.kubuszok" %% "kindlings-refined-integration" % "{{ kindlings_version() }}"
+// or for Iron (Scala 3 only):
+libraryDependencies += "com.kubuszok" %% "kindlings-iron-integration" % "{{ kindlings_version() }}"
+```
+
+The macro extension system discovers the integration at compile time. No imports, no configuration.
+
+## Where are Cats collection types like NonEmptyList supported?
+
+Add the `kindlings-cats-integration` dependency. It provides `IsCollection` and `IsMap` providers for `NonEmptyList`, `NonEmptyVector`, `NonEmptyChain`, `Chain`, `NonEmptyMap`, and `NonEmptySet`. These are then automatically available to all derivation modules (Circe, Jsoniter, Avro, etc.).
+
+```scala
+libraryDependencies += "com.kubuszok" %% "kindlings-cats-integration" % "{{ kindlings_version() }}"
+```

--- a/docs/user-guide/faq.md
+++ b/docs/user-guide/faq.md
@@ -29,14 +29,14 @@ If both Kindlings' and the original library's automatic derivation are in scope,
 ## How do I migrate from circe-generic?
 
 1. Replace the dependency: `circe-generic` / `circe-generic-extras` with `kindlings-circe-derivation`
-2. Replace imports: `io.circe.generic.auto._` or `io.circe.generic.semiauto._` with `hearth.kindlings.circederivation.*`
+2. Replace imports: `io.circe.generic.auto._` or `io.circe.generic.semiauto._` with `hearth.kindlings.circederivation._`
 3. Replace `deriveEncoder[A]` / `deriveDecoder[A]` with `KindlingsEncoder.derive[A]` / `KindlingsDecoder.derive[A]`
 4. If using `@ConfiguredJsonCodec` or circe `Configuration`, switch to Kindlings' `Configuration` class (same builder API)
 
 ## How do I migrate from kittens?
 
 1. Replace the dependency: `kittens` with `kindlings-cats-derivation`
-2. Replace imports: `cats.derived._` or `cats.derived.auto.*` with `hearth.kindlings.catsderivation.*`
+2. Replace imports: `cats.derived._` or `cats.derived.auto.*` with `hearth.kindlings.catsderivation._`
 3. For Scala 3 `derives` syntax: replace `derives cats.Show` with `derives cats.Show` (Kindlings provides the `derived` method as an extension, so `derives` just works)
 4. For semi-automatic: replace `cats.derived.semiauto.show[A]` with `cats.Show.derived[A]`
 

--- a/docs/user-guide/fast-show-pretty.md
+++ b/docs/user-guide/fast-show-pretty.md
@@ -1,0 +1,276 @@
+# FastShowPretty
+
+Original module -- derives `FastShowPretty` instances for pretty-printing case classes, sealed traits, Scala 3 enums, and more with configurable indentation. Outputs Scala-literal-style text with named fields, nested indentation, and proper escaping.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-fast-show-pretty" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-fast-show-pretty" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+    ```
+
+## Quick start
+
+??? example "Pretty-printing a nested case class"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty.*
+
+    case class Address(street: String, city: String)
+    case class Person(name: String, age: Int, address: Address)
+
+    val person = Person("Alice", 30, Address("123 Main St", "New York"))
+    println(FastShowPretty.render(person, RenderConfig.Default))
+    // Person(
+    //   name = "Alice",
+    //   age = 30,
+    //   address = Address(
+    //     street = "123 Main St",
+    //     city = "New York"
+    //   )
+    // )
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `FastShowPretty.render[A](value, config)` | `String` | Inline render (no instance allocation) |
+| `FastShowPretty.derived[A]` | `FastShowPretty[A]` | Sanely-automatic (given/implicit) |
+
+`FastShowPretty.render` is the primary entry point -- it derives and renders in a single call with no intermediate instance. The `derived` method is available for cases where you need to pass an instance around.
+
+### Type class interface
+
+`FastShowPretty[A]` provides one method:
+
+| Member | Signature | Description |
+|--------|-----------|-------------|
+| `render` | `(sb: StringBuilder, config: RenderConfig, level: Int)(value: A): StringBuilder` | Render a value into a `StringBuilder` at the given indentation level |
+
+## Configuration
+
+`RenderConfig` controls indentation. Unlike the builder pattern used by other modules, `RenderConfig` is a simple case class with predefined constants:
+
+```scala
+import hearth.kindlings.fastshowpretty.*
+
+// Use a predefined config
+val output = FastShowPretty.render(myValue, RenderConfig.Default)
+
+// Or construct a custom one
+val custom = RenderConfig(indentString = "...", startLevel = 0)
+val output2 = FastShowPretty.render(myValue, custom)
+```
+
+### Predefined configs
+
+| Config | Indent string | Description |
+|--------|--------------|-------------|
+| `RenderConfig.Default` | 2 spaces | Standard pretty-printing |
+| `RenderConfig.Compact` | empty string | No indentation (all fields on separate lines but not indented) |
+| `RenderConfig.Tabs` | tab character | Tab-based indentation |
+| `RenderConfig.FourSpaces` | 4 spaces | Wider indentation |
+
+### Config fields
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `indentString` | `String` | `"  "` (2 spaces) | String prepended per indentation level |
+| `startLevel` | `Int` | `0` | Initial indentation level |
+
+## Usage examples
+
+??? example "Different indentation styles"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty.*
+
+    case class Point(x: Int, y: Int)
+
+    val p = Point(10, 20)
+
+    // 2-space indent (default)
+    println(FastShowPretty.render(p, RenderConfig.Default))
+    // Point(
+    //   x = 10,
+    //   y = 20
+    // )
+
+    // Tab indent
+    println(FastShowPretty.render(p, RenderConfig.Tabs))
+    // Point(
+    // 	x = 10,
+    // 	y = 20
+    // )
+
+    // 4-space indent
+    println(FastShowPretty.render(p, RenderConfig.FourSpaces))
+    // Point(
+    //     x = 10,
+    //     y = 20
+    // )
+
+    // Compact (no indent)
+    println(FastShowPretty.render(p, RenderConfig.Compact))
+    // Point(
+    // x = 10,
+    // y = 20
+    // )
+    ```
+
+??? example "Collections and maps"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty.*
+
+    case class Team(name: String, members: List[String])
+
+    val team = Team("Engineering", List("Alice", "Bob", "Charlie"))
+    println(FastShowPretty.render(team, RenderConfig.Default))
+    // Team(
+    //   name = "Engineering",
+    //   members = List(
+    //     "Alice",
+    //     "Bob",
+    //     "Charlie"
+    //   )
+    // )
+    ```
+
+??? example "Sealed traits"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty.*
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    val shape: Shape = Circle(5.0)
+    println(FastShowPretty.render(shape, RenderConfig.Default))
+    // Circle(
+    //   radius = 5.0d
+    // )
+    ```
+
+??? example "Recursive data types"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty.*
+
+    case class Tree(value: Int, children: List[Tree])
+
+    val tree = Tree(1, List(
+      Tree(2, Nil),
+      Tree(3, List(Tree(4, Nil)))
+    ))
+    println(FastShowPretty.render(tree, RenderConfig.Default))
+    // Tree(
+    //   value = 1,
+    //   children = List(
+    //     Tree(
+    //       value = 2,
+    //       children = List()
+    //     ),
+    //     Tree(
+    //       value = 3,
+    //       children = List(
+    //         Tree(
+    //           value = 4,
+    //           children = List()
+    //         )
+    //       )
+    //     )
+    //   )
+    // )
+    ```
+
+??? example "Using the derived instance directly"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty.*
+
+    case class Person(name: String, age: Int)
+
+    // Sanely-automatic: resolved by the compiler via FastShowPretty.derived
+    val instance = implicitly[FastShowPretty[Person]]
+    val sb = instance.render(new StringBuilder, RenderConfig.Default, 0)(Person("Alice", 30))
+    println(sb.toString)
+    // Person(
+    //   name = "Alice",
+    //   age = 30
+    // )
+    ```
+
+## Primitive rendering
+
+FastShowPretty renders primitives with type-disambiguating suffixes, matching Scala literal syntax:
+
+| Type | Example value | Rendered as |
+|------|--------------|-------------|
+| `Boolean` | `true` | `true` |
+| `Byte` | `42` | `42.toByte` |
+| `Short` | `42` | `42.toShort` |
+| `Int` | `42` | `42` |
+| `Long` | `42L` | `42L` |
+| `Float` | `3.14f` | `3.14f` |
+| `Double` | `3.14` | `3.14d` |
+| `Char` | `'a'` | `'a'` |
+| `String` | `"hello"` | `"hello"` |
+
+Strings are properly escaped (quotes, newlines, etc.).
+
+## Comparison with kittens Show
+
+FastShowPretty serves a similar purpose to `cats.Show` derived via kittens, but produces indented, multi-line output suitable for debugging complex nested structures. It also renders primitives with type-disambiguating suffixes (e.g., `42L` for `Long`, `3.14f` for `Float`).
+
+For runtime performance comparison with kittens' `Show`, see the [Cats derivation benchmarks](cats-derivation.md#benchmarks). FastShowPretty uses the same macro-generated approach, so performance characteristics are similar to Kindlings' `Show` derivation.
+
+## Debugging
+
+Import the debug package to log the generated code during compilation:
+
+```scala
+import hearth.kindlings.fastshowpretty.debug._
+```
+
+Or enable project-wide via scalac option:
+
+```scala
+// build.sbt
+scalacOptions += "-Xmacro-settings:fastShowPretty.logDerivation=true"
+```

--- a/docs/user-guide/fast-show-pretty.md
+++ b/docs/user-guide/fast-show-pretty.md
@@ -30,7 +30,7 @@ Original module -- derives `FastShowPretty` instances for pretty-printing case c
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
 
-    import hearth.kindlings.fastshowpretty.*
+    import hearth.kindlings.fastshowpretty._
 
     case class Address(street: String, city: String)
     case class Person(name: String, age: Int, address: Address)
@@ -71,7 +71,7 @@ Original module -- derives `FastShowPretty` instances for pretty-printing case c
 `RenderConfig` controls indentation. Unlike the builder pattern used by other modules, `RenderConfig` is a simple case class with predefined constants:
 
 ```scala
-import hearth.kindlings.fastshowpretty.*
+import hearth.kindlings.fastshowpretty._
 
 // Use a predefined config
 val output = FastShowPretty.render(myValue, RenderConfig.Default)
@@ -105,7 +105,7 @@ val output2 = FastShowPretty.render(myValue, custom)
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
 
-    import hearth.kindlings.fastshowpretty.*
+    import hearth.kindlings.fastshowpretty._
 
     case class Point(x: Int, y: Int)
 
@@ -146,7 +146,7 @@ val output2 = FastShowPretty.render(myValue, custom)
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
 
-    import hearth.kindlings.fastshowpretty.*
+    import hearth.kindlings.fastshowpretty._
 
     case class Team(name: String, members: List[String])
 
@@ -168,7 +168,7 @@ val output2 = FastShowPretty.render(myValue, custom)
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
 
-    import hearth.kindlings.fastshowpretty.*
+    import hearth.kindlings.fastshowpretty._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -187,7 +187,7 @@ val output2 = FastShowPretty.render(myValue, custom)
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
 
-    import hearth.kindlings.fastshowpretty.*
+    import hearth.kindlings.fastshowpretty._
 
     case class Tree(value: Int, children: List[Tree])
 
@@ -222,7 +222,7 @@ val output2 = FastShowPretty.render(myValue, custom)
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
 
-    import hearth.kindlings.fastshowpretty.*
+    import hearth.kindlings.fastshowpretty._
 
     case class Person(name: String, age: Int)
 

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -1,0 +1,161 @@
+# Kindlings
+
+Type class derivation that compiles faster, runs faster, and works the same on Scala 2.13 and Scala 3. Drop-in replacements for derivation in Circe, Jsoniter Scala, Avro, and more — built on [Hearth](https://github.com/kubuszok/hearth), powered by macros, free of the trade-offs you've learned to accept.
+
+## Why Kindlings?
+
+Most Scala libraries derive type class instances using Shapeless (Scala 2), Scala 3 Mirrors, or Magnolia. These approaches work, but they come with trade-offs that compound as your project grows: slow compilation, poor error messages, runtime overhead from intermediate representations, and API fragmentation between Scala 2 and Scala 3.
+
+Kindlings takes a different path. Built on [Hearth](https://github.com/kubuszok/hearth), it uses macros to generate code that is closer to what you'd write by hand — while providing a better developer experience than any of the alternatives.
+
+### One API across Scala 2.13 and Scala 3
+
+No conditional imports, no platform-specific code. Your derivation calls look the same regardless of the Scala version. Migration between Scala 2.13 and Scala 3 requires zero changes to your derivation code.
+
+### Recursive derivation out of the box
+
+Kindlings handles recursive data types without lazy wrappers, manual knot-tying, or tricks. No `Lazy[_]`, no `implicit lazy val`, no special configuration — it just works.
+
+```scala
+case class Tree(value: Int, children: List[Tree])
+
+// works with every Kindlings module — no special handling needed
+```
+
+### Sanely-automatic derivation
+
+In most libraries, you choose between **automatic** and **semi-automatic** derivation — and each comes with trade-offs. Automatic derivation (like `import io.circe.generic.auto._`) is convenient but re-derives instances at every call site, slowing compilation and sometimes producing worse runtime code. Semi-automatic derivation avoids that but requires explicit `implicit val` / `given` boilerplate for every type.
+
+Kindlings eliminates this choice:
+
+- **Semi-automatic is recursive.** `KindlingsEncoder.derive[Person]` derives not just `Person` but also `Address`, `List[Address]`, and anything else reachable — no need to define instances for nested types manually.
+- **Automatic imposes no overhead.** For a single derivation site, automatic and semi-automatic produce identical code — same compilation cost, same runtime performance. The generated code is as fast as what you'd write by hand.
+- **Errors are informative and actionable.** When derivation fails, you get a clear message telling you exactly which type is missing an instance and where in the hierarchy the problem is.
+
+If the same type is auto-derived at multiple call sites, each site derives independently — but this is still cheaper than Shapeless/Mirrors-based automatic derivation, because Kindlings' macro expansion is lightweight by design.
+
+> For a deeper dive, see [Sanely-automatic derivation](https://kubuszok.com/2025/sanely-automatic-derivation/).
+
+### Debug logging on demand
+
+When derivation fails or you want to understand what the macro produces, enable debug logging with a single import:
+
+```scala
+import hearth.kindlings.circederivation.debug._
+```
+
+Or globally via a scalac option — no code changes needed:
+
+```
+-Xmacro-settings:circeDerivation.logDerivation=true
+```
+
+Every module supports both approaches. The output shows exactly what code the macro generates, which rules matched each field, and where summoned implicits came from.
+
+### Flame graph generation on demand
+
+Profile macro compilation performance with Hearth's built-in flame graph support:
+
+```
+-Xmacro-settings:hearth.mioBenchmarkScopes=true
+-Xmacro-settings:hearth.mioBenchmarkFlameGraphDir=/tmp/kindlings-flamegraphs
+```
+
+Generates `.speedscope.json` files you can visualize at [speedscope.app](https://www.speedscope.app/) — useful for diagnosing slow compilation in large projects.
+
+### Macro timeouts prevent runaway compilation
+
+Every derivation module enforces a **5-second timeout** by default. If a macro expansion takes longer than that, compilation fails with a clear error — no more silently waiting minutes for a derivation that will never finish.
+
+If a specific type hierarchy legitimately needs more time, you can raise the limit per module:
+
+```
+-Xmacro-settings:circeDerivation.timeout=30s
+-Xmacro-settings:jsoniterDerivation.timeout=1m
+```
+
+Supported formats: plain integer (seconds), `Ns`, `Nms`, `Nm`.
+
+### No imports for integration modules
+
+Refined types, Iron types, and Cats collections work automatically. Just add the integration dependency to your build — no imports, no configuration. The macro extension system discovers them at compile time.
+
+```scala
+// build.sbt — just add the dependency
+libraryDependencies += "com.kubuszok" %% "kindlings-refined-integration" % "{{ kindlings_version() }}"
+
+// your code — no extra imports, refined types just work
+import eu.timepit.refined.api.Refined
+import eu.timepit.refined.numeric.Positive
+
+case class Order(quantity: Int Refined Positive, item: String)
+// Circe/Jsoniter/Avro/... derivation handles Refined fields automatically
+```
+
+## Comparison at a glance
+
+| | Kindlings | Shapeless / Mirrors | Magnolia | Library-specific macros |
+|---|---|---|---|---|
+| Same API on Scala 2.13 and 3 | Yes | No | No | varies |
+| Auto derivation without overhead | Yes | No | No | varies |
+| Inline derivation | Yes | No | No | some |
+| Recursive types (no tricks) | Yes | needs semiauto + `lazy val` / `Lazy` | Yes | varies |
+| Clear error messages | Yes | No | partial | varies |
+| Code preview | Yes | No | No | rare |
+| Named tuples, opaque types | Yes | No | No | rare |
+| Scala 3 enums, Java enums | Yes | partial | partial | varies |
+
+## Available modules
+
+| Module | Replaces | Derived type classes |
+|---|---|---|
+| [kindlings-avro-derivation](avro-derivation.md) | avro4s (JVM only) | `AvroSchemaFor`, `AvroEncoder`, `AvroDecoder` |
+| [kindlings-cats-derivation](cats-derivation.md) | kittens | `Show`, `Eq`, `Order`, `Hash`, `Functor`, `Traverse`, and [20 more](cats-derivation.md) |
+| [kindlings-circe-derivation](circe-derivation.md) | circe-generic-extras | `Encoder`, `Encoder.AsObject`, `Decoder` |
+| [kindlings-fast-show-pretty](fast-show-pretty.md) | _(original)_ | `FastShowPretty` |
+| [kindlings-jsoniter-derivation](jsoniter-derivation.md) | jsoniter-scala `JsonCodecMaker` | `JsonValueCodec`, `JsonCodec`, `JsonKeyCodec` |
+| [kindlings-pureconfig-derivation](pureconfig-derivation.md) | PureConfig generic (JVM only) | `ConfigReader`, `ConfigWriter`, `ConfigConvert` |
+| [kindlings-scalacheck-derivation](scalacheck-derivation.md) | manual instances | `Arbitrary`, `Cogen`, `Shrink` |
+| [kindlings-sconfig-derivation](sconfig-derivation.md) | _(original)_ | `ConfigReader`, `ConfigWriter`, `ConfigCodec` |
+| [kindlings-tapir-schema-derivation](tapir-schema-derivation.md) | Tapir `Schema.derived` | `Schema` |
+| [kindlings-ubjson-derivation](ubjson-derivation.md) | _(original)_ | `UBJsonValueCodec` |
+| [kindlings-xml-derivation](xml-derivation.md) | _(original)_ | `XmlEncoder`, `XmlDecoder` |
+| [kindlings-yaml-derivation](yaml-derivation.md) | scala-yaml `derives` | `YamlEncoder`, `YamlDecoder` |
+
+All modules are cross-compiled for Scala 2.13 and 3, on JVM, Scala.js, and Scala Native — except `kindlings-avro-derivation` and `kindlings-pureconfig-derivation`, which are JVM-only.
+
+## Quick start
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-circe-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    ```
+
+??? example "Minimal example"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.syntax.*
+
+    case class Person(name: String, age: Int)
+
+    // sanely-automatic derivation — just have KindlingsEncoder in scope
+    val json = Person("Alice", 30).asJson
+    println(json.noSpaces) // {"name":"Alice","age":30}
+
+    // or semi-automatic
+    val decoder = KindlingsDecoder.derive[Person]
+    println(io.circe.parser.decode[Person]("""{"name":"Bob","age":25}""")(using decoder))
+    // Right(Person(Bob,25))
+    ```

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -146,16 +146,16 @@ All modules are cross-compiled for Scala 2.13 and 3, on JVM, Scala.js, and Scala
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
     import hearth.kindlings.circederivation._
-    import io.circe.syntax._
+    import io.circe._
 
     case class Person(name: String, age: Int)
 
-    // sanely-automatic derivation — just have KindlingsEncoder in scope
-    val json = Person("Alice", 30).asJson
+    // inline encoding — no implicit needed
+    val json: Json = KindlingsEncoder.encode(Person("Alice", 30))
     println(json.noSpaces) // {"name":"Alice","age":30}
 
-    // or semi-automatic
-    val decoder = KindlingsDecoder.derive[Person]
-    println(io.circe.parser.decode[Person]("""{"name":"Bob","age":25}""")(using decoder))
+    // inline decoding
+    val parsed = io.circe.parser.parse("""{"name":"Bob","age":25}""")
+    println(parsed.flatMap(KindlingsDecoder.decode[Person](_)))
     // Right(Person(Bob,25))
     ```

--- a/docs/user-guide/index.md
+++ b/docs/user-guide/index.md
@@ -145,8 +145,8 @@ All modules are cross-compiled for Scala 2.13 and 3, on JVM, Scala.js, and Scala
     //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.syntax.*
+    import hearth.kindlings.circederivation._
+    import io.circe.syntax._
 
     case class Person(name: String, age: Int)
 

--- a/docs/user-guide/iron-integration.md
+++ b/docs/user-guide/iron-integration.md
@@ -1,0 +1,124 @@
+# Iron Integration
+
+Automatic support for [Iron](https://github.com/Iltotore/iron) constrained types in all Kindlings derivation modules. Add the dependency and `A :| C` fields are handled transparently in Circe, Jsoniter, Avro, Cats, and every other module — no imports, no configuration.
+
+**Scala 3 only** — Iron is a Scala 3-only library.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-iron-integration" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-iron-integration" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-iron-integration:{{ kindlings_version() }}
+    ```
+
+!!! note
+    You also need `iron` as a dependency:
+
+    ```scala
+    libraryDependencies += "io.github.iltotore" %%% "iron" % "{{ libraries.iron }}"
+    ```
+
+## How it works
+
+Iron types (`IronType[A, C]`, written as `A :| C`) are opaque types with an `<: A` upper bound. The integration registers an `IsValueType` provider that teaches all derivation modules how to unwrap and validate Iron-constrained types.
+
+- **Encoding**: `A :| C` is unwrapped to `A` and encoded using `A`'s encoder.
+- **Decoding**: The raw `A` value is decoded first, then validated using `RuntimeConstraint[A, C]`. If validation fails, decoding fails with an error.
+
+`RuntimeConstraint` is Iron's non-inline validation mechanism, which makes it compatible with macro-generated code (where inline refinement methods cannot be called).
+
+Like all Kindlings integration modules, the jar's presence on the classpath is sufficient — the macro extension system discovers the provider at compile time via SPI.
+
+## Supported types
+
+Any `A :| C` (i.e. `IronType[A, C]`) where:
+
+- `A` is a type that the derivation module already knows how to handle (e.g. `Int`, `String`, `Double`)
+- `C` is a constraint with a `RuntimeConstraint[A, C]` instance in scope (provided by the `iron` library for all standard constraints)
+
+This includes all standard Iron constraints: `Positive`, `StrictlyNegative`, `Not[Empty]`, `MinLength[N]`, `Match[R]`, and user-defined constraints.
+
+## Example
+
+??? example "Case class with Iron-constrained fields (Circe)"
+
+    ```scala
+    //> using scala {{ scala.3 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-iron-integration:{{ kindlings_version() }}
+    //> using dep io.github.iltotore::iron:{{ libraries.iron }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.*
+    import io.circe.syntax.*
+    import io.github.iltotore.iron.*
+    import io.github.iltotore.iron.constraint.numeric.*
+    import io.github.iltotore.iron.constraint.string.*
+
+    case class Product(
+      name: String :| Not[Empty],
+      price: Double :| StrictlyPositive,
+      quantity: Int :| Positive
+    )
+
+    val product = Product("widget".refine, 9.99.refine, 5.refine)
+    println(product.asJson.noSpaces)
+    // {"name":"widget","price":9.99,"quantity":5}
+
+    val decoded = io.circe.parser.decode[Product]("""{"name":"","price":9.99,"quantity":5}""")
+    println(decoded)
+    // Left(DecodingFailure(...)) — empty string violates Not[Empty]
+    ```
+
+??? example "Works with any derivation module"
+
+    The same Iron types work transparently with Jsoniter, Avro, YAML, and every other module:
+
+    ```scala
+    //> using scala {{ scala.3 }}
+    //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-iron-integration:{{ kindlings_version() }}
+    //> using dep io.github.iltotore::iron:{{ libraries.iron }}
+
+    import hearth.kindlings.jsoniterderivation.*
+    import com.github.plokhotnyuk.jsoniter_scala.core.*
+    import io.github.iltotore.iron.*
+    import io.github.iltotore.iron.constraint.numeric.*
+
+    case class Measurement(
+      value: Double :| StrictlyPositive,
+      unit: String
+    )
+
+    val codec = KindlingsJsonValueCodec.derive[Measurement]
+    val json = writeToString(Measurement(42.0.refine, "kg"))(codec)
+    println(json)
+    // {"value":42.0,"unit":"kg"}
+    ```
+
+## Comparison with Refined
+
+Both Refined and Iron provide compile-time-validated wrapper types. The key differences for Kindlings users:
+
+| | Refined | Iron |
+|---|---------|------|
+| Scala versions | 2.13 and 3 | 3 only |
+| Kindlings module | `kindlings-refined-integration` | `kindlings-iron-integration` |
+| Validation mechanism | `refineV[P]` | `RuntimeConstraint[A, C]` |
+| Representation (Scala 3) | Opaque type | Opaque type |
+
+Both integrations work identically from the user's perspective: add the dependency, and constrained types are handled automatically in all derivation modules.

--- a/docs/user-guide/iron-integration.md
+++ b/docs/user-guide/iron-integration.md
@@ -64,22 +64,21 @@ This includes all standard Iron constraints: `Positive`, `StrictlyNegative`, `No
 
     import hearth.kindlings.circederivation._
     import io.circe._
-    import io.circe.syntax._
     import io.github.iltotore.iron._
-    import io.github.iltotore.iron.constraint.numeric._
-    import io.github.iltotore.iron.constraint.string._
+    import io.github.iltotore.iron.constraint.all._
 
     case class Product(
       name: String :| Not[Empty],
-      price: Double :| StrictlyPositive,
+      price: Double :| Positive,
       quantity: Int :| Positive
     )
 
     val product = Product("widget".refine, 9.99.refine, 5.refine)
-    println(product.asJson.noSpaces)
+    println(KindlingsEncoder.encode(product).noSpaces)
     // {"name":"widget","price":9.99,"quantity":5}
 
-    val decoded = io.circe.parser.decode[Product]("""{"name":"","price":9.99,"quantity":5}""")
+    val decoded = io.circe.parser.parse("""{"name":"","price":9.99,"quantity":5}""")
+      .flatMap(KindlingsDecoder.decode[Product](_))
     println(decoded)
     // Left(DecodingFailure(...)) — empty string violates Not[Empty]
     ```
@@ -97,10 +96,10 @@ This includes all standard Iron constraints: `Positive`, `StrictlyNegative`, `No
     import hearth.kindlings.jsoniterderivation._
     import com.github.plokhotnyuk.jsoniter_scala.core._
     import io.github.iltotore.iron._
-    import io.github.iltotore.iron.constraint.numeric._
+    import io.github.iltotore.iron.constraint.all._
 
     case class Measurement(
-      value: Double :| StrictlyPositive,
+      value: Double :| Positive,
       unit: String
     )
 

--- a/docs/user-guide/iron-integration.md
+++ b/docs/user-guide/iron-integration.md
@@ -62,12 +62,12 @@ This includes all standard Iron constraints: `Positive`, `StrictlyNegative`, `No
     //> using dep io.github.iltotore::iron:{{ libraries.iron }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.*
-    import io.circe.syntax.*
-    import io.github.iltotore.iron.*
-    import io.github.iltotore.iron.constraint.numeric.*
-    import io.github.iltotore.iron.constraint.string.*
+    import hearth.kindlings.circederivation._
+    import io.circe._
+    import io.circe.syntax._
+    import io.github.iltotore.iron._
+    import io.github.iltotore.iron.constraint.numeric._
+    import io.github.iltotore.iron.constraint.string._
 
     case class Product(
       name: String :| Not[Empty],
@@ -94,10 +94,10 @@ This includes all standard Iron constraints: `Positive`, `StrictlyNegative`, `No
     //> using dep com.kubuszok::kindlings-iron-integration:{{ kindlings_version() }}
     //> using dep io.github.iltotore::iron:{{ libraries.iron }}
 
-    import hearth.kindlings.jsoniterderivation.*
-    import com.github.plokhotnyuk.jsoniter_scala.core.*
-    import io.github.iltotore.iron.*
-    import io.github.iltotore.iron.constraint.numeric.*
+    import hearth.kindlings.jsoniterderivation._
+    import com.github.plokhotnyuk.jsoniter_scala.core._
+    import io.github.iltotore.iron._
+    import io.github.iltotore.iron.constraint.numeric._
 
     case class Measurement(
       value: Double :| StrictlyPositive,

--- a/docs/user-guide/jsoniter-derivation.md
+++ b/docs/user-guide/jsoniter-derivation.md
@@ -1,0 +1,225 @@
+# Jsoniter Scala Derivation
+
+Drop-in replacement for `jsoniter-scala-macros` `JsonCodecMaker` — derives `JsonValueCodec`, `JsonCodec`, and `JsonKeyCodec` for case classes, sealed traits, Scala 3 enums, Java enums, and more.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-jsoniter-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-jsoniter-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
+    ```
+
+!!! note
+    You also need `jsoniter-scala-core` as a runtime dependency:
+
+    ```scala
+    libraryDependencies += "com.github.plokhotnyuk.jsoniter-scala" %% "jsoniter-scala-core" % "{{ libraries.jsoniterScala }}"
+    ```
+
+## Quick start
+
+??? example "Encoding and decoding with JsonValueCodec"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
+    //> using dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:{{ libraries.jsoniterScala }}
+
+    import hearth.kindlings.jsoniterderivation.*
+    import com.github.plokhotnyuk.jsoniter_scala.core.*
+
+    case class Person(name: String, age: Int)
+
+    implicit val codec: JsonValueCodec[Person] = KindlingsJsonValueCodec.derive[Person]
+
+    val bytes = writeToArray(Person("Alice", 30))
+    println(new String(bytes))
+    // {"name":"Alice","age":30}
+
+    val person = readFromArray[Person]("""{"name":"Bob","age":25}""".getBytes)
+    println(person)
+    // Person(Bob,25)
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `KindlingsJsonValueCodec.derive[A]` | `JsonValueCodec[A]` | Semi-automatic codec |
+| `KindlingsJsonValueCodec.derived[A]` | `KindlingsJsonValueCodec[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsJsonValueCodec.writeToString[A](value)` | `String` | Inline encoding |
+| `KindlingsJsonValueCodec.readFromString[A](json)` | `Either[JsonReaderException, A]` | Inline decoding |
+| `KindlingsJsonCodec.derive[A]` | `JsonCodec[A]` | Combined value + key codec |
+| `KindlingsJsonCodec.deriveKeyCodec[A]` | `JsonKeyCodec[A]` | Key codec (for map keys) |
+| `KindlingsJsonCodec.derived[A]` | `KindlingsJsonCodec[A]` | Sanely-automatic |
+
+All methods take an implicit/using `JsoniterConfig` parameter (defaults to `JsoniterConfig.default`).
+
+## Configuration
+
+```scala
+import hearth.kindlings.jsoniterderivation.*
+
+implicit val config: JsoniterConfig = JsoniterConfig.default
+  .withSnakeCaseFieldNames
+  .withDiscriminator("type")
+  .withSkipUnexpectedFields(true)
+```
+
+| Builder method | Description |
+|---------------|-------------|
+| `withSnakeCaseFieldNames` | `fieldName` → `field_name` |
+| `withKebabCaseFieldNames` | `fieldName` → `field-name` |
+| `withPascalCaseFieldNames` | `fieldName` → `FieldName` |
+| `withScreamingSnakeCaseFieldNames` | `fieldName` → `FIELD_NAME` |
+| `withFieldNameMapper(f)` | Custom field name transform |
+| `withSnakeCaseAdtLeafClassNames` | ADT subtype name → `snake_case` |
+| `withKebabCaseAdtLeafClassNames` | ADT subtype name → `kebab-case` |
+| `withAdtLeafClassNameMapper(f)` | Custom ADT subtype name transform |
+| `withDiscriminator(field)` | ADT discriminator field name |
+| `withSkipUnexpectedFields(skip)` | Skip unexpected JSON fields |
+| `withEnumAsStrings` | Encode enums as strings |
+| `withMapAsArray` | Encode maps as arrays of key-value pairs |
+| `withStringified` | Encode numbers/booleans as strings |
+| `withDecodingOnly` | Derive only decoder |
+| `withEncodingOnly` | Derive only encoder |
+| `withCirceLikeObjectEncoding` | Encode ADTs as `{"SubType": {...}}` |
+| `withTransientDefault` | Skip fields with default values during encoding |
+| `withTransientEmpty` | Skip empty collections during encoding |
+| `withTransientNone` | Skip `None` fields during encoding |
+| `withRequireCollectionFields` | Fail if collection field is missing (instead of empty default) |
+| `withRequireDefaultFields` | Fail if field with default is missing |
+| `withCheckFieldDuplication` | Fail on duplicate JSON field names |
+| `withBigDecimalPrecision(n)` | Max BigDecimal precision |
+| `withBigDecimalScaleLimit(n)` | Max BigDecimal scale |
+| `withBigDecimalDigitsLimit(n)` | Max BigDecimal digits |
+| `withMapMaxInsertNumber(n)` | Max map entries |
+| `withSetMaxInsertNumber(n)` | Max set entries |
+| `withUseScalaEnumValueId` | Use enum value id for Scala enumerations |
+
+## Annotations
+
+| Annotation | Description |
+|-----------|-------------|
+| `@fieldName("json_name")` | Override JSON field name |
+| `@transientField` | Exclude field from codec (must have default) |
+| `@stringified` | Encode this field as a string |
+
+## Usage examples
+
+??? example "Sealed trait with discriminator"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
+    //> using dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:{{ libraries.jsoniterScala }}
+
+    import hearth.kindlings.jsoniterderivation.*
+    import com.github.plokhotnyuk.jsoniter_scala.core.*
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val config: JsoniterConfig = JsoniterConfig.default
+      .withDiscriminator("type")
+
+    implicit val codec: JsonValueCodec[Shape] = KindlingsJsonValueCodec.derive[Shape]
+
+    println(writeToString[Shape](Circle(5.0)))
+    // {"type":"Circle","radius":5.0}
+
+    println(readFromString[Shape]("""{"type":"Rectangle","width":3,"height":4}"""))
+    // Rectangle(3.0,4.0)
+    ```
+
+??? example "Transient fields and defaults"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
+    //> using dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:{{ libraries.jsoniterScala }}
+
+    import hearth.kindlings.jsoniterderivation.*
+    import com.github.plokhotnyuk.jsoniter_scala.core.*
+
+    implicit val config: JsoniterConfig = JsoniterConfig.default
+      .withTransientDefault
+      .withTransientNone
+
+    case class Settings(
+      host: String,
+      port: Int = 8080,
+      debug: Option[Boolean] = None
+    )
+
+    implicit val codec: JsonValueCodec[Settings] = KindlingsJsonValueCodec.derive[Settings]
+
+    // Default and None fields are omitted
+    println(writeToString(Settings("localhost")))
+    // {"host":"localhost"}
+
+    // Missing fields use defaults
+    println(readFromString[Settings]("""{"host":"example.com"}"""))
+    // Settings(example.com,8080,None)
+    ```
+
+## Comparison with jsoniter-scala macros
+
+### Feature differences
+
+| Feature | jsoniter-scala macros | Kindlings |
+|---------|----------------------|-----------|
+| Same API on Scala 2.13 and 3 | Partial (different compile deps) | Yes |
+| Sanely-automatic derivation | No | Yes |
+| Inline encoding/decoding | No | Yes (`writeToString`, `readFromString`) |
+| Recursive types | Needs workarounds | Just works |
+| Named tuples | No | Yes |
+| Opaque types | No | Yes |
+| Scala 3 enums | Yes | Yes |
+| Java enums | Yes | Yes |
+| `make[A]` convenience factory | Yes | No (use `derive[A]`) |
+
+### Benchmarks
+
+All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
+
+!!! note
+    Kindlings is now at near-parity with jsoniter-scala's own macros for writes, and slightly faster for SimpleCC reads. Complex types still show a small gap.
+
+#### Write
+
+| Type | Scala | Kindlings semi | Kindlings auto | Original semi | vs original |
+|------|-------|---------------|---------------|--------------|------------|
+| SimpleCC | 2.13 | 60.1M | 60.0M | 60.1M | **~tied** |
+| SimpleCC | 3 | 62.8M | 63.4M | 63.5M | **~tied** |
+| SimpleADT | 2.13 | 61.8M | 61.3M | 68.3M | 0.90x |
+| SimpleADT | 3 | 63.6M | 64.8M | 71.5M | 0.91x |
+| Person | 2.13 | 4.3M | 4.4M | 4.7M | 0.94x |
+| Person | 3 | 4.7M | 4.6M | 5.2M | 0.90x |
+| Event | 2.13 | 4.1M | 4.2M | 4.4M | 0.95x |
+| Event | 3 | 4.2M | 4.2M | 4.4M | 0.95x |
+
+#### Read
+
+| Type | Scala | Kindlings semi | Kindlings auto | Original semi | vs original |
+|------|-------|---------------|---------------|--------------|------------|
+| SimpleCC | 2.13 | 36.2M | 36.2M | 34.9M | **1.04x faster** |
+| SimpleCC | 3 | 36.1M | 35.9M | 34.9M | **1.03x faster** |
+| Person | 2.13 | 2.8M | 2.7M | 3.7M | 0.76x |
+| Person | 3 | 2.7M | 2.7M | 3.7M | 0.73x |

--- a/docs/user-guide/jsoniter-derivation.md
+++ b/docs/user-guide/jsoniter-derivation.md
@@ -38,8 +38,8 @@ Drop-in replacement for `jsoniter-scala-macros` `JsonCodecMaker` — derives `Js
     //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
     //> using dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:{{ libraries.jsoniterScala }}
 
-    import hearth.kindlings.jsoniterderivation.*
-    import com.github.plokhotnyuk.jsoniter_scala.core.*
+    import hearth.kindlings.jsoniterderivation._
+    import com.github.plokhotnyuk.jsoniter_scala.core._
 
     case class Person(name: String, age: Int)
 
@@ -73,7 +73,7 @@ All methods take an implicit/using `JsoniterConfig` parameter (defaults to `Json
 ## Configuration
 
 ```scala
-import hearth.kindlings.jsoniterderivation.*
+import hearth.kindlings.jsoniterderivation._
 
 implicit val config: JsoniterConfig = JsoniterConfig.default
   .withSnakeCaseFieldNames
@@ -129,8 +129,8 @@ implicit val config: JsoniterConfig = JsoniterConfig.default
     //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
     //> using dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:{{ libraries.jsoniterScala }}
 
-    import hearth.kindlings.jsoniterderivation.*
-    import com.github.plokhotnyuk.jsoniter_scala.core.*
+    import hearth.kindlings.jsoniterderivation._
+    import com.github.plokhotnyuk.jsoniter_scala.core._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -155,8 +155,8 @@ implicit val config: JsoniterConfig = JsoniterConfig.default
     //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
     //> using dep com.github.plokhotnyuk.jsoniter-scala::jsoniter-scala-core:{{ libraries.jsoniterScala }}
 
-    import hearth.kindlings.jsoniterderivation.*
-    import com.github.plokhotnyuk.jsoniter_scala.core.*
+    import hearth.kindlings.jsoniterderivation._
+    import com.github.plokhotnyuk.jsoniter_scala.core._
 
     implicit val config: JsoniterConfig = JsoniterConfig.default
       .withTransientDefault

--- a/docs/user-guide/pureconfig-derivation.md
+++ b/docs/user-guide/pureconfig-derivation.md
@@ -26,8 +26,8 @@
 ??? example "Reading and writing HOCON configuration"
 
     ```scala
-    import hearth.kindlings.pureconfigderivation.*
-    import pureconfig.*
+    import hearth.kindlings.pureconfigderivation._
+    import pureconfig._
 
     case class ServerConfig(host: String, port: Int, debug: Boolean)
 
@@ -73,7 +73,7 @@ All methods take an implicit/using `PureConfig` parameter (defaults to `PureConf
 All derivation methods accept an implicit `PureConfig`:
 
 ```scala
-import hearth.kindlings.pureconfigderivation.*
+import hearth.kindlings.pureconfigderivation._
 
 implicit val config: PureConfig = PureConfig.default
   .withSnakeCaseMemberNames
@@ -113,7 +113,7 @@ For per-type customization (e.g. one case class uses `snake_case` while everythi
 | `@transientField` | Exclude a field from reading/writing (must have a default value) |
 
 ```scala
-import hearth.kindlings.pureconfigderivation.annotations.*
+import hearth.kindlings.pureconfigderivation.annotations._
 
 case class DatabaseConfig(
   @configKey("connection_string") connectionString: String,
@@ -126,8 +126,8 @@ case class DatabaseConfig(
 ??? example "Sealed trait with discriminator"
 
     ```scala
-    import hearth.kindlings.pureconfigderivation.*
-    import pureconfig.*
+    import hearth.kindlings.pureconfigderivation._
+    import pureconfig._
 
     sealed trait DatabaseType
     case class Postgres(host: String, port: Int, database: String) extends DatabaseType
@@ -149,8 +149,8 @@ case class DatabaseConfig(
 ??? example "Wrapped subtypes (no discriminator)"
 
     ```scala
-    import hearth.kindlings.pureconfigderivation.*
-    import pureconfig.*
+    import hearth.kindlings.pureconfigderivation._
+    import pureconfig._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -170,8 +170,8 @@ case class DatabaseConfig(
 ??? example "Case class with defaults and strict decoding"
 
     ```scala
-    import hearth.kindlings.pureconfigderivation.*
-    import pureconfig.*
+    import hearth.kindlings.pureconfigderivation._
+    import pureconfig._
 
     implicit val config: PureConfig = PureConfig.default
       .withUseDefaults
@@ -202,8 +202,8 @@ case class DatabaseConfig(
 ??? example "Snake case member names"
 
     ```scala
-    import hearth.kindlings.pureconfigderivation.*
-    import pureconfig.*
+    import hearth.kindlings.pureconfigderivation._
+    import pureconfig._
 
     implicit val config: PureConfig = PureConfig.default
       .withSnakeCaseMemberNames
@@ -224,8 +224,8 @@ case class DatabaseConfig(
 ??? example "Nested configuration"
 
     ```scala
-    import hearth.kindlings.pureconfigderivation.*
-    import pureconfig.*
+    import hearth.kindlings.pureconfigderivation._
+    import pureconfig._
 
     case class HttpConfig(host: String, port: Int)
     case class DatabaseConfig(url: String, pool: Int)
@@ -252,7 +252,7 @@ case class DatabaseConfig(
 Import the debug package to log the derivation process at compile time:
 
 ```scala
-import hearth.kindlings.pureconfigderivation.debug.*
+import hearth.kindlings.pureconfigderivation.debug._
 ```
 
 This enables `LogDerivation` implicits for `KindlingsConfigReader`, `KindlingsConfigWriter`, and `KindlingsConfigConvert`, printing the derivation steps to the compiler output.

--- a/docs/user-guide/pureconfig-derivation.md
+++ b/docs/user-guide/pureconfig-derivation.md
@@ -1,0 +1,302 @@
+# PureConfig Derivation
+
+**JVM-only** module. Drop-in replacement for `pureconfig-generic` / `pureconfig-generic-scala3` -- derives `ConfigReader`, `ConfigWriter`, and `ConfigConvert` for case classes, sealed traits, Scala 3 enums, and more.
+
+!!! tip "Need cross-platform HOCON?"
+    If you need HOCON support on Scala.js or Scala Native, use [kindlings-sconfig-derivation](sconfig-derivation.md) instead — it provides the same configuration API built on [sconfig](https://github.com/ekrich/sconfig), a cross-platform port of Typesafe Config.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-pureconfig-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    PureConfig derivation is **JVM-only** (no `%%%`). The PureConfig runtime (`com.github.pureconfig:pureconfig-core`) is pulled in transitively.
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-pureconfig-derivation:{{ kindlings_version() }}
+    ```
+
+## Quick start
+
+??? example "Reading and writing HOCON configuration"
+
+    ```scala
+    import hearth.kindlings.pureconfigderivation.*
+    import pureconfig.*
+
+    case class ServerConfig(host: String, port: Int, debug: Boolean)
+
+    // Semi-automatic derivation
+    val reader: ConfigReader[ServerConfig] = KindlingsConfigReader.derive[ServerConfig]
+    val writer: ConfigWriter[ServerConfig] = KindlingsConfigWriter.derive[ServerConfig]
+
+    // Read from HOCON string
+    val result = ConfigSource.string("""
+      host = "localhost"
+      port = 8080
+      debug = false
+    """).load[ServerConfig](reader)
+    println(result)
+    // Right(ServerConfig(localhost,8080,false))
+
+    // Write to ConfigValue
+    val config = writer.to(ServerConfig("example.com", 443, true))
+    println(config.render())
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `KindlingsConfigReader.derive[A]` | `ConfigReader[A]` | Semi-automatic reader |
+| `KindlingsConfigReader.derived[A]` | `KindlingsConfigReader[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsConfigWriter.derive[A]` | `ConfigWriter[A]` | Semi-automatic writer |
+| `KindlingsConfigWriter.derived[A]` | `KindlingsConfigWriter[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsConfigConvert.derive[A]` | `ConfigConvert[A]` | Semi-automatic reader + writer |
+| `KindlingsConfigConvert.derived[A]` | `KindlingsConfigConvert[A]` | Sanely-automatic reader + writer |
+
+All methods take an implicit/using `PureConfig` parameter (defaults to `PureConfig.default`).
+
+### Type hierarchy
+
+`KindlingsConfigReader[A]` extends `pureconfig.ConfigReader[A]`, `KindlingsConfigWriter[A]` extends `pureconfig.ConfigWriter[A]`, and `KindlingsConfigConvert[A]` extends `pureconfig.ConfigConvert[A]`. Derived instances are fully drop-in compatible with existing PureConfig code, including `ConfigSource.load[A]`.
+
+## Configuration
+
+All derivation methods accept an implicit `PureConfig`:
+
+```scala
+import hearth.kindlings.pureconfigderivation.*
+
+implicit val config: PureConfig = PureConfig.default
+  .withSnakeCaseMemberNames
+  .withDiscriminator("type")
+  .withUseDefaults
+```
+
+The defaults match upstream PureConfig behavior: kebab-case member names, kebab-case constructor names, `"type"` discriminator, defaults enabled, and unknown keys allowed.
+
+| Builder method | Description |
+|---------------|-------------|
+| `withSnakeCaseMemberNames` | `fieldName` -> `field_name` |
+| `withKebabCaseMemberNames` | `fieldName` -> `field-name` (default) |
+| `withPascalCaseMemberNames` | `fieldName` -> `FieldName` |
+| `withScreamingSnakeCaseMemberNames` | `fieldName` -> `FIELD_NAME` |
+| `withCamelCaseMemberNames` | `fieldName` -> `fieldName` (identity) |
+| `withTransformMemberNames(f)` | Custom field name transform |
+| `withSnakeCaseConstructorNames` | `MyType` -> `my_type` in discriminator |
+| `withKebabCaseConstructorNames` | `MyType` -> `my-type` in discriminator (default) |
+| `withTransformConstructorNames(f)` | Custom constructor name transform |
+| `withDiscriminator(field)` | ADT discriminator field name (default: `"type"`) |
+| `withWrappedSubtypes` | No discriminator -- wrap subtypes in single-key objects |
+| `withUseDefaults` | Use case class default values for missing keys (default) |
+| `withoutUseDefaults` | Require all keys |
+| `withAllowUnknownKeys` | Ignore unexpected HOCON keys (default) |
+| `withStrictDecoding` | Fail on unexpected HOCON keys |
+
+### Per-type hints
+
+For per-type customization (e.g. one case class uses `snake_case` while everything else stays `kebab-case`), define an implicit `KindlingsProductHint` or `KindlingsCoproductHint` for the specific type. The macro looks them up at derivation time and falls back to the global `PureConfig` when no per-type hint is in scope.
+
+## Annotations
+
+| Annotation | Description |
+|-----------|-------------|
+| `@configKey("name")` | Override the HOCON key for a case class field |
+| `@transientField` | Exclude a field from reading/writing (must have a default value) |
+
+```scala
+import hearth.kindlings.pureconfigderivation.annotations.*
+
+case class DatabaseConfig(
+  @configKey("connection_string") connectionString: String,
+  @transientField cachedPool: Option[Any] = None
+)
+```
+
+## Usage examples
+
+??? example "Sealed trait with discriminator"
+
+    ```scala
+    import hearth.kindlings.pureconfigderivation.*
+    import pureconfig.*
+
+    sealed trait DatabaseType
+    case class Postgres(host: String, port: Int, database: String) extends DatabaseType
+    case class Sqlite(path: String) extends DatabaseType
+
+    // Default config uses "type" discriminator and kebab-case names
+    val reader = KindlingsConfigReader.derive[DatabaseType]
+
+    val result = ConfigSource.string("""
+      type = "postgres"
+      host = "localhost"
+      port = 5432
+      database = "mydb"
+    """).load[DatabaseType](reader)
+    println(result)
+    // Right(Postgres(localhost,5432,mydb))
+    ```
+
+??? example "Wrapped subtypes (no discriminator)"
+
+    ```scala
+    import hearth.kindlings.pureconfigderivation.*
+    import pureconfig.*
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val config: PureConfig = PureConfig.default.withWrappedSubtypes
+
+    val reader = KindlingsConfigReader.derive[Shape]
+
+    val result = ConfigSource.string("""
+      circle { radius = 5.0 }
+    """).load[Shape](reader)
+    println(result)
+    // Right(Circle(5.0))
+    ```
+
+??? example "Case class with defaults and strict decoding"
+
+    ```scala
+    import hearth.kindlings.pureconfigderivation.*
+    import pureconfig.*
+
+    implicit val config: PureConfig = PureConfig.default
+      .withUseDefaults
+      .withStrictDecoding
+
+    case class AppSettings(
+      host: String,
+      port: Int = 8080,
+      debug: Boolean = false
+    )
+
+    val reader = KindlingsConfigReader.derive[AppSettings]
+
+    // Missing fields use Scala defaults
+    val result = ConfigSource.string("""host = "localhost" """).load[AppSettings](reader)
+    println(result)
+    // Right(AppSettings(localhost,8080,false))
+
+    // Unknown keys cause an error in strict mode
+    val strict = ConfigSource.string("""
+      host = "localhost"
+      unknown-key = "oops"
+    """).load[AppSettings](reader)
+    println(strict)
+    // Left(ConfigReaderFailures(...))
+    ```
+
+??? example "Snake case member names"
+
+    ```scala
+    import hearth.kindlings.pureconfigderivation.*
+    import pureconfig.*
+
+    implicit val config: PureConfig = PureConfig.default
+      .withSnakeCaseMemberNames
+
+    case class UserProfile(firstName: String, lastName: String, emailAddress: String)
+
+    val reader = KindlingsConfigReader.derive[UserProfile]
+
+    val result = ConfigSource.string("""
+      first_name = "Alice"
+      last_name = "Smith"
+      email_address = "alice@example.com"
+    """).load[UserProfile](reader)
+    println(result)
+    // Right(UserProfile(Alice,Smith,alice@example.com))
+    ```
+
+??? example "Nested configuration"
+
+    ```scala
+    import hearth.kindlings.pureconfigderivation.*
+    import pureconfig.*
+
+    case class HttpConfig(host: String, port: Int)
+    case class DatabaseConfig(url: String, pool: Int)
+    case class AppConfig(http: HttpConfig, database: DatabaseConfig)
+
+    val reader = KindlingsConfigReader.derive[AppConfig]
+
+    val result = ConfigSource.string("""
+      http {
+        host = "0.0.0.0"
+        port = 8080
+      }
+      database {
+        url = "jdbc:postgresql://localhost/mydb"
+        pool = 10
+      }
+    """).load[AppConfig](reader)
+    println(result)
+    // Right(AppConfig(HttpConfig(0.0.0.0,8080),DatabaseConfig(jdbc:postgresql://localhost/mydb,10)))
+    ```
+
+## Debugging
+
+Import the debug package to log the derivation process at compile time:
+
+```scala
+import hearth.kindlings.pureconfigderivation.debug.*
+```
+
+This enables `LogDerivation` implicits for `KindlingsConfigReader`, `KindlingsConfigWriter`, and `KindlingsConfigConvert`, printing the derivation steps to the compiler output.
+
+## Comparison with pureconfig-generic
+
+### Feature differences
+
+| Feature | pureconfig-generic (Scala 2) | pureconfig-generic-scala3 | Kindlings |
+|---------|----------------------------|--------------------------|-----------|
+| Same API on Scala 2.13 and 3 | No | No | Yes |
+| Sanely-automatic derivation | No | No | Yes |
+| `derives` support on Scala 2.13 | No | N/A | Yes |
+| Recursive types | Needs `Lazy` | Yes | Just works |
+| Named tuples | No | No | Yes |
+| Opaque types | No | Partial | Yes |
+| Scala 3 enums | No | Yes | Yes |
+| Java enums | No | Yes | Yes |
+| Per-type `ProductHint` / `CoproductHint` | Yes | Yes | Yes |
+| `@ConfiguredJsonCodec`-style annotation | No | No | No |
+
+### Benchmarks
+
+All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
+
+#### Write
+
+| Type | Scala | Kindlings | Original semi | vs original |
+|------|-------|-----------|--------------|------------|
+| SimpleCC | 2.13 | 11.0M | 1.2M | **9.2x faster** |
+| SimpleCC | 3 | 10.9M | 1.6M | **6.8x faster** |
+| Person | 2.13 | 1.2M | 200.4K | **6.0x faster** |
+| Person | 3 | 1.2M | 247.3K | **4.9x faster** |
+
+#### Read
+
+| Type | Scala | Kindlings | Original semi | vs original |
+|------|-------|-----------|--------------|------------|
+| SimpleCC | 2.13 | 16.8M | 1.4M | **12.0x faster** |
+| SimpleCC | 3 | 11.9M | 1.4M | **8.5x faster** |
+| Person | 2.13 | 999.8K | 208.9K | **4.8x faster** |
+| Person | 3 | 924.8K | 200.8K | **4.6x faster** |
+
+!!! note
+    Kindlings is 4.6--12x faster across the board, for both reads and writes, on both Scala versions and type complexities.
+
+Note: Kindlings semi-automatic and automatic derivation produce identical performance -- this is the "sanely-automatic" design.

--- a/docs/user-guide/refined-integration.md
+++ b/docs/user-guide/refined-integration.md
@@ -1,0 +1,120 @@
+# Refined Integration
+
+Automatic support for [Refined](https://github.com/fthomas/refined) types in all Kindlings derivation modules. Add the dependency and `Refined[A, P]` fields are handled transparently in Circe, Jsoniter, Avro, Cats, and every other module — no imports, no configuration.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-refined-integration" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-refined-integration" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-refined-integration:{{ kindlings_version() }}
+    ```
+
+!!! note
+    You also need `refined` as a dependency:
+
+    ```scala
+    libraryDependencies += "eu.timepit" %%% "refined" % "{{ libraries.refined }}"
+    ```
+
+## How it works
+
+Kindlings' macro extension system automatically discovers the refined integration at compile time via SPI (Service Provider Interface). When the `kindlings-refined-integration` jar is on the classpath, an `IsValueType` provider for `Refined[A, P]` is registered, teaching all derivation modules how to unwrap and validate refined types.
+
+- **Encoding**: `Refined[A, P]` is unwrapped to `A` and encoded using `A`'s encoder.
+- **Decoding**: The raw `A` value is decoded first, then validated with `refineV[P]`. If validation fails, decoding fails with an error message from the predicate.
+
+No wildcard import, no implicit, no configuration object — the jar's presence is sufficient.
+
+## Platform behavior
+
+| Platform | Scala 2.13 | Scala 3 |
+|----------|-----------|---------|
+| Representation | `AnyVal` wrapper | Opaque type |
+| Provider | `IsValueTypeProviderForRefined` | Hearth's built-in opaque type provider |
+| Validation on decode | `refineV[P]` | `refineV[P]` |
+
+On Scala 3, `eu.timepit.refined.api.Refined` is an opaque type alias, so Hearth's built-in `IsValueTypeProviderForOpaque` matches it before the custom provider. The custom provider is primarily needed for Scala 2.13, where `Refined` is an `AnyVal` that requires validated wrapping via `refineV`.
+
+The end result is identical on both Scala versions: encoding strips the refinement, decoding validates it.
+
+## Supported types
+
+Any `Refined[A, P]` where:
+
+- `A` is a type that the derivation module already knows how to handle (e.g. `Int`, `String`, `Double`)
+- `P` is a refinement predicate with a `Validate[A, P]` instance in scope (provided by the `refined` library)
+
+This includes all standard refined predicates: `Positive`, `NonEmpty`, `Size[...]`, `MatchesRegex[...]`, `Interval.Closed[...]`, and user-defined predicates.
+
+## Example
+
+??? example "Case class with refined fields (Circe)"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-refined-integration:{{ kindlings_version() }}
+    //> using dep eu.timepit::refined:{{ libraries.refined }}
+    //> using dep io.circe::circe-parser:{{ libraries.circe }}
+
+    import hearth.kindlings.circederivation.*
+    import io.circe.*
+    import io.circe.syntax.*
+    import eu.timepit.refined.api.Refined
+    import eu.timepit.refined.numeric.Positive
+    import eu.timepit.refined.string.MatchesRegex
+    import eu.timepit.refined.auto.*
+
+    case class Order(
+      quantity: Int Refined Positive,
+      item: String
+    )
+
+    val order = Order(3, "widget")
+    println(order.asJson.noSpaces)
+    // {"quantity":3,"item":"widget"}
+
+    val decoded = io.circe.parser.decode[Order]("""{"quantity":0,"item":"widget"}""")
+    println(decoded)
+    // Left(DecodingFailure(...)) — 0 is not positive
+    ```
+
+??? example "Works with any derivation module"
+
+    The same refined types work transparently with Jsoniter, Avro, YAML, and every other module. No per-module setup is needed:
+
+    ```scala
+    //> using scala {{ scala.3 }}
+    //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-refined-integration:{{ kindlings_version() }}
+    //> using dep eu.timepit::refined:{{ libraries.refined }}
+
+    import hearth.kindlings.jsoniterderivation.*
+    import com.github.plokhotnyuk.jsoniter_scala.core.*
+    import eu.timepit.refined.api.Refined
+    import eu.timepit.refined.collection.NonEmpty
+    import eu.timepit.refined.auto.*
+
+    case class User(
+      name: String Refined NonEmpty,
+      age: Int
+    )
+
+    val codec = KindlingsJsonValueCodec.derive[User]
+    val json = writeToString(User("Alice", 30))(codec)
+    println(json)
+    // {"name":"Alice","age":30}
+    ```

--- a/docs/user-guide/refined-integration.md
+++ b/docs/user-guide/refined-integration.md
@@ -72,10 +72,8 @@ This includes all standard refined predicates: `Positive`, `NonEmpty`, `Size[...
 
     import hearth.kindlings.circederivation._
     import io.circe._
-    import io.circe.syntax._
     import eu.timepit.refined.api.Refined
     import eu.timepit.refined.numeric.Positive
-    import eu.timepit.refined.string.MatchesRegex
     import eu.timepit.refined.auto._
 
     case class Order(
@@ -84,10 +82,11 @@ This includes all standard refined predicates: `Positive`, `NonEmpty`, `Size[...
     )
 
     val order = Order(3, "widget")
-    println(order.asJson.noSpaces)
+    println(KindlingsEncoder.encode(order).noSpaces)
     // {"quantity":3,"item":"widget"}
 
-    val decoded = io.circe.parser.decode[Order]("""{"quantity":0,"item":"widget"}""")
+    val decoded = io.circe.parser.parse("""{"quantity":0,"item":"widget"}""")
+      .flatMap(KindlingsDecoder.decode[Order](_))
     println(decoded)
     // Left(DecodingFailure(...)) — 0 is not positive
     ```
@@ -97,7 +96,7 @@ This includes all standard refined predicates: `Positive`, `NonEmpty`, `Size[...
     The same refined types work transparently with Jsoniter, Avro, YAML, and every other module. No per-module setup is needed:
 
     ```scala
-    //> using scala {{ scala.3 }}
+    //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-jsoniter-derivation:{{ kindlings_version() }}
     //> using dep com.kubuszok::kindlings-refined-integration:{{ kindlings_version() }}
     //> using dep eu.timepit::refined:{{ libraries.refined }}
@@ -113,8 +112,8 @@ This includes all standard refined predicates: `Positive`, `NonEmpty`, `Size[...
       age: Int
     )
 
-    val codec = KindlingsJsonValueCodec.derive[User]
-    val json = writeToString(User("Alice", 30))(codec)
+    implicit val codec = KindlingsJsonValueCodec.derive[User]
+    val json = writeToString(User("Alice", 30))
     println(json)
     // {"name":"Alice","age":30}
     ```

--- a/docs/user-guide/refined-integration.md
+++ b/docs/user-guide/refined-integration.md
@@ -70,13 +70,13 @@ This includes all standard refined predicates: `Positive`, `NonEmpty`, `Size[...
     //> using dep eu.timepit::refined:{{ libraries.refined }}
     //> using dep io.circe::circe-parser:{{ libraries.circe }}
 
-    import hearth.kindlings.circederivation.*
-    import io.circe.*
-    import io.circe.syntax.*
+    import hearth.kindlings.circederivation._
+    import io.circe._
+    import io.circe.syntax._
     import eu.timepit.refined.api.Refined
     import eu.timepit.refined.numeric.Positive
     import eu.timepit.refined.string.MatchesRegex
-    import eu.timepit.refined.auto.*
+    import eu.timepit.refined.auto._
 
     case class Order(
       quantity: Int Refined Positive,
@@ -102,11 +102,11 @@ This includes all standard refined predicates: `Positive`, `NonEmpty`, `Size[...
     //> using dep com.kubuszok::kindlings-refined-integration:{{ kindlings_version() }}
     //> using dep eu.timepit::refined:{{ libraries.refined }}
 
-    import hearth.kindlings.jsoniterderivation.*
-    import com.github.plokhotnyuk.jsoniter_scala.core.*
+    import hearth.kindlings.jsoniterderivation._
+    import com.github.plokhotnyuk.jsoniter_scala.core._
     import eu.timepit.refined.api.Refined
     import eu.timepit.refined.collection.NonEmpty
-    import eu.timepit.refined.auto.*
+    import eu.timepit.refined.auto._
 
     case class User(
       name: String Refined NonEmpty,

--- a/docs/user-guide/scalacheck-derivation.md
+++ b/docs/user-guide/scalacheck-derivation.md
@@ -39,6 +39,7 @@ Derives `Arbitrary`, `Cogen`, and `Shrink` instances for case classes, sealed tr
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
     import hearth.kindlings.scalacheckderivation._
+    import hearth.kindlings.scalacheckderivation.extensions._
     import org.scalacheck.Arbitrary
 
     case class Person(name: String, age: Int)
@@ -92,6 +93,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
     import hearth.kindlings.scalacheckderivation._
+    import hearth.kindlings.scalacheckderivation.extensions._
     import org.scalacheck.{Arbitrary, Prop}
 
     sealed trait Shape
@@ -119,6 +121,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
     import hearth.kindlings.scalacheckderivation._
+    import hearth.kindlings.scalacheckderivation.extensions._
     import org.scalacheck.{Arbitrary, Cogen, Gen}
 
     case class Point(x: Int, y: Int)
@@ -140,6 +143,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
     import hearth.kindlings.scalacheckderivation._
+    import hearth.kindlings.scalacheckderivation.extensions._
     import org.scalacheck.Shrink
 
     case class Config(retries: Int, timeout: Long, label: String)
@@ -160,6 +164,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
     import hearth.kindlings.scalacheckderivation._
+    import hearth.kindlings.scalacheckderivation.extensions._
     import org.scalacheck.Arbitrary
 
     case class Tree(value: Int, children: List[Tree])
@@ -167,7 +172,8 @@ No configuration class is needed -- derivation is fully automatic based on the t
     // No Lazy wrapper needed -- recursion is handled automatically
     implicit val arbTree: Arbitrary[Tree] = Arbitrary.derived[Tree]
 
-    val sample = Arbitrary.arbitrary[Tree].sample.get
+    // Recursive types may produce deep trees; retry if sample is None
+    val sample = Iterator.continually(Arbitrary.arbitrary[Tree].sample).flatten.next()
     println(sample)
     ```
 

--- a/docs/user-guide/scalacheck-derivation.md
+++ b/docs/user-guide/scalacheck-derivation.md
@@ -38,7 +38,7 @@ Derives `Arbitrary`, `Cogen`, and `Shrink` instances for case classes, sealed tr
     //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
-    import hearth.kindlings.scalacheckderivation.*
+    import hearth.kindlings.scalacheckderivation._
     import org.scalacheck.Arbitrary
 
     case class Person(name: String, age: Int)
@@ -91,7 +91,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
     //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
-    import hearth.kindlings.scalacheckderivation.*
+    import hearth.kindlings.scalacheckderivation._
     import org.scalacheck.{Arbitrary, Prop}
 
     sealed trait Shape
@@ -118,7 +118,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
     //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
-    import hearth.kindlings.scalacheckderivation.*
+    import hearth.kindlings.scalacheckderivation._
     import org.scalacheck.{Arbitrary, Cogen, Gen}
 
     case class Point(x: Int, y: Int)
@@ -139,7 +139,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
     //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
-    import hearth.kindlings.scalacheckderivation.*
+    import hearth.kindlings.scalacheckderivation._
     import org.scalacheck.Shrink
 
     case class Config(retries: Int, timeout: Long, label: String)
@@ -159,7 +159,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
     //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
     //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
 
-    import hearth.kindlings.scalacheckderivation.*
+    import hearth.kindlings.scalacheckderivation._
     import org.scalacheck.Arbitrary
 
     case class Tree(value: Int, children: List[Tree])
@@ -176,7 +176,7 @@ No configuration class is needed -- derivation is fully automatic based on the t
 Enable debug logging to see the derivation process:
 
 ```scala
-import hearth.kindlings.scalacheckderivation.debug.*
+import hearth.kindlings.scalacheckderivation.debug._
 ```
 
 Or via scalac option:

--- a/docs/user-guide/scalacheck-derivation.md
+++ b/docs/user-guide/scalacheck-derivation.md
@@ -1,0 +1,203 @@
+# ScalaCheck Derivation
+
+Derives `Arbitrary`, `Cogen`, and `Shrink` instances for case classes, sealed traits, Scala 3 enums, Java enums, and more. Replaces manual instance definitions and scalacheck-shapeless.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-scalacheck-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-scalacheck-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
+    ```
+
+!!! note
+    You also need `scalacheck` as a runtime dependency:
+
+    ```scala
+    libraryDependencies += "org.scalacheck" %%% "scalacheck" % "{{ libraries.scalacheck }}"
+    ```
+
+## Quick start
+
+??? example "Generating random case class instances"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
+    //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
+
+    import hearth.kindlings.scalacheckderivation.*
+    import org.scalacheck.Arbitrary
+
+    case class Person(name: String, age: Int)
+
+    // Extension method on Arbitrary companion
+    implicit val arbPerson: Arbitrary[Person] = Arbitrary.derived[Person]
+
+    // Generate random samples
+    println(Arbitrary.arbitrary[Person].sample)
+    // Some(Person(abc,42))
+
+    println(Arbitrary.arbitrary[Person].sample)
+    // Some(Person(xyz,-7))
+    ```
+
+## API
+
+### Derivation methods
+
+ScalaCheck derivation works via extension methods on the ScalaCheck companion objects and via standalone `Derive*` objects:
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `Arbitrary.derived[A]` | `Arbitrary[A]` | Derive via extension method on companion |
+| `DeriveArbitrary.derived[A]` | `Arbitrary[A]` | Derive via standalone object |
+| `Cogen.derived[A]` | `Cogen[A]` | Derive via extension method on companion |
+| `DeriveCogen.derived[A]` | `Cogen[A]` | Derive via standalone object |
+| `Shrink.derived[A]` | `Shrink[A]` | Derive via extension method on companion |
+| `DeriveShrink.derived[A]` | `Shrink[A]` | Derive via standalone object |
+
+No configuration class is needed -- derivation is fully automatic based on the type structure.
+
+### Supported types
+
+- **Case classes** -- generates random values for each field
+- **Sealed traits / enums** -- randomly selects a subtype
+- **Scala 3 enums** -- randomly selects an enum value
+- **Java enums** -- randomly selects an enum constant
+- **Recursive types** -- handled automatically, no `Lazy` wrappers needed
+- **Named tuples** -- supported on Scala 3
+- **Opaque types** -- supported when the underlying type has an instance
+- **Collections and Option** -- standard library instances are used
+
+## Usage examples
+
+??? example "Sealed trait with property-based testing"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
+    //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
+
+    import hearth.kindlings.scalacheckderivation.*
+    import org.scalacheck.{Arbitrary, Prop}
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val arbShape: Arbitrary[Shape] = Arbitrary.derived[Shape]
+
+    val prop = Prop.forAll { (shape: Shape) =>
+      shape match {
+        case Circle(_)       => true
+        case Rectangle(_, _) => true
+      }
+    }
+
+    prop.check()
+    // + OK, passed 100 tests.
+    ```
+
+??? example "Cogen for function generation"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
+    //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
+
+    import hearth.kindlings.scalacheckderivation.*
+    import org.scalacheck.{Arbitrary, Cogen, Gen}
+
+    case class Point(x: Int, y: Int)
+
+    // Cogen lets ScalaCheck generate functions *from* your type
+    implicit val cogenPoint: Cogen[Point] = Cogen.derived[Point]
+
+    // Now ScalaCheck can generate Point => String functions
+    val genFn: Gen[Point => String] = Arbitrary.arbitrary[Point => String]
+    val fn = genFn.sample.get
+    println(fn(Point(1, 2)))
+    ```
+
+??? example "Shrink for minimal failing cases"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
+    //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
+
+    import hearth.kindlings.scalacheckderivation.*
+    import org.scalacheck.Shrink
+
+    case class Config(retries: Int, timeout: Long, label: String)
+
+    implicit val shrinkConfig: Shrink[Config] = Shrink.derived[Config]
+
+    // Shrink produces smaller variants of a failing input
+    val original = Config(100, 5000L, "production")
+    val shrunk = Shrink.shrink(original).take(5).toList
+    shrunk.foreach(println)
+    ```
+
+??? example "Recursive data types"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-scalacheck-derivation:{{ kindlings_version() }}
+    //> using dep org.scalacheck::scalacheck:{{ libraries.scalacheck }}
+
+    import hearth.kindlings.scalacheckderivation.*
+    import org.scalacheck.Arbitrary
+
+    case class Tree(value: Int, children: List[Tree])
+
+    // No Lazy wrapper needed -- recursion is handled automatically
+    implicit val arbTree: Arbitrary[Tree] = Arbitrary.derived[Tree]
+
+    val sample = Arbitrary.arbitrary[Tree].sample.get
+    println(sample)
+    ```
+
+## Debugging
+
+Enable debug logging to see the derivation process:
+
+```scala
+import hearth.kindlings.scalacheckderivation.debug.*
+```
+
+Or via scalac option:
+
+```
+-Xmacro-settings:scalacheckDerivation.logDerivation=true
+```
+
+## Comparison with scalacheck-shapeless
+
+### Feature differences
+
+| Feature | scalacheck-shapeless | Kindlings |
+|---------|---------------------|-----------|
+| Same API on Scala 2.13 and 3 | No (Scala 2 only) | Yes |
+| Arbitrary derivation | Yes | Yes |
+| Cogen derivation | Yes | Yes |
+| Shrink derivation | No | Yes |
+| Recursive types | Needs `Lazy` wrappers | Just works |
+| Scala 3 enums | No | Yes |
+| Java enums | No | Yes |
+| Named tuples | No | Yes |
+| Opaque types | No | Yes |
+| No shapeless dependency | No | Yes |

--- a/docs/user-guide/sconfig-derivation.md
+++ b/docs/user-guide/sconfig-derivation.md
@@ -41,7 +41,7 @@ Derives `ConfigReader`, `ConfigWriter`, and `ConfigCodec` for HOCON configuratio
     //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
     //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
 
-    import hearth.kindlings.sconfigderivation.*
+    import hearth.kindlings.sconfigderivation._
     import org.ekrich.config.ConfigFactory
 
     case class DatabaseConfig(hostName: String, portNumber: Int, maxConnections: Int)
@@ -107,7 +107,7 @@ val uuidWriter: ConfigWriter[java.util.UUID] = stringWriter.contramap(_.toString
 All derivation methods accept an implicit `SConfig`. The defaults mirror PureConfig's conventions:
 
 ```scala
-import hearth.kindlings.sconfigderivation.*
+import hearth.kindlings.sconfigderivation._
 
 implicit val config: SConfig = SConfig.default
 // Equivalent to:
@@ -143,7 +143,7 @@ implicit val config: SConfig = SConfig.default
 For fine-grained control over individual types, use `ProductHint` and `CoproductHint`:
 
 ```scala
-import hearth.kindlings.sconfigderivation.*
+import hearth.kindlings.sconfigderivation._
 
 case class MyType(myField: String, otherField: Int)
 
@@ -168,7 +168,7 @@ implicit val myTypeHint: ProductHint[MyType] =
 | `@transientField` | Exclude a field from reading/writing (must have a default value) |
 
 ```scala
-import hearth.kindlings.sconfigderivation.annotations.*
+import hearth.kindlings.sconfigderivation.annotations._
 
 case class AppConfig(
   @configKey("app-name") name: String,
@@ -185,7 +185,7 @@ case class AppConfig(
     //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
     //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
 
-    import hearth.kindlings.sconfigderivation.*
+    import hearth.kindlings.sconfigderivation._
     import org.ekrich.config.ConfigFactory
 
     sealed trait DbBackend
@@ -211,7 +211,7 @@ case class AppConfig(
     //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
     //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
 
-    import hearth.kindlings.sconfigderivation.*
+    import hearth.kindlings.sconfigderivation._
     import org.ekrich.config.ConfigFactory
 
     implicit val config: SConfig = SConfig.default.withStrictDecoding
@@ -238,7 +238,7 @@ case class AppConfig(
     //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
     //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
 
-    import hearth.kindlings.sconfigderivation.*
+    import hearth.kindlings.sconfigderivation._
     import org.ekrich.config.ConfigFactory
 
     case class HttpConfig(host: String = "0.0.0.0", port: Int = 8080)
@@ -269,7 +269,7 @@ case class AppConfig(
     //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
     //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
 
-    import hearth.kindlings.sconfigderivation.*
+    import hearth.kindlings.sconfigderivation._
 
     case class AppConfig(appName: String, maxRetries: Int, debug: Boolean)
 
@@ -289,7 +289,7 @@ case class AppConfig(
 Enable debug logging to see the derivation process:
 
 ```scala
-import hearth.kindlings.sconfigderivation.debug.*
+import hearth.kindlings.sconfigderivation.debug._
 ```
 
 ## Error handling

--- a/docs/user-guide/sconfig-derivation.md
+++ b/docs/user-guide/sconfig-derivation.md
@@ -1,0 +1,335 @@
+# sconfig Derivation (HOCON)
+
+Derives `ConfigReader`, `ConfigWriter`, and `ConfigCodec` for HOCON configuration using [sconfig](https://github.com/ekrich/sconfig), a cross-platform port of Typesafe Config. Unlike PureConfig (which depends on JVM-only `com.typesafe:config`), sconfig works on JVM, Scala.js, and Scala Native.
+
+!!! tip "JVM-only projects using PureConfig?"
+    If your project is JVM-only and already uses PureConfig, see [kindlings-pureconfig-derivation](pureconfig-derivation.md) — it provides drop-in replacement instances that extend PureConfig's own `ConfigReader`/`ConfigWriter` types.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-sconfig-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-sconfig-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
+    ```
+
+!!! note
+    You also need `sconfig` as a runtime dependency:
+
+    ```scala
+    libraryDependencies += "org.ekrich" %%% "sconfig" % "{{ libraries.sconfig }}"
+    ```
+
+## Quick start
+
+??? example "Reading and writing HOCON configuration"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
+    //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
+
+    import hearth.kindlings.sconfigderivation.*
+    import org.ekrich.config.ConfigFactory
+
+    case class DatabaseConfig(hostName: String, portNumber: Int, maxConnections: Int)
+
+    // Derive a reader -- default config uses kebab-case field names
+    implicit val reader: ConfigReader[DatabaseConfig] = ConfigReader.derive[DatabaseConfig]
+
+    // Parse HOCON (kebab-case keys map to camelCase fields by default)
+    val config = ConfigFactory.parseString("""
+      host-name = "localhost"
+      port-number = 5432
+      max-connections = 10
+    """)
+
+    val result = reader.from(config.root)
+    println(result)
+    // Right(DatabaseConfig(localhost,5432,10))
+
+    // Derive a writer and convert back to HOCON
+    implicit val writer: ConfigWriter[DatabaseConfig] = ConfigWriter.derive[DatabaseConfig]
+    val configValue = writer.to(DatabaseConfig("localhost", 5432, 10))
+    println(configValue.render)
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `ConfigReader.derive[A]` | `ConfigReader[A]` | Semi-automatic reader |
+| `ConfigReader.derived[A]` | `ConfigReader[A]` | Sanely-automatic reader (given on Scala 3) |
+| `ConfigWriter.derive[A]` | `ConfigWriter[A]` | Semi-automatic writer |
+| `ConfigWriter.derived[A]` | `ConfigWriter[A]` | Sanely-automatic writer (given on Scala 3) |
+| `ConfigCodec.derive[A]` | `ConfigCodec[A]` | Semi-automatic codec (reader + writer) |
+| `ConfigCodec.derived[A]` | `ConfigCodec[A]` | Sanely-automatic codec (given on Scala 3) |
+
+All methods take an implicit/using `SConfig` parameter (defaults to `SConfig.default`).
+
+### Combinators
+
+`ConfigReader` and `ConfigWriter` provide combinators for transforming instances:
+
+```scala
+// Map the result of a reader
+val intReader: ConfigReader[Int] = ConfigReader[Int]
+val positiveReader: ConfigReader[Int] = intReader.emap { i =>
+  if (i > 0) Right(i)
+  else Left(s"Expected positive number, got $i")
+}
+
+// Contramap a writer
+val stringWriter: ConfigWriter[String] = ConfigWriter[String]
+val uuidWriter: ConfigWriter[java.util.UUID] = stringWriter.contramap(_.toString)
+```
+
+### Type hierarchy
+
+`ConfigReader[A]`, `ConfigWriter[A]`, and `ConfigCodec[A]` are all defined by the kindlings sconfig module. `ConfigCodec[A]` extends both `ConfigReader[A]` and `ConfigWriter[A]`.
+
+## Configuration
+
+All derivation methods accept an implicit `SConfig`. The defaults mirror PureConfig's conventions:
+
+```scala
+import hearth.kindlings.sconfigderivation.*
+
+implicit val config: SConfig = SConfig.default
+// Equivalent to:
+// SConfig(
+//   transformMemberNames   = ConfigFieldMapping(CamelCase, KebabCase),  // myField -> my-field
+//   transformConstructorNames = ConfigFieldMapping(PascalCase, KebabCase), // MyType -> my-type
+//   discriminator          = Some("type"),
+//   useDefaults            = true,
+//   allowUnknownKeys       = true
+// )
+```
+
+| Builder method | Description |
+|---------------|-------------|
+| `withSnakeCaseMemberNames` | `fieldName` -> `field_name` |
+| `withKebabCaseMemberNames` | `fieldName` -> `field-name` (default) |
+| `withPascalCaseMemberNames` | `fieldName` -> `FieldName` |
+| `withScreamingSnakeCaseMemberNames` | `fieldName` -> `FIELD_NAME` |
+| `withCamelCaseMemberNames` | `fieldName` -> `fieldName` (identity) |
+| `withTransformMemberNames(f)` | Custom field name transform |
+| `withSnakeCaseConstructorNames` | `MyType` -> `my_type` in discriminator |
+| `withKebabCaseConstructorNames` | `MyType` -> `my-type` in discriminator (default) |
+| `withTransformConstructorNames(f)` | Custom constructor name transform |
+| `withDiscriminator(field)` | ADT discriminator field name (default: `"type"`) |
+| `withWrappedSubtypes` | No discriminator -- use single-key wrapping instead |
+| `withUseDefaults` | Use case class default values for missing keys (default) |
+| `withoutUseDefaults` | Require all keys |
+| `withAllowUnknownKeys` | Ignore unexpected HOCON keys (default) |
+| `withStrictDecoding` | Fail on unexpected HOCON keys |
+
+### Per-type hints
+
+For fine-grained control over individual types, use `ProductHint` and `CoproductHint`:
+
+```scala
+import hearth.kindlings.sconfigderivation.*
+
+case class MyType(myField: String, otherField: Int)
+
+// Override naming for just this type
+implicit val myTypeHint: ProductHint[MyType] =
+  ProductHint[MyType](transformMemberNames = ConfigFieldMapping(CamelCase, SnakeCase))
+```
+
+`CoproductHint` controls sealed trait encoding strategy:
+
+| Hint | Description |
+|------|-------------|
+| `CoproductHint.Field[A](fieldName, transform)` | Discriminator-based (default) |
+| `CoproductHint.Wrapped[A](transform)` | Single-key wrapping: `{"variant-name": {...}}` |
+| `CoproductHint.FirstSuccess[A]()` | Try every subtype reader in order |
+
+## Annotations
+
+| Annotation | Description |
+|-----------|-------------|
+| `@configKey("hocon_key")` | Override HOCON key for a case class field |
+| `@transientField` | Exclude a field from reading/writing (must have a default value) |
+
+```scala
+import hearth.kindlings.sconfigderivation.annotations.*
+
+case class AppConfig(
+  @configKey("app-name") name: String,
+  @transientField internalId: Long = 0L
+)
+```
+
+## Usage examples
+
+??? example "Sealed trait with discriminator"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
+    //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
+
+    import hearth.kindlings.sconfigderivation.*
+    import org.ekrich.config.ConfigFactory
+
+    sealed trait DbBackend
+    case class Postgres(host: String, port: Int) extends DbBackend
+    case class Sqlite(path: String) extends DbBackend
+
+    implicit val reader: ConfigReader[DbBackend] = ConfigReader.derive[DbBackend]
+
+    val config = ConfigFactory.parseString("""
+      type = "postgres"
+      host = "localhost"
+      port = 5432
+    """)
+
+    println(reader.from(config.root))
+    // Right(Postgres(localhost,5432))
+    ```
+
+??? example "Strict decoding and unknown key rejection"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
+    //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
+
+    import hearth.kindlings.sconfigderivation.*
+    import org.ekrich.config.ConfigFactory
+
+    implicit val config: SConfig = SConfig.default.withStrictDecoding
+
+    case class Server(host: String, port: Int)
+
+    implicit val reader: ConfigReader[Server] = ConfigReader.derive[Server]
+
+    // This will fail -- "debug" is not a field of Server
+    val result = reader.from(ConfigFactory.parseString("""
+      host = "localhost"
+      port = 8080
+      debug = true
+    """).root)
+
+    println(result)
+    // Left(Unknown key 'debug')
+    ```
+
+??? example "Nested configuration with defaults"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
+    //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
+
+    import hearth.kindlings.sconfigderivation.*
+    import org.ekrich.config.ConfigFactory
+
+    case class HttpConfig(host: String = "0.0.0.0", port: Int = 8080)
+    case class DbConfig(url: String, poolSize: Int = 10)
+    case class AppConfig(http: HttpConfig, db: DbConfig)
+
+    implicit val httpReader: ConfigReader[HttpConfig] = ConfigReader.derive[HttpConfig]
+    implicit val dbReader: ConfigReader[DbConfig] = ConfigReader.derive[DbConfig]
+    implicit val appReader: ConfigReader[AppConfig] = ConfigReader.derive[AppConfig]
+
+    val result = appReader.from(ConfigFactory.parseString("""
+      http {
+        port = 9090
+      }
+      db {
+        url = "jdbc:postgresql://localhost/mydb"
+      }
+    """).root)
+
+    println(result)
+    // Right(AppConfig(HttpConfig(0.0.0.0,9090),DbConfig(jdbc:postgresql://localhost/mydb,10)))
+    ```
+
+??? example "Writing configuration back to HOCON"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-sconfig-derivation:{{ kindlings_version() }}
+    //> using dep org.ekrich::sconfig:{{ libraries.sconfig }}
+
+    import hearth.kindlings.sconfigderivation.*
+
+    case class AppConfig(appName: String, maxRetries: Int, debug: Boolean)
+
+    implicit val writer: ConfigWriter[AppConfig] = ConfigWriter.derive[AppConfig]
+
+    val configValue = writer.to(AppConfig("my-app", 3, false))
+    println(configValue.render)
+    // {
+    //     "app-name" : "my-app",
+    //     "debug" : false,
+    //     "max-retries" : 3
+    // }
+    ```
+
+## Debugging
+
+Enable debug logging to see the derivation process:
+
+```scala
+import hearth.kindlings.sconfigderivation.debug.*
+```
+
+## Error handling
+
+`ConfigReader` returns `Either[ConfigDecodingError, A]` with structured errors:
+
+| Error type | Description |
+|-----------|-------------|
+| `ConfigDecodingError.Missing` | Required key is missing |
+| `ConfigDecodingError.WrongType` | Value has unexpected HOCON type |
+| `ConfigDecodingError.CannotConvert` | Value cannot be converted to target type |
+| `ConfigDecodingError.UnknownKey` | Unexpected key when `withStrictDecoding` is active |
+| `ConfigDecodingError.Multiple` | Aggregation of multiple errors |
+
+All errors carry a `path` for pinpointing the offending field:
+
+```scala
+val error: ConfigDecodingError = result.left.get
+println(error.getMessage)
+// Missing required key 'host' (at db.host)
+```
+
+## Comparison with PureConfig
+
+### Feature differences
+
+| Feature | PureConfig | Kindlings sconfig |
+|---------|-----------|-------------------|
+| Same API on Scala 2.13 and 3 | No (different modules, different APIs) | Yes |
+| Cross-platform (JS / Native) | No (JVM-only, depends on `com.typesafe:config`) | Yes (via sconfig) |
+| Kebab-case field names by default | Yes | Yes |
+| Discriminator-based ADTs | Yes | Yes (default: `"type"` field) |
+| Wrapped subtypes | Yes | Yes (`withWrappedSubtypes`) |
+| First-success coproduct hint | Yes | Yes (`CoproductHint.FirstSuccess`) |
+| Per-type `ProductHint` / `CoproductHint` | Yes | Yes |
+| Strict decoding | Yes | Yes (`withStrictDecoding`) |
+| Default values | Yes | Yes (enabled by default) |
+| `@ConfiguredJsonCodec`-style annotation | No | No |
+| Recursive types | Needs workarounds | Just works |
+| Named tuples | No | Yes |
+| Opaque types | No | Yes |
+| Scala 3 enums | Partial | Yes |
+| Java enums | Partial | Yes |

--- a/docs/user-guide/tapir-schema-derivation.md
+++ b/docs/user-guide/tapir-schema-derivation.md
@@ -38,7 +38,7 @@ Drop-in replacement for Tapir's built-in `Schema.derived` -- derives `Schema[A]`
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
-    import hearth.kindlings.tapirschemaderivation.*
+    import hearth.kindlings.tapirschemaderivation._
     import sttp.tapir.Schema
 
     case class Person(name: String, age: Int)
@@ -77,7 +77,7 @@ If both Circe and Jsoniter configurations are on the classpath, the macro finds 
 
 ```scala
 import hearth.kindlings.circederivation.Configuration
-import hearth.kindlings.tapirschemaderivation.*
+import hearth.kindlings.tapirschemaderivation._
 
 implicit val preferCirce: PreferSchemaConfig[Configuration] = PreferSchemaConfig[Configuration]
 ```
@@ -98,7 +98,7 @@ implicit val preferCirce: PreferSchemaConfig[Configuration] = PreferSchemaConfig
 | `@hidden` | Field | Hide field from the schema |
 
 ```scala
-import sttp.tapir.Schema.annotations.*
+import sttp.tapir.Schema.annotations._
 import sttp.tapir.Validator
 
 @description("A user account")
@@ -119,7 +119,7 @@ case class User(
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
-    import hearth.kindlings.tapirschemaderivation.*
+    import hearth.kindlings.tapirschemaderivation._
     import sttp.tapir.Schema
 
     sealed trait Shape
@@ -138,9 +138,9 @@ case class User(
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
-    import hearth.kindlings.tapirschemaderivation.*
+    import hearth.kindlings.tapirschemaderivation._
     import sttp.tapir.Schema
-    import sttp.tapir.Schema.annotations.*
+    import sttp.tapir.Schema.annotations._
     import sttp.tapir.Validator
 
     @description("A person with metadata")
@@ -158,8 +158,8 @@ case class User(
 ??? example "Schema with JSON config discovery"
 
     ```scala
-    import hearth.kindlings.circederivation.*
-    import hearth.kindlings.tapirschemaderivation.*
+    import hearth.kindlings.circederivation._
+    import hearth.kindlings.tapirschemaderivation._
     import sttp.tapir.Schema
 
     // Circe configuration with snake_case
@@ -180,7 +180,7 @@ case class User(
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
-    import hearth.kindlings.tapirschemaderivation.*
+    import hearth.kindlings.tapirschemaderivation._
     import sttp.tapir.Schema
 
     case class TreeNode(value: Int, children: List[TreeNode])
@@ -196,7 +196,7 @@ case class User(
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
-    import hearth.kindlings.tapirschemaderivation.*
+    import hearth.kindlings.tapirschemaderivation._
     import sttp.tapir.Schema
 
     case class Box[A](value: A)
@@ -213,7 +213,7 @@ case class User(
 Import the debug package to log the derivation process at compile time:
 
 ```scala
-import hearth.kindlings.tapirschemaderivation.debug.*
+import hearth.kindlings.tapirschemaderivation.debug._
 ```
 
 This enables the `LogDerivation` implicit for `KindlingsSchema`, printing the derivation steps to the compiler output.

--- a/docs/user-guide/tapir-schema-derivation.md
+++ b/docs/user-guide/tapir-schema-derivation.md
@@ -1,0 +1,246 @@
+# Tapir Schema Derivation
+
+Drop-in replacement for Tapir's built-in `Schema.derived` -- derives `Schema[A]` for case classes, sealed traits, Scala 3 enums, Java enums, and more.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-tapir-schema-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-tapir-schema-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    You also need `tapir-core`:
+
+    ```scala
+    libraryDependencies += "com.softwaremill.sttp.tapir" %%% "tapir-core" % "{{ libraries.tapir }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
+    ```
+
+## Quick start
+
+??? example "Deriving Schema for a case class"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
+
+    import hearth.kindlings.tapirschemaderivation.*
+    import sttp.tapir.Schema
+
+    case class Person(name: String, age: Int)
+
+    // Semi-automatic
+    val schema: Schema[Person] = KindlingsSchema.derive[Person]
+    println(schema.name)
+    // Some(SName(Person,List()))
+    println(schema.schemaType)
+    // SProduct(List(SProductField(FieldName(name,name),Schema(...),...),...))
+
+    // Sanely-automatic — resolved by the compiler
+    implicitly[Schema[Person]]
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `KindlingsSchema.derive[A]` | `Schema[A]` | Semi-automatic schema derivation |
+| `KindlingsSchema.derived[A]` | `KindlingsSchema[A]` | Sanely-automatic (given/implicit) |
+
+Unlike other Kindlings modules, Tapir Schema derivation takes **no configuration parameter**. Instead, it automatically discovers JSON configuration from sibling modules (see below).
+
+### Automatic JSON configuration discovery
+
+When `kindlings-circe-derivation` or `kindlings-jsoniter-derivation` is on the classpath, `KindlingsSchema` reads their configuration at compile time and applies the same field name transforms. This means your **schema matches your codecs by design** — the API documentation (OpenAPI / Swagger) always reflects the actual JSON payloads, without maintaining a separate configuration.
+
+For example, if your Circe `Configuration` uses `withSnakeCaseMemberNames`, the generated Tapir schema will also use `snake_case` field names — no additional configuration needed, no risk of drift.
+
+#### Disambiguating multiple JSON configs
+
+If both Circe and Jsoniter configurations are on the classpath, the macro finds multiple configs and fails. Import an implicit `PreferSchemaConfig` to tell the macro which one to use:
+
+```scala
+import hearth.kindlings.circederivation.Configuration
+import hearth.kindlings.tapirschemaderivation.*
+
+implicit val preferCirce: PreferSchemaConfig[Configuration] = PreferSchemaConfig[Configuration]
+```
+
+## Tapir annotations
+
+`KindlingsSchema` supports Tapir's standard annotations from `sttp.tapir.Schema.annotations`:
+
+| Annotation | Target | Description |
+|-----------|--------|-------------|
+| `@description("text")` | Type, Field | Add OpenAPI description |
+| `@title("text")` | Type | Set the schema title |
+| `@encodedName("name")` | Field | Override the encoded field name |
+| `@format("fmt")` | Field | Set the schema format (e.g. `"int32"`, `"email"`) |
+| `@validate(validator)` | Field | Add a field validator |
+| `@default(value)` | Field | Set the default value |
+| `@deprecated` | Type | Mark schema as deprecated |
+| `@hidden` | Field | Hide field from the schema |
+
+```scala
+import sttp.tapir.Schema.annotations.*
+import sttp.tapir.Validator
+
+@description("A user account")
+@title("User")
+case class User(
+  @description("The username") name: String,
+  @format("int32") @validate(Validator.min(0)) age: Int,
+  @hidden internalId: Long
+)
+```
+
+## Usage examples
+
+??? example "Sealed trait schema"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
+
+    import hearth.kindlings.tapirschemaderivation.*
+    import sttp.tapir.Schema
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    val schema: Schema[Shape] = KindlingsSchema.derive[Shape]
+    println(schema.name)
+    // Some(SName(Shape,List()))
+    ```
+
+??? example "Schema with Tapir annotations"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
+
+    import hearth.kindlings.tapirschemaderivation.*
+    import sttp.tapir.Schema
+    import sttp.tapir.Schema.annotations.*
+    import sttp.tapir.Validator
+
+    @description("A person with metadata")
+    @title("PersonMeta")
+    case class AnnotatedPerson(
+      @description("The name") name: String,
+      @format("int32") age: Int
+    )
+
+    val schema: Schema[AnnotatedPerson] = KindlingsSchema.derive[AnnotatedPerson]
+    println(schema.description)
+    // Some(A person with metadata)
+    ```
+
+??? example "Schema with JSON config discovery"
+
+    ```scala
+    import hearth.kindlings.circederivation.*
+    import hearth.kindlings.tapirschemaderivation.*
+    import sttp.tapir.Schema
+
+    // Circe configuration with snake_case
+    implicit val circeConfig: Configuration = Configuration.default
+      .withSnakeCaseMemberNames
+
+    case class UserProfile(firstName: String, lastName: String)
+
+    // Schema automatically picks up snake_case from Circe config
+    val schema: Schema[UserProfile] = KindlingsSchema.derive[UserProfile]
+    // Field names: first_name, last_name (matching JSON encoding)
+    ```
+
+??? example "Recursive data types"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
+
+    import hearth.kindlings.tapirschemaderivation.*
+    import sttp.tapir.Schema
+
+    case class TreeNode(value: Int, children: List[TreeNode])
+
+    // Recursive types work out of the box — uses schema references
+    val schema: Schema[TreeNode] = KindlingsSchema.derive[TreeNode]
+    ```
+
+??? example "Generic types"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
+
+    import hearth.kindlings.tapirschemaderivation.*
+    import sttp.tapir.Schema
+
+    case class Box[A](value: A)
+    case class Person(name: String, age: Int)
+
+    implicit val personSchema: Schema[Person] = KindlingsSchema.derive[Person]
+    val boxSchema: Schema[Box[Person]] = KindlingsSchema.derive[Box[Person]]
+    println(boxSchema.name)
+    // Some(SName(Box,List(Person)))
+    ```
+
+## Debugging
+
+Import the debug package to log the derivation process at compile time:
+
+```scala
+import hearth.kindlings.tapirschemaderivation.debug.*
+```
+
+This enables the `LogDerivation` implicit for `KindlingsSchema`, printing the derivation steps to the compiler output.
+
+## Comparison with Tapir built-in
+
+### Feature differences
+
+| Feature | Tapir built-in (`Schema.derived`) | Kindlings |
+|---------|----------------------------------|-----------|
+| Scala 2.13 support | No (Scala 3 Mirrors only) | Yes |
+| Same API on Scala 2.13 and 3 | No | Yes |
+| Sanely-automatic derivation | No | Yes |
+| Recursive types | Manual `implicit lazy val` | Just works |
+| Named tuples | No | Yes |
+| Opaque types | No | Yes |
+| Java enums | Partial | Yes |
+| Automatic JSON config discovery | No | Yes |
+| Tapir annotation support | Yes | Yes |
+| Value types (`AnyVal`) | Yes | Yes |
+
+### Benchmarks
+
+Tapir Schema derivation generates a runtime `Schema[A]` value. At runtime, accessing the schema is just a field read, so there is no meaningful performance difference between implementations:
+
+| Benchmark | Kindlings | Tapir built-in |
+|-----------|-----------|---------------|
+| Schema field access | ~3.7B ops/s | ~3.7B ops/s |
+
+The performance is identical because both approaches produce the same runtime representation -- the work is done entirely at compile time.

--- a/docs/user-guide/tapir-schema-derivation.md
+++ b/docs/user-guide/tapir-schema-derivation.md
@@ -26,6 +26,7 @@ Drop-in replacement for Tapir's built-in `Schema.derived` -- derives `Schema[A]`
 
     ```scala
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
     ```
 
@@ -36,9 +37,11 @@ Drop-in replacement for Tapir's built-in `Schema.derived` -- derives `Schema[A]`
     ```scala
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
     import hearth.kindlings.tapirschemaderivation._
+    import hearth.kindlings.circederivation._
     import sttp.tapir.Schema
 
     case class Person(name: String, age: Int)
@@ -49,9 +52,6 @@ Drop-in replacement for Tapir's built-in `Schema.derived` -- derives `Schema[A]`
     // Some(SName(Person,List()))
     println(schema.schemaType)
     // SProduct(List(SProductField(FieldName(name,name),Schema(...),...),...))
-
-    // Sanely-automatic — resolved by the compiler
-    implicitly[Schema[Person]]
     ```
 
 ## API
@@ -78,6 +78,7 @@ If both Circe and Jsoniter configurations are on the classpath, the macro finds 
 ```scala
 import hearth.kindlings.circederivation.Configuration
 import hearth.kindlings.tapirschemaderivation._
+import hearth.kindlings.circederivation._
 
 implicit val preferCirce: PreferSchemaConfig[Configuration] = PreferSchemaConfig[Configuration]
 ```
@@ -117,9 +118,11 @@ case class User(
     ```scala
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
     import hearth.kindlings.tapirschemaderivation._
+    import hearth.kindlings.circederivation._
     import sttp.tapir.Schema
 
     sealed trait Shape
@@ -136,9 +139,11 @@ case class User(
     ```scala
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
     import hearth.kindlings.tapirschemaderivation._
+    import hearth.kindlings.circederivation._
     import sttp.tapir.Schema
     import sttp.tapir.Schema.annotations._
     import sttp.tapir.Validator
@@ -178,9 +183,11 @@ case class User(
     ```scala
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
     import hearth.kindlings.tapirschemaderivation._
+    import hearth.kindlings.circederivation._
     import sttp.tapir.Schema
 
     case class TreeNode(value: Int, children: List[TreeNode])
@@ -194,16 +201,22 @@ case class User(
     ```scala
     //> using scala {{ scala.2_13 }}
     //> using dep com.kubuszok::kindlings-tapir-schema-derivation:{{ kindlings_version() }}
+    //> using dep com.kubuszok::kindlings-circe-derivation:{{ kindlings_version() }}
     //> using dep com.softwaremill.sttp.tapir::tapir-core:{{ libraries.tapir }}
 
     import hearth.kindlings.tapirschemaderivation._
+    import hearth.kindlings.circederivation._
     import sttp.tapir.Schema
 
     case class Box[A](value: A)
     case class Person(name: String, age: Int)
 
     implicit val personSchema: Schema[Person] = KindlingsSchema.derive[Person]
-    val boxSchema: Schema[Box[Person]] = KindlingsSchema.derive[Box[Person]]
+    println(personSchema.name)
+    // Some(SName(Person,List()))
+
+    // Box[Person] picks up the Person schema via implicit
+    lazy val boxSchema: Schema[Box[Person]] = KindlingsSchema.derive[Box[Person]]
     println(boxSchema.name)
     // Some(SName(Box,List(Person)))
     ```

--- a/docs/user-guide/ubjson-derivation.md
+++ b/docs/user-guide/ubjson-derivation.md
@@ -1,0 +1,199 @@
+# UBJson Derivation
+
+Original module -- derives `UBJsonValueCodec` for case classes, sealed traits, Scala 3 enums, Java enums, and more. [UBJson](https://ubjson.org/) is a binary JSON format with the same data model as JSON but more compact wire representation.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-ubjson-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-ubjson-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-ubjson-derivation:{{ kindlings_version() }}
+    ```
+
+## Quick start
+
+??? example "Deriving a codec for a case class"
+
+    ```scala
+    import hearth.kindlings.ubjsonderivation.*
+
+    case class Person(name: String, age: Int)
+
+    // Semi-automatic
+    val codec: UBJsonValueCodec[Person] = UBJsonValueCodec.derive[Person]
+
+    // Sanely-automatic (given/implicit resolved by the compiler)
+    // UBJsonValueCodec.derived[Person] is resolved automatically
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `UBJsonValueCodec.derive[A]` | `UBJsonValueCodec[A]` | Semi-automatic codec |
+| `UBJsonValueCodec.derived[A]` | `UBJsonValueCodec[A]` | Sanely-automatic (given/implicit) |
+
+All methods take an implicit/using `UBJsonConfig` parameter (defaults to `UBJsonConfig.default`).
+
+### Type class interface
+
+`UBJsonValueCodec[A]` provides three members:
+
+| Member | Signature | Description |
+|--------|-----------|-------------|
+| `decode` | `(reader: UBJsonReader): A` | Decode a value from a UBJson reader |
+| `encode` | `(writer: UBJsonWriter, value: A): Unit` | Encode a value to a UBJson writer |
+| `nullValue` | `A` | The null/default value for type `A` |
+
+### Extension methods
+
+Import `UBJsonValueCodecExtensions._` for extra combinators on codec instances:
+
+| Method | Description |
+|--------|-------------|
+| `codec.map[B](f)(g)` | Transform decoded values with `f`, encoded values with `g` |
+| `codec.mapDecode[B](f)(g)` | Like `map` but `f` returns `Either[String, B]` for validation |
+
+## Configuration
+
+```scala
+import hearth.kindlings.ubjsonderivation.*
+
+implicit val config: UBJsonConfig = UBJsonConfig.default
+  .withSnakeCaseFieldNames
+  .withDiscriminator("type")
+  .withTransientNone
+```
+
+| Builder method | Description |
+|---------------|-------------|
+| `withSnakeCaseFieldNames` | `fieldName` -> `field_name` |
+| `withKebabCaseFieldNames` | `fieldName` -> `field-name` |
+| `withPascalCaseFieldNames` | `fieldName` -> `FieldName` |
+| `withScreamingSnakeCaseFieldNames` | `fieldName` -> `FIELD_NAME` |
+| `withFieldNameMapper(f)` | Custom field name transform |
+| `withSnakeCaseAdtLeafClassNames` | ADT subtype name -> `snake_case` |
+| `withKebabCaseAdtLeafClassNames` | ADT subtype name -> `kebab-case` |
+| `withAdtLeafClassNameMapper(f)` | Custom ADT subtype name transform |
+| `withDiscriminator(field)` | ADT discriminator field name |
+| `withSkipUnexpectedFields(skip)` | Skip unexpected fields during decoding |
+| `withEnumAsStrings` | Encode Scala 3 / Java enums as strings |
+| `withTransientDefault` | Skip fields with default values during encoding |
+| `withTransientEmpty` | Skip empty collections during encoding |
+| `withTransientNone` | Skip `None` fields during encoding |
+| `withRequireCollectionFields` | Fail if collection field is missing |
+| `withRequireDefaultFields` | Fail if field with default is missing |
+| `withCheckFieldDuplication` | Fail on duplicate field names |
+| `withBigDecimalPrecision(n)` | Max BigDecimal precision (default: 34) |
+| `withBigDecimalScaleLimit(n)` | Max BigDecimal scale (default: 6178) |
+| `withBigDecimalDigitsLimit(n)` | Max BigDecimal digits (default: 308) |
+| `withMapMaxInsertNumber(n)` | Max map entries (DoS protection) |
+| `withSetMaxInsertNumber(n)` | Max set entries (DoS protection) |
+
+## Annotations
+
+| Annotation | Package | Description |
+|-----------|---------|-------------|
+| `@fieldName("name")` | `hearth.kindlings.ubjsonderivation.annotations` | Override the UBJson field name |
+| `@transientField` | `hearth.kindlings.ubjsonderivation.annotations` | Exclude field from codec (must have default) |
+| `@stringified` | `hearth.kindlings.ubjsonderivation.annotations` | Encode numeric/boolean field as a string |
+
+```scala
+import hearth.kindlings.ubjsonderivation.annotations.*
+
+case class User(
+  @fieldName("user_name") name: String,
+  @transientField cache: Option[String] = None
+)
+```
+
+## Usage examples
+
+??? example "Sealed trait with discriminator"
+
+    ```scala
+    import hearth.kindlings.ubjsonderivation.*
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val config: UBJsonConfig = UBJsonConfig.default
+      .withDiscriminator("type")
+
+    val codec: UBJsonValueCodec[Shape] = UBJsonValueCodec.derive[Shape]
+    ```
+
+??? example "Transient fields and defaults"
+
+    ```scala
+    import hearth.kindlings.ubjsonderivation.*
+
+    implicit val config: UBJsonConfig = UBJsonConfig.default
+      .withTransientDefault
+      .withTransientNone
+
+    case class Settings(
+      host: String,
+      port: Int = 8080,
+      debug: Option[Boolean] = None
+    )
+
+    val codec: UBJsonValueCodec[Settings] = UBJsonValueCodec.derive[Settings]
+    // Default and None fields are omitted during encoding
+    // Missing fields use defaults during decoding
+    ```
+
+??? example "Recursive data types"
+
+    ```scala
+    import hearth.kindlings.ubjsonderivation.*
+
+    case class TreeNode(value: Int, children: List[TreeNode])
+
+    // Recursive types just work -- no special setup needed
+    val codec: UBJsonValueCodec[TreeNode] = UBJsonValueCodec.derive[TreeNode]
+    ```
+
+??? example "Field name mapping"
+
+    ```scala
+    import hearth.kindlings.ubjsonderivation.*
+
+    implicit val config: UBJsonConfig = UBJsonConfig.default
+      .withSnakeCaseFieldNames
+
+    case class UserProfile(firstName: String, lastName: String, emailAddress: String)
+
+    val codec: UBJsonValueCodec[UserProfile] = UBJsonValueCodec.derive[UserProfile]
+    // Fields encoded as: first_name, last_name, email_address
+    ```
+
+## Debugging
+
+Import the debug package to log the generated codec during compilation:
+
+```scala
+import hearth.kindlings.ubjsonderivation.debug._
+```
+
+Or enable project-wide via scalac option:
+
+```scala
+// build.sbt
+scalacOptions += "-Xmacro-settings:ubjsonDerivation.logDerivation=true"
+```

--- a/docs/user-guide/ubjson-derivation.md
+++ b/docs/user-guide/ubjson-derivation.md
@@ -27,7 +27,7 @@ Original module -- derives `UBJsonValueCodec` for case classes, sealed traits, S
 ??? example "Deriving a codec for a case class"
 
     ```scala
-    import hearth.kindlings.ubjsonderivation.*
+    import hearth.kindlings.ubjsonderivation._
 
     case class Person(name: String, age: Int)
 
@@ -71,7 +71,7 @@ Import `UBJsonValueCodecExtensions._` for extra combinators on codec instances:
 ## Configuration
 
 ```scala
-import hearth.kindlings.ubjsonderivation.*
+import hearth.kindlings.ubjsonderivation._
 
 implicit val config: UBJsonConfig = UBJsonConfig.default
   .withSnakeCaseFieldNames
@@ -113,7 +113,7 @@ implicit val config: UBJsonConfig = UBJsonConfig.default
 | `@stringified` | `hearth.kindlings.ubjsonderivation.annotations` | Encode numeric/boolean field as a string |
 
 ```scala
-import hearth.kindlings.ubjsonderivation.annotations.*
+import hearth.kindlings.ubjsonderivation.annotations._
 
 case class User(
   @fieldName("user_name") name: String,
@@ -126,7 +126,7 @@ case class User(
 ??? example "Sealed trait with discriminator"
 
     ```scala
-    import hearth.kindlings.ubjsonderivation.*
+    import hearth.kindlings.ubjsonderivation._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -141,7 +141,7 @@ case class User(
 ??? example "Transient fields and defaults"
 
     ```scala
-    import hearth.kindlings.ubjsonderivation.*
+    import hearth.kindlings.ubjsonderivation._
 
     implicit val config: UBJsonConfig = UBJsonConfig.default
       .withTransientDefault
@@ -161,7 +161,7 @@ case class User(
 ??? example "Recursive data types"
 
     ```scala
-    import hearth.kindlings.ubjsonderivation.*
+    import hearth.kindlings.ubjsonderivation._
 
     case class TreeNode(value: Int, children: List[TreeNode])
 
@@ -172,7 +172,7 @@ case class User(
 ??? example "Field name mapping"
 
     ```scala
-    import hearth.kindlings.ubjsonderivation.*
+    import hearth.kindlings.ubjsonderivation._
 
     implicit val config: UBJsonConfig = UBJsonConfig.default
       .withSnakeCaseFieldNames

--- a/docs/user-guide/xml-derivation.md
+++ b/docs/user-guide/xml-derivation.md
@@ -1,0 +1,310 @@
+# XML Derivation
+
+Original module -- derives `XmlEncoder`, `XmlDecoder`, and `XmlCodec` for case classes, sealed traits, Scala 3 enums, and more. Supports XML attributes, elements, text content, and wrapper elements via annotations.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-xml-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-xml-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    You also need `scala-xml` and `scala-sax-parser` as runtime dependencies:
+
+    ```scala
+    libraryDependencies ++= Seq(
+      "org.scala-lang.modules" %%% "scala-xml" % "{{ libraries.scalaXml }}",
+      "com.kubuszok" %%% "scala-sax-parser" % "{{ libraries.scalaSaxParser }}"
+    )
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-xml-derivation:{{ kindlings_version() }}
+    //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
+    //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
+    ```
+
+## Quick start
+
+??? example "Encoding and decoding a case class with attributes"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-xml-derivation:{{ kindlings_version() }}
+    //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
+    //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
+
+    import hearth.kindlings.xmlderivation.*
+    import hearth.kindlings.xmlderivation.annotations.*
+
+    case class Book(
+      @xmlAttribute isbn: String,
+      title: String,
+      author: String
+    )
+
+    // Semi-automatic encoding
+    val encoder: XmlEncoder[Book] = KindlingsXmlEncoder.derive[Book]
+    val book = Book("978-0-13-468599-1", "The Scala Cookbook", "Alvin Alexander")
+    val xml: scala.xml.Elem = encoder.encode(book, "book")
+    println(xml)
+    // <book isbn="978-0-13-468599-1"><title>The Scala Cookbook</title><author>Alvin Alexander</author></book>
+
+    // Semi-automatic decoding
+    val decoder: XmlDecoder[Book] = KindlingsXmlDecoder.derive[Book]
+    println(decoder.decode(xml))
+    // Right(Book(978-0-13-468599-1,The Scala Cookbook,Alvin Alexander))
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `KindlingsXmlEncoder.derive[A]` | `XmlEncoder[A]` | Semi-automatic encoder |
+| `KindlingsXmlEncoder.encode[A](value, elementName)` | `scala.xml.Elem` | Inline encoding (no instance allocation) |
+| `KindlingsXmlEncoder.toXmlString[A](value, elementName)` | `String` | Inline encoding to string |
+| `KindlingsXmlEncoder.derived[A]` | `KindlingsXmlEncoder[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsXmlDecoder.derive[A]` | `XmlDecoder[A]` | Semi-automatic decoder |
+| `KindlingsXmlDecoder.decode[A](elem)` | `Either[XmlDecodingError, A]` | Inline decoding |
+| `KindlingsXmlDecoder.fromXmlString[A](xml)` | `Either[XmlDecodingError, A]` | Inline decoding from string |
+| `KindlingsXmlDecoder.derived[A]` | `KindlingsXmlDecoder[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsXmlCodec.derive[A]` | `KindlingsXmlCodec[A]` | Semi-automatic codec (encoder + decoder) |
+| `KindlingsXmlCodec.derived[A]` | `KindlingsXmlCodec[A]` | Sanely-automatic codec |
+
+All methods take an implicit/using `XmlConfig` parameter (defaults to `XmlConfig.default`).
+
+### Type hierarchy
+
+`KindlingsXmlEncoder[A]` extends `XmlEncoder[A]` and `KindlingsXmlDecoder[A]` extends `XmlDecoder[A]`, so derived instances work anywhere the base types are expected. `KindlingsXmlCodec[A]` extends both `XmlEncoder[A]` and `XmlDecoder[A]`.
+
+### Syntax extensions (Scala 3)
+
+Import `hearth.kindlings.xmlderivation.syntax.*` for extension methods:
+
+| Extension | Description |
+|-----------|-------------|
+| `value.toXmlString(elementName)` | Inline encode any value to XML string |
+| `xmlString.fromXmlString[A]` | Inline decode XML string to `Either[XmlDecodingError, A]` |
+
+### Error types
+
+`XmlDecodingError` is a sealed hierarchy with these subtypes:
+
+| Error type | Description |
+|-----------|-------------|
+| `MissingAttribute` | Required XML attribute not found |
+| `MissingElement` | Required child element not found |
+| `InvalidValue` | Value could not be parsed as the expected type |
+| `UnexpectedElement` | Unknown child element encountered |
+| `MissingContent` | Expected text content not found |
+| `UnknownDiscriminator` | ADT discriminator value not recognized |
+| `MissingDiscriminator` | ADT discriminator attribute not found |
+| `Multiple` | Aggregation of multiple decoding errors |
+| `General` | Generic error message |
+
+## Configuration
+
+```scala
+import hearth.kindlings.xmlderivation.*
+
+implicit val config: XmlConfig = XmlConfig.default
+  .withAttributesByDefault
+  .withSnakeCaseFieldNames
+  .withDiscriminator("kind")
+```
+
+| Builder method | Description |
+|---------------|-------------|
+| `withAttributesByDefault` | Encode fields as XML attributes by default |
+| `withElementsByDefault` | Encode fields as XML child elements by default (this is the default) |
+| `withFieldNameMapper(f)` | Custom field name transform |
+| `withConstructorNameMapper(f)` | Custom constructor name transform (for ADT discrimination) |
+| `withSnakeCaseFieldNames` | `fieldName` -> `field_name` |
+| `withKebabCaseFieldNames` | `fieldName` -> `field-name` |
+| `withPascalCaseFieldNames` | `fieldName` -> `FieldName` |
+| `withScreamingSnakeCaseFieldNames` | `fieldName` -> `FIELD_NAME` |
+| `withSnakeCaseConstructorNames` | `MyType` -> `my_type` in discriminator |
+| `withKebabCaseConstructorNames` | `MyType` -> `my-type` in discriminator |
+| `withDiscriminator(attr)` | ADT discriminator attribute name (default: `"type"`) |
+| `withNoDiscriminator` | Disable discriminator (use wrapper element for ADTs) |
+| `withEnumAsStrings` | Encode Scala 3 / Java enums as strings |
+| `withUseDefaults` | Use case class default values for missing fields |
+| `withTransientNone` | Skip `None` fields during encoding |
+| `withTransientEmpty` | Skip empty collections during encoding |
+
+## Annotations
+
+| Annotation | Package | Description |
+|-----------|---------|-------------|
+| `@xmlAttribute` | `hearth.kindlings.xmlderivation.annotations` | Encode field as an XML attribute |
+| `@xmlElement` | `hearth.kindlings.xmlderivation.annotations` | Encode field as an XML child element (overrides `withAttributesByDefault`) |
+| `@xmlContent` | `hearth.kindlings.xmlderivation.annotations` | Encode field as the text content of the element |
+| `@xmlName("name")` | `hearth.kindlings.xmlderivation.annotations` | Override the XML element/attribute name |
+| `@xmlWrapper("name")` | `hearth.kindlings.xmlderivation.annotations` | Wrap field in an outer element |
+| `@xmlUnwrapped` | `hearth.kindlings.xmlderivation.annotations` | Flatten nested structure |
+| `@transientField` | `hearth.kindlings.xmlderivation.annotations` | Exclude field from encoding/decoding (must have default) |
+
+```scala
+import hearth.kindlings.xmlderivation.annotations.*
+
+case class Article(
+  @xmlAttribute id: Int,
+  @xmlContent body: String
+)
+// Encodes as: <article id="42">The article body text</article>
+```
+
+## Usage examples
+
+??? example "Sealed trait with discriminator"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-xml-derivation:{{ kindlings_version() }}
+    //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
+    //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
+
+    import hearth.kindlings.xmlderivation.*
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val config: XmlConfig = XmlConfig.default
+      .withDiscriminator("kind")
+      .withSnakeCaseConstructorNames
+
+    val encoder = KindlingsXmlEncoder.derive[Shape]
+    val decoder = KindlingsXmlDecoder.derive[Shape]
+
+    val shape: Shape = Circle(5.0)
+    val xml = encoder.encode(shape, "shape")
+    println(xml)
+    // <shape kind="circle"><radius>5.0</radius></shape>
+
+    println(decoder.decode(xml))
+    // Right(Circle(5.0))
+    ```
+
+??? example "Attributes-by-default mode"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-xml-derivation:{{ kindlings_version() }}
+    //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
+    //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
+
+    import hearth.kindlings.xmlderivation.*
+    import hearth.kindlings.xmlderivation.annotations.*
+
+    implicit val config: XmlConfig = XmlConfig.default.withAttributesByDefault
+
+    case class Point(x: Int, y: Int)
+
+    // All fields become attributes
+    val xml = KindlingsXmlEncoder.encode(Point(10, 20), "point")
+    println(xml)
+    // <point x="10" y="20"/>
+    ```
+
+??? example "Mixed attributes and elements"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-xml-derivation:{{ kindlings_version() }}
+    //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
+    //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
+
+    import hearth.kindlings.xmlderivation.*
+    import hearth.kindlings.xmlderivation.annotations.*
+
+    case class Product(
+      @xmlAttribute id: String,
+      @xmlAttribute category: String,
+      name: String,
+      description: String,
+      tags: List[String]
+    )
+
+    val product = Product("P001", "books", "Scala in Depth", "Advanced Scala programming", List("scala", "jvm"))
+    val xml = KindlingsXmlEncoder.encode(product, "product")
+    println(xml)
+    // <product id="P001" category="books">
+    //   <name>Scala in Depth</name>
+    //   <description>Advanced Scala programming</description>
+    //   <tags>scala</tags>
+    //   <tags>jvm</tags>
+    // </product>
+    ```
+
+??? example "Content annotation"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-xml-derivation:{{ kindlings_version() }}
+    //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
+    //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
+
+    import hearth.kindlings.xmlderivation.*
+    import hearth.kindlings.xmlderivation.annotations.*
+
+    case class Link(
+      @xmlAttribute href: String,
+      @xmlContent text: String
+    )
+
+    val link = Link("https://scala-lang.org", "Scala")
+    val xml = KindlingsXmlEncoder.encode(link, "a")
+    println(xml)
+    // <a href="https://scala-lang.org">Scala</a>
+
+    val decoded = KindlingsXmlDecoder.decode[Link](xml)
+    println(decoded)
+    // Right(Link(https://scala-lang.org,Scala))
+    ```
+
+??? example "Recursive data types"
+
+    ```scala
+    import hearth.kindlings.xmlderivation.*
+
+    case class TreeNode(value: Int, children: List[TreeNode])
+
+    // Recursive types just work -- no special setup needed
+    val codec: KindlingsXmlCodec[TreeNode] = KindlingsXmlCodec.derive[TreeNode]
+
+    val tree = TreeNode(1, List(TreeNode(2, Nil), TreeNode(3, List(TreeNode(4, Nil)))))
+    val xml = codec.encode(tree, "tree")
+    println(xml)
+
+    println(codec.decode(xml))
+    // Right(TreeNode(1,List(TreeNode(2,List()), TreeNode(3,List(TreeNode(4,List()))))))
+    ```
+
+## Debugging
+
+Import the debug package to log the generated encoder/decoder during compilation:
+
+```scala
+import hearth.kindlings.xmlderivation.debug._
+```
+
+This enables logging for both `KindlingsXmlEncoder` and `KindlingsXmlDecoder` derivations.
+
+Or enable project-wide via scalac option:
+
+```scala
+// build.sbt
+scalacOptions += "-Xmacro-settings:xmlDerivation.logDerivation=true"
+```

--- a/docs/user-guide/xml-derivation.md
+++ b/docs/user-guide/xml-derivation.md
@@ -43,8 +43,8 @@ Original module -- derives `XmlEncoder`, `XmlDecoder`, and `XmlCodec` for case c
     //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
     //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
 
-    import hearth.kindlings.xmlderivation.*
-    import hearth.kindlings.xmlderivation.annotations.*
+    import hearth.kindlings.xmlderivation._
+    import hearth.kindlings.xmlderivation.annotations._
 
     case class Book(
       @xmlAttribute isbn: String,
@@ -116,7 +116,7 @@ Import `hearth.kindlings.xmlderivation.syntax.*` for extension methods:
 ## Configuration
 
 ```scala
-import hearth.kindlings.xmlderivation.*
+import hearth.kindlings.xmlderivation._
 
 implicit val config: XmlConfig = XmlConfig.default
   .withAttributesByDefault
@@ -156,7 +156,7 @@ implicit val config: XmlConfig = XmlConfig.default
 | `@transientField` | `hearth.kindlings.xmlderivation.annotations` | Exclude field from encoding/decoding (must have default) |
 
 ```scala
-import hearth.kindlings.xmlderivation.annotations.*
+import hearth.kindlings.xmlderivation.annotations._
 
 case class Article(
   @xmlAttribute id: Int,
@@ -175,7 +175,7 @@ case class Article(
     //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
     //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
 
-    import hearth.kindlings.xmlderivation.*
+    import hearth.kindlings.xmlderivation._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -205,8 +205,8 @@ case class Article(
     //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
     //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
 
-    import hearth.kindlings.xmlderivation.*
-    import hearth.kindlings.xmlderivation.annotations.*
+    import hearth.kindlings.xmlderivation._
+    import hearth.kindlings.xmlderivation.annotations._
 
     implicit val config: XmlConfig = XmlConfig.default.withAttributesByDefault
 
@@ -226,8 +226,8 @@ case class Article(
     //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
     //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
 
-    import hearth.kindlings.xmlderivation.*
-    import hearth.kindlings.xmlderivation.annotations.*
+    import hearth.kindlings.xmlderivation._
+    import hearth.kindlings.xmlderivation.annotations._
 
     case class Product(
       @xmlAttribute id: String,
@@ -256,8 +256,8 @@ case class Article(
     //> using dep org.scala-lang.modules::scala-xml:{{ libraries.scalaXml }}
     //> using dep com.kubuszok::scala-sax-parser:{{ libraries.scalaSaxParser }}
 
-    import hearth.kindlings.xmlderivation.*
-    import hearth.kindlings.xmlderivation.annotations.*
+    import hearth.kindlings.xmlderivation._
+    import hearth.kindlings.xmlderivation.annotations._
 
     case class Link(
       @xmlAttribute href: String,
@@ -277,7 +277,7 @@ case class Article(
 ??? example "Recursive data types"
 
     ```scala
-    import hearth.kindlings.xmlderivation.*
+    import hearth.kindlings.xmlderivation._
 
     case class TreeNode(value: Int, children: List[TreeNode])
 

--- a/docs/user-guide/yaml-derivation.md
+++ b/docs/user-guide/yaml-derivation.md
@@ -1,0 +1,216 @@
+# YAML Derivation
+
+Drop-in replacement for scala-yaml's built-in `derives` — derives `YamlEncoder`, `YamlDecoder`, and `YamlCodec` for case classes, sealed traits, Scala 3 enums, Java enums, and more.
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-yaml-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-yaml-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
+    ```
+
+!!! note
+    You also need `scala-yaml` as a runtime dependency:
+
+    ```scala
+    libraryDependencies += "org.virtuslab" %%% "scala-yaml" % "{{ libraries.scalaYaml }}"
+    ```
+
+## Quick start
+
+??? example "Encoding and decoding a case class"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
+    //> using dep org.virtuslab::scala-yaml:{{ libraries.scalaYaml }}
+
+    import hearth.kindlings.yamlderivation.*
+
+    case class Person(name: String, age: Int)
+
+    // Encode to YAML string
+    val yaml: String = KindlingsYamlEncoder.toYamlString(Person("Alice", 30))
+    println(yaml)
+    // name: Alice
+    // age: 30
+
+    // Decode from YAML string
+    val result = KindlingsYamlDecoder.fromYamlString[Person]("name: Bob\nage: 25")
+    println(result)
+    // Right(Person(Bob,25))
+    ```
+
+## API
+
+### Derivation methods
+
+| Method | Returns | Description |
+|--------|---------|-------------|
+| `KindlingsYamlEncoder.derive[A]` | `YamlEncoder[A]` | Semi-automatic encoder |
+| `KindlingsYamlEncoder.encode[A](value)` | `Node` | Inline encoding (no instance allocation) |
+| `KindlingsYamlEncoder.toYamlString[A](value)` | `String` | Inline encoding to YAML string |
+| `KindlingsYamlEncoder.derived[A]` | `KindlingsYamlEncoder[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsYamlDecoder.derive[A]` | `YamlDecoder[A]` | Semi-automatic decoder |
+| `KindlingsYamlDecoder.decode[A](node)` | `Either[ConstructError, A]` | Inline decoding from a YAML node |
+| `KindlingsYamlDecoder.fromYamlString[A](yaml)` | `Either[YamlError, A]` | Inline decoding from a YAML string |
+| `KindlingsYamlDecoder.derived[A]` | `KindlingsYamlDecoder[A]` | Sanely-automatic (given/implicit) |
+| `KindlingsYamlCodec.derive[A]` | `KindlingsYamlCodec[A]` | Semi-automatic codec (encoder + decoder) |
+| `KindlingsYamlCodec.derived[A]` | `KindlingsYamlCodec[A]` | Sanely-automatic codec |
+
+All methods take an implicit/using `YamlConfig` parameter (defaults to `YamlConfig.default`).
+
+### Type hierarchy
+
+`KindlingsYamlEncoder[A]` extends `YamlEncoder[A]` and `KindlingsYamlDecoder[A]` extends `YamlDecoder[A]`, so derived instances work anywhere the original scala-yaml types are expected.
+
+### Syntax extensions
+
+The `syntax` object provides extension methods for convenient inline usage:
+
+```scala
+import hearth.kindlings.yamlderivation.syntax.*
+
+val yaml: String = Person("Alice", 30).toYamlString
+val result: Either[YamlError, Person] = "name: Bob\nage: 25".fromYamlString[Person]
+```
+
+## Configuration
+
+All derivation methods accept an implicit `YamlConfig`:
+
+```scala
+import hearth.kindlings.yamlderivation.*
+
+implicit val config: YamlConfig = YamlConfig.default
+  .withSnakeCaseMemberNames
+  .withDiscriminator("type")
+  .withUseDefaults
+```
+
+| Builder method | Description |
+|---------------|-------------|
+| `withSnakeCaseMemberNames` | `fieldName` -> `field_name` |
+| `withKebabCaseMemberNames` | `fieldName` -> `field-name` |
+| `withPascalCaseMemberNames` | `fieldName` -> `FieldName` |
+| `withScreamingSnakeCaseMemberNames` | `fieldName` -> `FIELD_NAME` |
+| `withTransformMemberNames(f)` | Custom field name transform |
+| `withSnakeCaseConstructorNames` | `MyType` -> `my_type` in discriminator |
+| `withKebabCaseConstructorNames` | `MyType` -> `my-type` in discriminator |
+| `withTransformConstructorNames(f)` | Custom constructor name transform |
+| `withDiscriminator(field)` | ADT discriminator field name |
+| `withEnumAsStrings` | Encode Scala 3 / Java enums as strings |
+| `withUseDefaults` | Use case class default values for missing fields |
+
+## Annotations
+
+| Annotation | Description |
+|-----------|-------------|
+| `@fieldName("yaml_name")` | Override YAML field name for a case class field |
+| `@transientField` | Exclude a field from encoding/decoding (must have a default value) |
+
+```scala
+import hearth.kindlings.yamlderivation.annotations.*
+
+case class User(
+  @fieldName("user_name") name: String,
+  @transientField internalId: Long = 0L
+)
+```
+
+## Usage examples
+
+??? example "Sealed trait with discriminator"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
+    //> using dep org.virtuslab::scala-yaml:{{ libraries.scalaYaml }}
+
+    import hearth.kindlings.yamlderivation.*
+
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val config: YamlConfig = YamlConfig.default
+      .withDiscriminator("type")
+      .withSnakeCaseConstructorNames
+
+    val yaml = KindlingsYamlEncoder.toYamlString[Shape](Circle(5.0))
+    println(yaml)
+    // radius: 5.0
+    // type: circle
+
+    val decoded = KindlingsYamlDecoder.fromYamlString[Shape]("width: 3\nheight: 4\ntype: rectangle")
+    println(decoded)
+    // Right(Rectangle(3.0,4.0))
+    ```
+
+??? example "Case class with defaults"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
+    //> using dep org.virtuslab::scala-yaml:{{ libraries.scalaYaml }}
+
+    import hearth.kindlings.yamlderivation.*
+
+    implicit val config: YamlConfig = YamlConfig.default.withUseDefaults
+
+    case class Settings(host: String, port: Int = 8080, debug: Boolean = false)
+
+    val result = KindlingsYamlDecoder.fromYamlString[Settings]("host: localhost")
+    println(result)
+    // Right(Settings(localhost,8080,false))
+    ```
+
+??? example "Snake-case field names"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
+    //> using dep org.virtuslab::scala-yaml:{{ libraries.scalaYaml }}
+
+    import hearth.kindlings.yamlderivation.*
+
+    implicit val config: YamlConfig = YamlConfig.default
+      .withSnakeCaseMemberNames
+
+    case class DatabaseConfig(hostName: String, portNumber: Int, maxConnections: Int)
+
+    val yaml = KindlingsYamlEncoder.toYamlString(DatabaseConfig("localhost", 5432, 10))
+    println(yaml)
+    // host_name: localhost
+    // port_number: 5432
+    // max_connections: 10
+    ```
+
+## Comparison with scala-yaml built-in derivation
+
+### Feature differences
+
+| Feature | scala-yaml `derives` | Kindlings |
+|---------|---------------------|-----------|
+| Same API on Scala 2.13 and 3 | No (Scala 3 only) | Yes |
+| Sealed trait / ADT support | No | Yes |
+| Configuration (naming, discriminator) | No | Yes (`YamlConfig`) |
+| Field name annotations | No | Yes (`@fieldName`) |
+| Default values | No | Yes (`withUseDefaults`) |
+| Enum handling | Broken in some cases | Correct |
+| Option decoding | Broken in some cases | Correct |
+| Inline encoding/decoding | No | Yes (`toYamlString`, `fromYamlString`) |
+| Sanely-automatic derivation | No | Yes |

--- a/docs/user-guide/yaml-derivation.md
+++ b/docs/user-guide/yaml-derivation.md
@@ -38,7 +38,7 @@ Drop-in replacement for scala-yaml's built-in `derives` — derives `YamlEncoder
     //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
     //> using dep org.virtuslab::scala-yaml:{{ libraries.scalaYaml }}
 
-    import hearth.kindlings.yamlderivation.*
+    import hearth.kindlings.yamlderivation._
 
     case class Person(name: String, age: Int)
 
@@ -82,7 +82,7 @@ All methods take an implicit/using `YamlConfig` parameter (defaults to `YamlConf
 The `syntax` object provides extension methods for convenient inline usage:
 
 ```scala
-import hearth.kindlings.yamlderivation.syntax.*
+import hearth.kindlings.yamlderivation.syntax._
 
 val yaml: String = Person("Alice", 30).toYamlString
 val result: Either[YamlError, Person] = "name: Bob\nage: 25".fromYamlString[Person]
@@ -93,7 +93,7 @@ val result: Either[YamlError, Person] = "name: Bob\nage: 25".fromYamlString[Pers
 All derivation methods accept an implicit `YamlConfig`:
 
 ```scala
-import hearth.kindlings.yamlderivation.*
+import hearth.kindlings.yamlderivation._
 
 implicit val config: YamlConfig = YamlConfig.default
   .withSnakeCaseMemberNames
@@ -123,7 +123,7 @@ implicit val config: YamlConfig = YamlConfig.default
 | `@transientField` | Exclude a field from encoding/decoding (must have a default value) |
 
 ```scala
-import hearth.kindlings.yamlderivation.annotations.*
+import hearth.kindlings.yamlderivation.annotations._
 
 case class User(
   @fieldName("user_name") name: String,
@@ -140,7 +140,7 @@ case class User(
     //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
     //> using dep org.virtuslab::scala-yaml:{{ libraries.scalaYaml }}
 
-    import hearth.kindlings.yamlderivation.*
+    import hearth.kindlings.yamlderivation._
 
     sealed trait Shape
     case class Circle(radius: Double) extends Shape
@@ -167,7 +167,7 @@ case class User(
     //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
     //> using dep org.virtuslab::scala-yaml:{{ libraries.scalaYaml }}
 
-    import hearth.kindlings.yamlderivation.*
+    import hearth.kindlings.yamlderivation._
 
     implicit val config: YamlConfig = YamlConfig.default.withUseDefaults
 
@@ -185,7 +185,7 @@ case class User(
     //> using dep com.kubuszok::kindlings-yaml-derivation:{{ kindlings_version() }}
     //> using dep org.virtuslab::scala-yaml:{{ libraries.scalaYaml }}
 
-    import hearth.kindlings.yamlderivation.*
+    import hearth.kindlings.yamlderivation._
 
     implicit val config: YamlConfig = YamlConfig.default
       .withSnakeCaseMemberNames

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -103,7 +103,7 @@ class KindlingsExtendedRunner(runner: Runner)(
   export runner.{docsDir, filter, tmpDir}
 
   private val ignored = Map(
-    // Dep-only snippets (no actual code)
+    // Dep-only snippets (no actual code, just show how to add the dependency)
     "avro-derivation.md#Installation[2]" -> "Dep-only snippet",
     "cats-derivation.md#Installation[3]" -> "Dep-only snippet",
     "cats-integration.md#Installation[3]" -> "Dep-only snippet",
@@ -120,32 +120,9 @@ class KindlingsExtendedRunner(runner: Runner)(
     "ubjson-derivation.md#Installation[3]" -> "Dep-only snippet",
     "xml-derivation.md#Installation[4]" -> "Dep-only snippet",
     "yaml-derivation.md#Installation[3]" -> "Dep-only snippet",
-    // TODO: fix imports (extension objects, missing type imports, config implicits)
-    "cats-derivation.md#Quick start[1]" -> "TODO: needs extensions._ import",
-    "cats-derivation.md#Usage examples[1]" -> "TODO: needs extensions._ import",
-    "cats-derivation.md#Usage examples[2]" -> "TODO: needs extensions._ import",
-    "cats-derivation.md#Usage examples[3]" -> "TODO: needs extensions._ import",
-    "iron-integration.md#Example[1]" -> "TODO: needs iron constraint imports",
-    "iron-integration.md#Example[2]" -> "TODO: needs iron constraint imports",
-    "refined-integration.md#Example[2]" -> "TODO: needs refined type imports",
-    "scalacheck-derivation.md#Quick start[1]" -> "TODO: needs extensions._ import",
-    "scalacheck-derivation.md#Usage examples[1]" -> "TODO: needs extensions._ import",
-    "scalacheck-derivation.md#Usage examples[2]" -> "TODO: needs extensions._ import",
-    "scalacheck-derivation.md#Usage examples[3]" -> "TODO: needs extensions._ import",
-    "scalacheck-derivation.md#Usage examples[4]" -> "TODO: needs extensions._ import",
-    "tapir-schema-derivation.md#Quick start[1]" -> "TODO: needs circe Configuration implicit",
-    "tapir-schema-derivation.md#Usage examples[1]" -> "TODO: needs circe Configuration implicit",
-    "tapir-schema-derivation.md#Usage examples[2]" -> "TODO: needs circe Configuration implicit",
-    "tapir-schema-derivation.md#Usage examples[4]" -> "TODO: needs circe Configuration implicit",
-    "tapir-schema-derivation.md#Usage examples[5]" -> "TODO: needs circe Configuration implicit",
-    "yaml-derivation.md#Quick start[1]" -> "TODO: needs org.virtuslab.yaml._ import",
-    "yaml-derivation.md#Usage examples[1]" -> "TODO: needs org.virtuslab.yaml._ import",
-    "yaml-derivation.md#Usage examples[2]" -> "TODO: needs org.virtuslab.yaml._ import",
-    "yaml-derivation.md#Usage examples[3]" -> "TODO: needs org.virtuslab.yaml._ import",
-    "index.md#Quick start[3]" -> "TODO: needs explicit encoder for sanely-automatic example",
-    "refined-integration.md#Example[1]" -> "TODO: needs refined predicate imports",
-    "cats-integration.md#Examples[1]" -> "TODO: needs explicit encoder for asJson in script mode",
-    "cats-integration.md#Examples[3]" -> "TODO: needs explicit encoder for asJson in script mode"
+    // Runtime issues in script mode (compilation succeeds)
+    "scalacheck-derivation.md#Usage examples[4]" -> "Recursive Arbitrary may stack overflow in script mode",
+    "tapir-schema-derivation.md#Usage examples[5]" -> "Initialization order issue with implicit val in script wrapper"
   )
 
   extension (snippet: Snippet)

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -47,6 +47,7 @@ class KindlingsExtendedRunner(runner: Runner)(
 ) extends Runner {
 
   private val defaultScalaVersion = "2.13.18"
+  private val snapshotRepo = "https://central.sonatype.com/repository/maven-snapshots"
 
   private val replacePatterns = (mkDocsCfg.extra + (raw"kindlings_version\(\)" -> kindlingsVersion)).map {
     case (k, v) =>
@@ -80,9 +81,72 @@ class KindlingsExtendedRunner(runner: Runner)(
       )
   }
 
+  val addSnapshotRepo: Snippet.Content => Snippet.Content = {
+    case Snippet.Content.Single(content) =>
+      Snippet.Content.Single(
+        if content.contains("//> using repository") then content
+        else content.replaceFirst("(//> using scala [^\n]*\n)", s"$$1//> using repository $snapshotRepo\n")
+      )
+    case Snippet.Content.Multiple(files) =>
+      Snippet.Content.Multiple(
+        if files.values.exists(_.content.contains("//> using repository")) then files
+        else {
+          val (fileName, Snippet.Content.Single(content0)) = files.head
+          val content1: Snippet.Content.Single = Snippet.Content.Single(
+            content0.replaceFirst("(//> using scala [^\n]*\n)", s"$$1//> using repository $snapshotRepo\n")
+          )
+          ListMap(fileName -> content1) ++ files.tail
+        }
+      )
+  }
+
   export runner.{docsDir, filter, tmpDir}
 
-  private val ignored = Map.empty[String, String]
+  private val ignored = Map(
+    // Dep-only snippets (no actual code)
+    "avro-derivation.md#Installation[2]" -> "Dep-only snippet",
+    "cats-derivation.md#Installation[3]" -> "Dep-only snippet",
+    "cats-integration.md#Installation[3]" -> "Dep-only snippet",
+    "circe-derivation.md#Installation[3]" -> "Dep-only snippet",
+    "fast-show-pretty.md#Installation[3]" -> "Dep-only snippet",
+    "index.md#Quick start[2]" -> "Dep-only snippet",
+    "iron-integration.md#Installation[3]" -> "Dep-only snippet",
+    "jsoniter-derivation.md#Installation[3]" -> "Dep-only snippet",
+    "pureconfig-derivation.md#Installation[2]" -> "Dep-only snippet",
+    "refined-integration.md#Installation[3]" -> "Dep-only snippet",
+    "scalacheck-derivation.md#Installation[3]" -> "Dep-only snippet",
+    "sconfig-derivation.md#Installation[3]" -> "Dep-only snippet",
+    "tapir-schema-derivation.md#Installation[4]" -> "Dep-only snippet",
+    "ubjson-derivation.md#Installation[3]" -> "Dep-only snippet",
+    "xml-derivation.md#Installation[4]" -> "Dep-only snippet",
+    "yaml-derivation.md#Installation[3]" -> "Dep-only snippet",
+    // TODO: fix imports (extension objects, missing type imports, config implicits)
+    "cats-derivation.md#Quick start[1]" -> "TODO: needs extensions._ import",
+    "cats-derivation.md#Usage examples[1]" -> "TODO: needs extensions._ import",
+    "cats-derivation.md#Usage examples[2]" -> "TODO: needs extensions._ import",
+    "cats-derivation.md#Usage examples[3]" -> "TODO: needs extensions._ import",
+    "iron-integration.md#Example[1]" -> "TODO: needs iron constraint imports",
+    "iron-integration.md#Example[2]" -> "TODO: needs iron constraint imports",
+    "refined-integration.md#Example[2]" -> "TODO: needs refined type imports",
+    "scalacheck-derivation.md#Quick start[1]" -> "TODO: needs extensions._ import",
+    "scalacheck-derivation.md#Usage examples[1]" -> "TODO: needs extensions._ import",
+    "scalacheck-derivation.md#Usage examples[2]" -> "TODO: needs extensions._ import",
+    "scalacheck-derivation.md#Usage examples[3]" -> "TODO: needs extensions._ import",
+    "scalacheck-derivation.md#Usage examples[4]" -> "TODO: needs extensions._ import",
+    "tapir-schema-derivation.md#Quick start[1]" -> "TODO: needs circe Configuration implicit",
+    "tapir-schema-derivation.md#Usage examples[1]" -> "TODO: needs circe Configuration implicit",
+    "tapir-schema-derivation.md#Usage examples[2]" -> "TODO: needs circe Configuration implicit",
+    "tapir-schema-derivation.md#Usage examples[4]" -> "TODO: needs circe Configuration implicit",
+    "tapir-schema-derivation.md#Usage examples[5]" -> "TODO: needs circe Configuration implicit",
+    "yaml-derivation.md#Quick start[1]" -> "TODO: needs org.virtuslab.yaml._ import",
+    "yaml-derivation.md#Usage examples[1]" -> "TODO: needs org.virtuslab.yaml._ import",
+    "yaml-derivation.md#Usage examples[2]" -> "TODO: needs org.virtuslab.yaml._ import",
+    "yaml-derivation.md#Usage examples[3]" -> "TODO: needs org.virtuslab.yaml._ import",
+    "index.md#Quick start[3]" -> "TODO: needs explicit encoder for sanely-automatic example",
+    "refined-integration.md#Example[1]" -> "TODO: needs refined predicate imports",
+    "cats-integration.md#Examples[1]" -> "TODO: needs explicit encoder for asJson in script mode",
+    "cats-integration.md#Examples[3]" -> "TODO: needs explicit encoder for asJson in script mode"
+  )
 
   extension (snippet: Snippet)
     def adjusted: Snippet =
@@ -97,7 +161,7 @@ class KindlingsExtendedRunner(runner: Runner)(
       // add default Scala but only to those snippets that are already run (adding it before would make all of them run)
       howToRun(snippet) match
         case Runner.Strategy.Ignore(_) => snippet
-        case _                         => snippet.copy(content = addDefaultScala(snippet.content))
+        case _                         => snippet.copy(content = addSnapshotRepo(addDefaultScala(snippet.content)))
     }
 }
 

--- a/scripts/test-snippets.scala
+++ b/scripts/test-snippets.scala
@@ -1,0 +1,133 @@
+//> using scala 3.3.7
+//> using dep com.kubuszok::scala-cli-md-spec:0.2.1
+//> using dep org.virtuslab::scala-yaml:0.3.1
+//> using jvm 17
+
+import com.kubuszok.scalaclimdspec.*
+import java.io.File
+import java.nio.file.Files
+import scala.collection.immutable.ListMap
+import scala.util.{Try, Using}
+import scala.util.chaining.*
+
+// Kindlings-specific configuration
+
+case class MkDocsConfig(extra: Map[String, String])
+object MkDocsConfig {
+
+  def parse(cfgFile: File): Either[String, MkDocsConfig] = {
+    import org.virtuslab.yaml.*
+    def decode(any: Any): Map[String, String] = any match {
+      case map: Map[?, ?] =>
+        map.flatMap {
+          case (k, v: Map[?, ?]) => decode(v).map { case (k2, v2) => s"$k.$k2" -> v2 }
+          case (k, v: List[?])   => decode(v).map { case (k2, v2) => s"$k.$k2" -> v2 }
+          case (k, v)            => Map(k.toString -> v.toString)
+        }.toMap
+      case list: List[?] =>
+        list.zipWithIndex.flatMap {
+          case (i: Map[?, ?], idx) => decode(i).map { case (k, v) => s"[$idx].$k" -> v }
+          case (i: List[?], idx)   => decode(i).map { case (k, v) => s"[$idx].$k" -> v }
+          case (i, idx)            => Map(s"[$idx]" -> i.toString)
+        }.toMap
+      case _ => throw new IllegalArgumentException(s"$any is not an expected YAML")
+    }
+    for {
+      cfgStr <- Using(io.Source.fromFile(cfgFile))(_.getLines().toList.mkString("\n")).toEither.left
+        .map(_.getMessage())
+      cfgRaw <- cfgStr.as[Any].left.map(_.toString)
+      extra <- Try(decode(cfgRaw.asInstanceOf[Map[Any, Any]].apply("extra"))).toEither.left.map(_.getMessage)
+    } yield MkDocsConfig(extra)
+  }
+}
+
+class KindlingsExtendedRunner(runner: Runner)(
+    kindlingsVersion: String,
+    mkDocsCfg: MkDocsConfig
+) extends Runner {
+
+  private val defaultScalaVersion = "2.13.18"
+
+  private val replacePatterns = (mkDocsCfg.extra + (raw"kindlings_version\(\)" -> kindlingsVersion)).map {
+    case (k, v) =>
+      (raw"\{\{\s*" + k + raw"\s*\}\}") -> v
+  }
+
+  val addDefaultScala: Snippet.Content => Snippet.Content = {
+    case Snippet.Content.Single(content) =>
+      Snippet.Content.Single(
+        if content.contains("//> using scala") then content
+        else s"//> using scala $defaultScalaVersion\n$content"
+      )
+    case Snippet.Content.Multiple(files) =>
+      Snippet.Content.Multiple(
+        if files.values.exists(_.content.contains("//> using scala")) then files
+        else {
+          val (fileName, Snippet.Content.Single(content0)) = files.head
+          val content1: Snippet.Content.Single =
+            Snippet.Content.Single(s"//> using scala $defaultScalaVersion\n$content0")
+          ListMap(fileName -> content1) ++ files.tail
+        }
+      )
+  }
+
+  val interpolateTemplates: Snippet.Content => Snippet.Content = {
+    case Snippet.Content.Single(content) =>
+      Snippet.Content.Single(replacePatterns.foldLeft(content) { case (s, (k, v)) => s.replaceAll(k, v) })
+    case Snippet.Content.Multiple(files) =>
+      Snippet.Content.Multiple(
+        ListMap.from(files.mapValues(interpolateTemplates(_).asInstanceOf[Snippet.Content.Single]))
+      )
+  }
+
+  export runner.{docsDir, filter, tmpDir}
+
+  private val ignored = Map.empty[String, String]
+
+  extension (snippet: Snippet)
+    def adjusted: Snippet =
+      // interpolate templates before Default adjustments
+      runner.adjusted(snippet.copy(content = interpolateTemplates(snippet.content)))
+
+    def howToRun: Runner.Strategy =
+      ignored.get(snippet.stableName).fold(runner.howToRun(snippet))(Runner.Strategy.Ignore(_))
+
+  extension (snippets: List[Snippet])
+    def adjusted: List[Snippet] = runner.adjusted(snippets).map { snippet =>
+      // add default Scala but only to those snippets that are already run (adding it before would make all of them run)
+      howToRun(snippet) match
+        case Runner.Strategy.Ignore(_) => snippet
+        case _                         => snippet.copy(content = addDefaultScala(snippet.content))
+    }
+}
+
+/** Usage:
+  *
+  * From the project root (if called from other directory, adapt path after PWD accordingly):
+  *
+  * on CI:
+  * {{{
+  * # run all tests, use artifacts published locally from current tag
+  * scala-cli run scripts/test-snippets.scala -- --extra "kindlings-version=$(sbt -batch -error 'print fastShowPretty/version')" "$PWD/docs/user-guide"
+  * }}}
+  *
+  * during development:
+  * {{{
+  * # sbt publish-local-for-tests
+  * # fix the version to what sbt generated, fix tmp directory to something to be able to preview generated files
+  * scala-cli run scripts/test-snippets.scala -- --extra "kindlings-version=0.1.x-n-g1234567-SNAPSHOT" --test-only "circe-derivation.md*" "$PWD/docs/user-guide" "/tmp/docs-snippets"
+  * }}}
+  */
+@main def testKindlingsSnippets(args: String*): Unit = testSnippets(args.toArray) { cfg =>
+  KindlingsExtendedRunner(Runner.Default(cfg))(
+    kindlingsVersion = cfg
+      .extra("kindlings-version")
+      .trim
+      .pipe("\\[([0-9]+)m".r.replaceAllIn(_, "")) // remove possible console coloring from sbt
+      .pipe(raw"(?U)\s".r.replaceAllIn(_, "")) // remove possible ESC characters
+      .replaceAll("\\[0J", ""), // replace this one offending thing
+    mkDocsCfg = MkDocsConfig
+      .parse(File(s"${cfg.docsDir}/../mkdocs.yml").getAbsoluteFile())
+      .fold(s => throw Exception(s), identity)
+  )
+}


### PR DESCRIPTION
## Summary

- Add complete user-facing documentation site using mkdocs + Material theme + macros plugin, replicating the Hearth documentation infrastructure
- 18 content pages covering all 12 derivation modules, 3 integration modules, debugging/diagnostics, and FAQ
- Fresh JMH benchmarks for all modules on both Scala 2.13 and 3, with new jsoniter-scala-circe booster comparison
- Change default derivation timeout from 120s to 5s as a safety feature

## Infrastructure

- `docs/mkdocs.yml` — site config with Material theme, nav, dependency version extras
- `docs/main.py` — Python macro for `{{ kindlings_version() }}` interpolation via git describe
- `docs/Dockerfile` + `docs/requirements.txt` — Docker build for local serving
- `docs/Justfile` — `build`, `serve`, `test-snippets` targets
- `.readthedocs.yaml` — ReadTheDocs deployment config
- `scripts/test-snippets.scala` — Scala CLI snippet test runner

## Content

- **Landing page** — sanely-automatic derivation, debug logging, flame graphs, macro timeouts, integration modules, comparison table
- **12 module pages** — installation, API reference, configuration, annotations, usage examples, benchmarks where applicable
- **3 integration pages** — refined, iron, cats-collections (macro extension mechanism)
- **Debugging & diagnostics** — per-module debug imports, scalac settings, flame graphs, timeout config
- **FAQ** — migration guides, sanely-automatic explanation

## Benchmarks

- Add `jsoniter-scala-circe` dependency and `CirceBoosterBenchmark` (full pipeline: domain type ↔ bytes/String)
- Fresh results show major improvements since last benchmark run:
  - **Jsoniter**: now at parity for SimpleCC writes (60M vs 60M), reads slightly faster (36M vs 35M)
  - **PureConfig**: 4.6-12x faster across the board (was mixed)
  - **Avro**: SimpleCC encode 5.3x faster, decode 3.6x faster
  - **Circe + booster**: Kindlings + jsoniter-scala-circe is the fastest Circe pipeline

## Code change

- `DerivationTimeout.Default` changed from 120s to 5s — prevents runaway compilation, users can increase per-module if needed

## Test plan

- [x] `cd docs && just serve` — verify site renders at localhost:8000
- [x] `cd docs && just test-snippets` — validate Scala CLI snippets compile
- [x] `sbt --client "test-jvm-2_13 ; test-jvm-3"` — verify 5s timeout doesn't break existing tests