### PR TITLE
Add diff-derivation module with Myers algorithm

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -230,7 +230,8 @@ val al = new {
       "catsDerivation",
       "scalacheckDerivation",
       "catsIntegration",
-      "sconfigDerivation"
+      "sconfigDerivation",
+      "diffDerivation"
     )
 
   private val jvmOnlyProdProjects = Vector("avroDerivation", "pureconfigDerivation")
@@ -322,6 +323,7 @@ lazy val root = project
   .aggregate(catsDerivation.projectRefs *)
   .aggregate(scalacheckDerivation.projectRefs *)
   .aggregate(catsIntegration.projectRefs *)
+  .aggregate(diffDerivation.projectRefs *)
   .aggregate(integrationTests.projectRefs *)
   .aggregate(benchmarks.projectRefs *)
   .settings(
@@ -367,6 +369,20 @@ lazy val root = project
         .alias("publish-local-for-tests")
     )
   )
+
+lazy val diffDerivation = projectMatrix
+  .in(file("diff-derivation"))
+  .someVariations(versions.scalas, versions.platforms)((useCrossQuotes ++ dev.only1VersionInIDE) *)
+  .dependsOn(derivationCommons)
+  .disablePlugins(WelcomePlugin)
+  .settings(
+    moduleName := "kindlings-diff-derivation",
+    name := "kindlings-diff-derivation",
+    description := "Structural Diff type class derivation using Myers algorithm with Hearth macros"
+  )
+  .settings(settings *)
+  .settings(dependencies *)
+  .settings(publishSettings *)
 
 lazy val fastShowPretty = projectMatrix
   .in(file("fast-show-pretty"))

--- a/diff-derivation/src/main/scala-2/hearth/kindlings/diffderivation/DiffCompanionCompat.scala
+++ b/diff-derivation/src/main/scala-2/hearth/kindlings/diffderivation/DiffCompanionCompat.scala
@@ -1,0 +1,8 @@
+package hearth.kindlings.diffderivation
+
+import scala.language.experimental.macros
+
+private[diffderivation] trait DiffCompanionCompat { this: Diff.type =>
+
+  implicit def derived[A]: Diff[A] = macro internal.compiletime.DiffMacros.deriveTypeClassImpl[A]
+}

--- a/diff-derivation/src/main/scala-2/hearth/kindlings/diffderivation/internal/compiletime/DiffMacros.scala
+++ b/diff-derivation/src/main/scala-2/hearth/kindlings/diffderivation/internal/compiletime/DiffMacros.scala
@@ -1,0 +1,12 @@
+package hearth.kindlings.diffderivation
+package internal.compiletime
+
+import hearth.MacroCommonsScala2
+import scala.reflect.macros.blackbox
+
+final private[diffderivation] class DiffMacros(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with DiffMacrosImpl {
+
+  def deriveTypeClassImpl[A: c.WeakTypeTag]: c.Expr[Diff[A]] = deriveTypeClass[A]
+}

--- a/diff-derivation/src/main/scala-2/hearth/kindlings/diffderivation/internal/compiletime/DiffMacros.scala
+++ b/diff-derivation/src/main/scala-2/hearth/kindlings/diffderivation/internal/compiletime/DiffMacros.scala
@@ -4,9 +4,7 @@ package internal.compiletime
 import hearth.MacroCommonsScala2
 import scala.reflect.macros.blackbox
 
-final private[diffderivation] class DiffMacros(val c: blackbox.Context)
-    extends MacroCommonsScala2
-    with DiffMacrosImpl {
+final private[diffderivation] class DiffMacros(val c: blackbox.Context) extends MacroCommonsScala2 with DiffMacrosImpl {
 
   def deriveTypeClassImpl[A: c.WeakTypeTag]: c.Expr[Diff[A]] = deriveTypeClass[A]
 }

--- a/diff-derivation/src/main/scala-3/hearth/kindlings/diffderivation/DiffCompanionCompat.scala
+++ b/diff-derivation/src/main/scala-3/hearth/kindlings/diffderivation/DiffCompanionCompat.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.diffderivation
+
+private[diffderivation] trait DiffCompanionCompat { this: Diff.type =>
+
+  inline given derived[A]: Diff[A] = ${ internal.compiletime.DiffMacros.deriveTypeClassImpl[A] }
+}

--- a/diff-derivation/src/main/scala-3/hearth/kindlings/diffderivation/internal/compiletime/DiffMacros.scala
+++ b/diff-derivation/src/main/scala-3/hearth/kindlings/diffderivation/internal/compiletime/DiffMacros.scala
@@ -1,0 +1,15 @@
+package hearth.kindlings.diffderivation
+package internal.compiletime
+
+import hearth.MacroCommonsScala3
+import scala.quoted.*
+
+final private[diffderivation] class DiffMacros(q: Quotes)
+    extends MacroCommonsScala3(using q),
+      DiffMacrosImpl
+
+private[diffderivation] object DiffMacros {
+
+  def deriveTypeClassImpl[A: Type](using q: Quotes): Expr[Diff[A]] =
+    new DiffMacros(q).deriveTypeClass[A]
+}

--- a/diff-derivation/src/main/scala-3/hearth/kindlings/diffderivation/internal/compiletime/DiffMacros.scala
+++ b/diff-derivation/src/main/scala-3/hearth/kindlings/diffderivation/internal/compiletime/DiffMacros.scala
@@ -4,9 +4,7 @@ package internal.compiletime
 import hearth.MacroCommonsScala3
 import scala.quoted.*
 
-final private[diffderivation] class DiffMacros(q: Quotes)
-    extends MacroCommonsScala3(using q),
-      DiffMacrosImpl
+final private[diffderivation] class DiffMacros(q: Quotes) extends MacroCommonsScala3(using q), DiffMacrosImpl
 
 private[diffderivation] object DiffMacros {
 

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/Diff.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/Diff.scala
@@ -1,0 +1,17 @@
+package hearth.kindlings.diffderivation
+
+trait Diff[A] {
+  def prettyName: String
+  def plainName: String
+  def simpleName: String
+  def shortName: String
+  def diff(left: A, right: A): DiffResult
+  def snapshot(value: A): DiffResult
+}
+object Diff extends DiffCompanionCompat {
+
+  def apply[A](implicit ev: Diff[A]): Diff[A] = ev
+
+  sealed trait LogDerivation
+  object LogDerivation extends LogDerivation
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/DiffRenderer.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/DiffRenderer.scala
@@ -1,6 +1,6 @@
 package hearth.kindlings.diffderivation
 
-import hearth.kindlings.diffderivation.DiffResult._
+import hearth.kindlings.diffderivation.DiffResult.*
 
 object DiffRenderer {
 
@@ -243,9 +243,9 @@ object DiffRenderer {
         case StringChunk.ChangedLine(words) =>
           sb ++= "~ "
           words.foreach {
-            case WordChunk.EqualWord(t)  => sb ++= t
-            case WordChunk.InsertWord(t) => sb ++= colorAdded(t, config)
-            case WordChunk.DeleteWord(t) => sb ++= colorRemoved(t, config)
+            case WordChunk.EqualWord(t)       => sb ++= t
+            case WordChunk.InsertWord(t)      => sb ++= colorAdded(t, config)
+            case WordChunk.DeleteWord(t)      => sb ++= colorRemoved(t, config)
             case WordChunk.ChangedWord(chars) =>
               chars.foreach {
                 case CharChunk.EqualChar(t)  => sb ++= t

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/DiffRenderer.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/DiffRenderer.scala
@@ -1,0 +1,262 @@
+package hearth.kindlings.diffderivation
+
+import hearth.kindlings.diffderivation.DiffResult._
+
+object DiffRenderer {
+
+  private val ESC = ''
+  private val AnsiGreen = ESC.toString + "[32m"
+  private val AnsiRed = ESC.toString + "[31m"
+  private val AnsiYellow = ESC.toString + "[33m"
+  private val AnsiReset = ESC.toString + "[0m"
+
+  def render(result: DiffResult, config: RenderConfig = RenderConfig.default): String = {
+    val sb = new StringBuilder()
+    renderTo(sb, result, config, 0)
+    sb.result()
+  }
+
+  private def nameOf(node: DiffResult, config: RenderConfig): String = config.nameStyle match {
+    case NameStyle.Simple         => node.simpleName
+    case NameStyle.Short          => node.shortName
+    case NameStyle.FullyQualified => node.plainName
+    case NameStyle.Pretty         => node.prettyName
+  }
+
+  private def indentStr(config: RenderConfig): String = config.indent match {
+    case Indent.Spaces(n) => " " * n
+    case Indent.Tab       => "\t"
+  }
+
+  private def appendIndent(sb: StringBuilder, config: RenderConfig, level: Int): Unit = {
+    val unit = indentStr(config)
+    var i = 0
+    while (i < level) { sb ++= unit; i += 1 }
+  }
+
+  private def colorAdded(text: String, config: RenderConfig): String = config.colorMode match {
+    case ColorMode.Ansi  => AnsiGreen + text + AnsiReset
+    case ColorMode.Plain => text
+  }
+
+  private def colorRemoved(text: String, config: RenderConfig): String = config.colorMode match {
+    case ColorMode.Ansi  => AnsiRed + text + AnsiReset
+    case ColorMode.Plain => text
+  }
+
+  private def colorChanged(text: String, config: RenderConfig): String = config.colorMode match {
+    case ColorMode.Ansi  => AnsiYellow + text + AnsiReset
+    case ColorMode.Plain => text
+  }
+
+  private def renderTo(sb: StringBuilder, result: DiffResult, config: RenderConfig, level: Int): Unit =
+    result match {
+      case v: Identical =>
+        sb ++= v.display
+
+      case v: ValueChanged =>
+        sb ++= colorRemoved(v.left, config)
+        sb ++= " -> "
+        sb ++= colorAdded(v.right, config)
+
+      case v: Record =>
+        sb ++= nameOf(v, config)
+        sb += '('
+        val changed = v.fields.filterNot(_._2.isIdentical)
+        if (changed.isEmpty && v.fields.nonEmpty) {
+          sb ++= "..."
+        } else {
+          var first = true
+          v.fields.foreach { case (name, fieldDiff) =>
+            sb += '\n'
+            appendIndent(sb, config, level + 1)
+            if (fieldDiff.isIdentical) {
+              sb ++= name
+              sb ++= " = "
+              renderTo(sb, fieldDiff, config, level + 1)
+            } else {
+              sb ++= colorChanged(name, config)
+              sb ++= " = "
+              renderTo(sb, fieldDiff, config, level + 1)
+            }
+            if (!first || v.fields.size > 1) sb += ','
+            first = false
+          }
+          sb += '\n'
+          appendIndent(sb, config, level)
+        }
+        sb += ')'
+
+      case v: Variant =>
+        sb ++= nameOf(v, config)
+        sb += '.'
+        sb ++= v.variantName
+        sb += '('
+        if (!v.body.isIdentical) {
+          sb += '\n'
+          appendIndent(sb, config, level + 1)
+          renderTo(sb, v.body, config, level + 1)
+          sb += '\n'
+          appendIndent(sb, config, level)
+        } else {
+          sb ++= "..."
+        }
+        sb += ')'
+
+      case v: TypeMismatch =>
+        sb ++= nameOf(v, config)
+        sb ++= ": "
+        sb ++= colorRemoved(v.leftVariant, config)
+        sb ++= " -> "
+        sb ++= colorAdded(v.rightVariant, config)
+        sb += '\n'
+        appendIndent(sb, config, level + 1)
+        sb ++= "- "
+        renderTo(sb, v.leftSnapshot, config, level + 1)
+        sb += '\n'
+        appendIndent(sb, config, level + 1)
+        sb ++= "+ "
+        renderTo(sb, v.rightSnapshot, config, level + 1)
+
+      case v: SeqDiff =>
+        sb ++= nameOf(v, config)
+        sb += '('
+        v.edits.foreach { edit =>
+          sb += '\n'
+          appendIndent(sb, config, level + 1)
+          edit match {
+            case Edit.Equal(d) =>
+              sb ++= "  "
+              renderTo(sb, d, config, level + 1)
+            case Edit.Insert(d) =>
+              sb ++= colorAdded("+ ", config)
+              renderTo(sb, d, config, level + 1)
+            case Edit.Delete(d) =>
+              sb ++= colorRemoved("- ", config)
+              renderTo(sb, d, config, level + 1)
+          }
+          sb += ','
+        }
+        sb += '\n'
+        appendIndent(sb, config, level)
+        sb += ')'
+
+      case v: MapDiff =>
+        sb ++= nameOf(v, config)
+        sb += '('
+        v.entries.foreach { entry =>
+          sb += '\n'
+          appendIndent(sb, config, level + 1)
+          entry match {
+            case MapEntry.Matched(key, valueDiff) =>
+              sb ++= "  "
+              sb ++= key
+              sb ++= " -> "
+              renderTo(sb, valueDiff, config, level + 1)
+            case MapEntry.Added(key, snapshot) =>
+              sb ++= colorAdded("+ ", config)
+              sb ++= key
+              sb ++= " -> "
+              renderTo(sb, snapshot, config, level + 1)
+            case MapEntry.Removed(key, snapshot) =>
+              sb ++= colorRemoved("- ", config)
+              sb ++= key
+              sb ++= " -> "
+              renderTo(sb, snapshot, config, level + 1)
+          }
+          sb += ','
+        }
+        sb += '\n'
+        appendIndent(sb, config, level)
+        sb += ')'
+
+      case v: SetDiff =>
+        sb ++= nameOf(v, config)
+        sb += '('
+        v.entries.foreach { entry =>
+          sb += '\n'
+          appendIndent(sb, config, level + 1)
+          entry match {
+            case SetEntry.Matched(d) =>
+              sb ++= "  "
+              renderTo(sb, d, config, level + 1)
+            case SetEntry.Added(snapshot) =>
+              sb ++= colorAdded("+ ", config)
+              renderTo(sb, snapshot, config, level + 1)
+            case SetEntry.Removed(snapshot) =>
+              sb ++= colorRemoved("- ", config)
+              renderTo(sb, snapshot, config, level + 1)
+          }
+          sb += ','
+        }
+        sb += '\n'
+        appendIndent(sb, config, level)
+        sb += ')'
+
+      case v: OptionalDiff =>
+        v.inner match {
+          case OptionalContent.BothPresent(d) =>
+            sb ++= nameOf(v, config)
+            sb += '('
+            renderTo(sb, d, config, level)
+            sb += ')'
+          case OptionalContent.LeftOnly(snapshot) =>
+            sb ++= colorRemoved("Some", config)
+            sb += '('
+            renderTo(sb, snapshot, config, level)
+            sb += ')'
+            sb ++= " -> "
+            sb ++= colorAdded("None", config)
+          case OptionalContent.RightOnly(snapshot) =>
+            sb ++= colorRemoved("None", config)
+            sb ++= " -> "
+            sb ++= colorAdded("Some", config)
+            sb += '('
+            renderTo(sb, snapshot, config, level)
+            sb += ')'
+          case OptionalContent.BothAbsent =>
+            sb ++= "None"
+        }
+
+      case v: StringDiff =>
+        renderStringDiff(sb, v, config, level)
+    }
+
+  private def renderStringDiff(
+      sb: StringBuilder,
+      v: StringDiff,
+      config: RenderConfig,
+      level: Int
+  ): Unit = {
+    sb ++= nameOf(v, config)
+    sb ++= "(\n"
+    v.chunks.foreach { chunk =>
+      appendIndent(sb, config, level + 1)
+      chunk match {
+        case StringChunk.EqualLine(text) =>
+          sb ++= "  "
+          sb ++= text
+        case StringChunk.InsertLine(text) =>
+          sb ++= colorAdded("+ " + text, config)
+        case StringChunk.DeleteLine(text) =>
+          sb ++= colorRemoved("- " + text, config)
+        case StringChunk.ChangedLine(words) =>
+          sb ++= "~ "
+          words.foreach {
+            case WordChunk.EqualWord(t)  => sb ++= t
+            case WordChunk.InsertWord(t) => sb ++= colorAdded(t, config)
+            case WordChunk.DeleteWord(t) => sb ++= colorRemoved(t, config)
+            case WordChunk.ChangedWord(chars) =>
+              chars.foreach {
+                case CharChunk.EqualChar(t)  => sb ++= t
+                case CharChunk.InsertChar(t) => sb ++= colorAdded(t, config)
+                case CharChunk.DeleteChar(t) => sb ++= colorRemoved(t, config)
+              }
+          }
+      }
+      sb += '\n'
+    }
+    appendIndent(sb, config, level)
+    sb += ')'
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/DiffResult.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/DiffResult.scala
@@ -1,0 +1,403 @@
+package hearth.kindlings.diffderivation
+
+sealed abstract class DiffResult(
+    _prettyName: => String,
+    _plainName: => String,
+    _simpleName: => String,
+    _shortName: => String
+) extends Product
+    with Serializable {
+  lazy val prettyName: String = _prettyName
+  lazy val plainName: String = _plainName
+  lazy val simpleName: String = _simpleName
+  lazy val shortName: String = _shortName
+  def isIdentical: Boolean
+}
+
+object DiffResult {
+
+  // ── Leaf nodes ──────────────────────────────────────────────
+
+  final class Identical private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val display: String
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = true
+    override def productPrefix: String = "Identical"
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any = n match {
+      case 0 => display
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[Identical]
+    override def toString: String = s"Identical($display)"
+  }
+  object Identical {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        display: String
+    ): Identical = new Identical(prettyName, plainName, simpleName, shortName, display)
+    def unapply(v: Identical): Some[String] = Some(v.display)
+  }
+
+  final class ValueChanged private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val left: String,
+      val right: String
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = false
+    override def productPrefix: String = "ValueChanged"
+    override def productArity: Int = 2
+    override def productElement(n: Int): Any = n match {
+      case 0 => left
+      case 1 => right
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[ValueChanged]
+    override def toString: String = s"ValueChanged($left, $right)"
+  }
+  object ValueChanged {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        left: String,
+        right: String
+    ): ValueChanged = new ValueChanged(prettyName, plainName, simpleName, shortName, left, right)
+    def unapply(v: ValueChanged): Some[(String, String)] = Some((v.left, v.right))
+  }
+
+  // ── Product (case class) ───────────────────────────────────
+
+  final class Record private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val fields: Vector[(String, DiffResult)]
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = fields.forall(_._2.isIdentical)
+    override def productPrefix: String = "Record"
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any = n match {
+      case 0 => fields
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[Record]
+    override def toString: String = s"Record($simpleName, $fields)"
+  }
+  object Record {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        fields: Vector[(String, DiffResult)]
+    ): Record = new Record(prettyName, plainName, simpleName, shortName, fields)
+    def unapply(v: Record): Some[Vector[(String, DiffResult)]] = Some(v.fields)
+  }
+
+  // ── Coproduct (sealed trait / enum) ────────────────────────
+
+  final class Variant private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val variantName: String,
+      val body: DiffResult
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = body.isIdentical
+    override def productPrefix: String = "Variant"
+    override def productArity: Int = 2
+    override def productElement(n: Int): Any = n match {
+      case 0 => variantName
+      case 1 => body
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[Variant]
+    override def toString: String = s"Variant($simpleName, $variantName, $body)"
+  }
+  object Variant {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        variantName: String,
+        body: DiffResult
+    ): Variant = new Variant(prettyName, plainName, simpleName, shortName, variantName, body)
+    def unapply(v: Variant): Some[(String, DiffResult)] = Some((v.variantName, v.body))
+  }
+
+  final class TypeMismatch private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val leftVariant: String,
+      val leftSnapshot: DiffResult,
+      val rightVariant: String,
+      val rightSnapshot: DiffResult
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = false
+    override def productPrefix: String = "TypeMismatch"
+    override def productArity: Int = 4
+    override def productElement(n: Int): Any = n match {
+      case 0 => leftVariant
+      case 1 => leftSnapshot
+      case 2 => rightVariant
+      case 3 => rightSnapshot
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[TypeMismatch]
+    override def toString: String = s"TypeMismatch($simpleName, $leftVariant, $rightVariant)"
+  }
+  object TypeMismatch {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        leftVariant: String,
+        leftSnapshot: DiffResult,
+        rightVariant: String,
+        rightSnapshot: DiffResult
+    ): TypeMismatch =
+      new TypeMismatch(prettyName, plainName, simpleName, shortName, leftVariant, leftSnapshot, rightVariant,
+        rightSnapshot)
+    def unapply(v: TypeMismatch): Some[(String, DiffResult, String, DiffResult)] =
+      Some((v.leftVariant, v.leftSnapshot, v.rightVariant, v.rightSnapshot))
+  }
+
+  // ── Ordered collections (Myers-based) ──────────────────────
+
+  final class SeqDiff private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val edits: Vector[Edit[DiffResult]]
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = edits.forall {
+      case Edit.Equal(d) => d.isIdentical
+      case _             => false
+    }
+    override def productPrefix: String = "SeqDiff"
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any = n match {
+      case 0 => edits
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[SeqDiff]
+    override def toString: String = s"SeqDiff($simpleName, ${edits.size} edits)"
+  }
+  object SeqDiff {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        edits: Vector[Edit[DiffResult]]
+    ): SeqDiff = new SeqDiff(prettyName, plainName, simpleName, shortName, edits)
+    def unapply(v: SeqDiff): Some[Vector[Edit[DiffResult]]] = Some(v.edits)
+  }
+
+  // ── Map ────────────────────────────────────────────────────
+
+  sealed trait MapEntry extends Product with Serializable {
+    def isIdentical: Boolean
+  }
+  object MapEntry {
+    final case class Matched(key: String, valueDiff: DiffResult) extends MapEntry {
+      def isIdentical: Boolean = valueDiff.isIdentical
+    }
+    final case class Added(key: String, snapshot: DiffResult) extends MapEntry {
+      def isIdentical: Boolean = false
+    }
+    final case class Removed(key: String, snapshot: DiffResult) extends MapEntry {
+      def isIdentical: Boolean = false
+    }
+  }
+
+  final class MapDiff private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val entries: Vector[MapEntry]
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = entries.forall(_.isIdentical)
+    override def productPrefix: String = "MapDiff"
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any = n match {
+      case 0 => entries
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[MapDiff]
+    override def toString: String = s"MapDiff($simpleName, ${entries.size} entries)"
+  }
+  object MapDiff {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        entries: Vector[MapEntry]
+    ): MapDiff = new MapDiff(prettyName, plainName, simpleName, shortName, entries)
+    def unapply(v: MapDiff): Some[Vector[MapEntry]] = Some(v.entries)
+  }
+
+  // ── Set ────────────────────────────────────────────────────
+
+  sealed trait SetEntry extends Product with Serializable {
+    def isIdentical: Boolean
+  }
+  object SetEntry {
+    final case class Matched(diff: DiffResult) extends SetEntry {
+      def isIdentical: Boolean = diff.isIdentical
+    }
+    final case class Added(snapshot: DiffResult) extends SetEntry {
+      def isIdentical: Boolean = false
+    }
+    final case class Removed(snapshot: DiffResult) extends SetEntry {
+      def isIdentical: Boolean = false
+    }
+  }
+
+  final class SetDiff private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val entries: Vector[SetEntry]
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = entries.forall(_.isIdentical)
+    override def productPrefix: String = "SetDiff"
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any = n match {
+      case 0 => entries
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[SetDiff]
+    override def toString: String = s"SetDiff($simpleName, ${entries.size} entries)"
+  }
+  object SetDiff {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        entries: Vector[SetEntry]
+    ): SetDiff = new SetDiff(prettyName, plainName, simpleName, shortName, entries)
+    def unapply(v: SetDiff): Some[Vector[SetEntry]] = Some(v.entries)
+  }
+
+  // ── Optional ───────────────────────────────────────────────
+
+  sealed trait OptionalContent extends Product with Serializable
+  object OptionalContent {
+    final case class BothPresent(diff: DiffResult) extends OptionalContent
+    final case class LeftOnly(snapshot: DiffResult) extends OptionalContent
+    final case class RightOnly(snapshot: DiffResult) extends OptionalContent
+    case object BothAbsent extends OptionalContent
+  }
+
+  final class OptionalDiff private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val inner: OptionalContent
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = inner match {
+      case OptionalContent.BothPresent(d) => d.isIdentical
+      case OptionalContent.BothAbsent     => true
+      case _                              => false
+    }
+    override def productPrefix: String = "OptionalDiff"
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any = n match {
+      case 0 => inner
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[OptionalDiff]
+    override def toString: String = s"OptionalDiff($simpleName, $inner)"
+  }
+  object OptionalDiff {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        inner: OptionalContent
+    ): OptionalDiff = new OptionalDiff(prettyName, plainName, simpleName, shortName, inner)
+    def unapply(v: OptionalDiff): Some[OptionalContent] = Some(v.inner)
+  }
+
+  // ── String (hierarchical Myers) ────────────────────────────
+
+  sealed trait CharChunk extends Product with Serializable
+  object CharChunk {
+    final case class EqualChar(text: String) extends CharChunk
+    final case class InsertChar(text: String) extends CharChunk
+    final case class DeleteChar(text: String) extends CharChunk
+  }
+
+  sealed trait WordChunk extends Product with Serializable
+  object WordChunk {
+    final case class EqualWord(text: String) extends WordChunk
+    final case class InsertWord(text: String) extends WordChunk
+    final case class DeleteWord(text: String) extends WordChunk
+    final case class ChangedWord(chars: Vector[CharChunk]) extends WordChunk
+  }
+
+  sealed trait StringChunk extends Product with Serializable
+  object StringChunk {
+    final case class EqualLine(text: String) extends StringChunk
+    final case class InsertLine(text: String) extends StringChunk
+    final case class DeleteLine(text: String) extends StringChunk
+    final case class ChangedLine(words: Vector[WordChunk]) extends StringChunk
+  }
+
+  final class StringDiff private (
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      val chunks: Vector[StringChunk]
+  ) extends DiffResult(_prettyName, _plainName, _simpleName, _shortName) {
+    def isIdentical: Boolean = chunks.forall {
+      case StringChunk.EqualLine(_) => true
+      case _                        => false
+    }
+    override def productPrefix: String = "StringDiff"
+    override def productArity: Int = 1
+    override def productElement(n: Int): Any = n match {
+      case 0 => chunks
+      case _ => throw new IndexOutOfBoundsException(n.toString)
+    }
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[StringDiff]
+    override def toString: String = s"StringDiff($simpleName, ${chunks.size} chunks)"
+  }
+  object StringDiff {
+    def apply(
+        prettyName: => String,
+        plainName: => String,
+        simpleName: => String,
+        shortName: => String,
+        chunks: Vector[StringChunk]
+    ): StringDiff = new StringDiff(prettyName, plainName, simpleName, shortName, chunks)
+    def unapply(v: StringDiff): Some[Vector[StringChunk]] = Some(v.chunks)
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/DiffResult.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/DiffResult.scala
@@ -174,8 +174,16 @@ object DiffResult {
         rightVariant: String,
         rightSnapshot: DiffResult
     ): TypeMismatch =
-      new TypeMismatch(prettyName, plainName, simpleName, shortName, leftVariant, leftSnapshot, rightVariant,
-        rightSnapshot)
+      new TypeMismatch(
+        prettyName,
+        plainName,
+        simpleName,
+        shortName,
+        leftVariant,
+        leftSnapshot,
+        rightVariant,
+        rightSnapshot
+      )
     def unapply(v: TypeMismatch): Some[(String, DiffResult, String, DiffResult)] =
       Some((v.leftVariant, v.leftSnapshot, v.rightVariant, v.rightSnapshot))
   }

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/Edit.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/Edit.scala
@@ -1,0 +1,8 @@
+package hearth.kindlings.diffderivation
+
+sealed trait Edit[+A] extends Product with Serializable
+object Edit {
+  final case class Equal[+A](value: A) extends Edit[A]
+  final case class Insert[+A](value: A) extends Edit[A]
+  final case class Delete[+A](value: A) extends Edit[A]
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/RenderConfig.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/RenderConfig.scala
@@ -1,0 +1,31 @@
+package hearth.kindlings.diffderivation
+
+sealed trait NameStyle extends Product with Serializable
+object NameStyle {
+  case object Simple extends NameStyle
+  case object Short extends NameStyle
+  case object FullyQualified extends NameStyle
+  case object Pretty extends NameStyle
+}
+
+sealed trait ColorMode extends Product with Serializable
+object ColorMode {
+  case object Plain extends ColorMode
+  case object Ansi extends ColorMode
+}
+
+sealed trait Indent extends Product with Serializable
+object Indent {
+  final case class Spaces(count: Int) extends Indent
+  case object Tab extends Indent
+}
+
+final case class RenderConfig(
+    nameStyle: NameStyle,
+    colorMode: ColorMode,
+    indent: Indent
+)
+object RenderConfig {
+  val default: RenderConfig = RenderConfig(NameStyle.Simple, ColorMode.Ansi, Indent.Spaces(2))
+  val plain: RenderConfig = RenderConfig(NameStyle.Simple, ColorMode.Plain, Indent.Spaces(2))
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/debug/package.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/debug/package.scala
@@ -1,0 +1,6 @@
+package hearth.kindlings.diffderivation
+
+package object debug {
+
+  implicit val logDerivationForDiffDerivation: Diff.LogDerivation = Diff.LogDerivation
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DerivationError.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DerivationError.scala
@@ -1,0 +1,16 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+
+sealed private[compiletime] trait DiffDerivationError
+    extends util.control.NoStackTrace
+    with Product
+    with Serializable {
+  def message: String
+  override def getMessage(): String = message
+}
+
+private[compiletime] object DiffDerivationError {
+
+  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends DiffDerivationError {
+    override def message: String = s"$tpeName not handled by any Diff rule:\n${reasons.mkString("\n")}"
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DerivationError.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DerivationError.scala
@@ -1,9 +1,6 @@
 package hearth.kindlings.diffderivation.internal.compiletime
 
-sealed private[compiletime] trait DiffDerivationError
-    extends util.control.NoStackTrace
-    with Product
-    with Serializable {
+sealed private[compiletime] trait DiffDerivationError extends util.control.NoStackTrace with Product with Serializable {
   def message: String
   override def getMessage(): String = message
 }

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DiffMacrosImpl.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DiffMacrosImpl.scala
@@ -3,8 +3,8 @@ package hearth.kindlings.diffderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
-import hearth.kindlings.diffderivation.internal.runtime._
+import hearth.kindlings.diffderivation.*
+import hearth.kindlings.diffderivation.internal.runtime.*
 
 trait DiffMacrosImpl
     extends hearth.kindlings.derivation.compiletime.DerivationTimeout
@@ -147,7 +147,7 @@ trait DiffMacrosImpl
       implicit val DiffA: Type[Diff[A]] = DiffTypes.Diff[A]
       sctx.cache.get1Ary[A, DiffResult]("cached-snapshot-method").flatMap {
         case Some(helper) => MIO.pure(Rule.matched(helper(sctx.value)))
-        case None =>
+        case None         =>
           sctx.cache.get0Ary[Diff[A]]("cached-diff-instance").map {
             case Some(instance) =>
               Rule.matched(Expr.quote(Expr.splice(instance).snapshot(Expr.splice(sctx.value))))
@@ -169,9 +169,11 @@ trait DiffMacrosImpl
         DiffA.summonExprIgnoring(ignoredImplicits*).toEither match {
           case Right(instanceExpr) =>
             val expr = instanceExpr.asInstanceOf[Expr[Diff[A]]]
-            MIO.pure(Rule.matched(
-              Expr.quote(Expr.splice(expr).snapshot(Expr.splice(sctx.value)))
-            ))
+            MIO.pure(
+              Rule.matched(
+                Expr.quote(Expr.splice(expr).snapshot(Expr.splice(sctx.value)))
+              )
+            )
           case Left(_) =>
             MIO.pure(Rule.yielded(s"No implicit Diff[${Type[A].prettyPrint}]"))
         }
@@ -188,8 +190,13 @@ trait DiffMacrosImpl
       val sn = Expr(Type.shortName[A])
       if (Type[A] <:< DiffTypes.StringType) {
         Rule.matched(Expr.quote {
-          DiffRuntime.snapshotString(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-            Expr.splice(sctx.value.upcast[String]))
+          DiffRuntime.snapshotString(
+            Expr.splice(pn),
+            Expr.splice(fn),
+            Expr.splice(sn),
+            Expr.splice(sn),
+            Expr.splice(sctx.value.upcast[String])
+          )
         })
       } else if (
         Type[A] <:< DiffTypes.BooleanType || Type[A] <:< DiffTypes.ByteType ||
@@ -199,8 +206,13 @@ trait DiffMacrosImpl
         Type[A] <:< DiffTypes.BigDecimalType || Type[A] <:< DiffTypes.BigIntType
       ) {
         Rule.matched(Expr.quote {
-          DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-            Expr.splice(sctx.value).toString)
+          DiffResult.Identical(
+            Expr.splice(pn),
+            Expr.splice(fn),
+            Expr.splice(sn),
+            Expr.splice(sn),
+            Expr.splice(sctx.value).toString
+          )
         })
       } else {
         Rule.yielded(s"${Type[A].prettyPrint} is not a built-in type")
@@ -217,8 +229,7 @@ trait DiffMacrosImpl
           val pn = Expr(Type.prettyPrint[A])
           val fn = Expr(Type.plainPrint[A])
           MIO.pure(Rule.matched(Expr.quote {
-            DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-              Expr.splice(sn))
+            DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn), Expr.splice(sn))
           }))
         case Left(reason) =>
           MIO.pure(Rule.yielded(reason.toString))
@@ -274,14 +285,24 @@ trait DiffMacrosImpl
                 Expr.quote(Expr.splice(item) +: Expr.splice(acc))
               }
               Expr.quote {
-                DiffResult.Record(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-                  Expr.splice(fieldsVec))
+                DiffResult.Record(
+                  Expr.splice(pn),
+                  Expr.splice(fn),
+                  Expr.splice(sn),
+                  Expr.splice(sn),
+                  Expr.splice(fieldsVec)
+                )
               }
             }
         case None =>
           MIO.pure(Expr.quote {
-            DiffResult.Record(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-              Vector.empty[(String, DiffResult)])
+            DiffResult.Record(
+              Expr.splice(pn),
+              Expr.splice(fn),
+              Expr.splice(sn),
+              Expr.splice(sn),
+              Vector.empty[(String, DiffResult)]
+            )
           })
       }
     }
@@ -320,13 +341,18 @@ trait DiffMacrosImpl
         }
         .flatMap {
           case Some(result) => MIO.pure(result)
-          case None =>
+          case None         =>
             val sn = Expr(Type.shortName[A])
             val pn = Expr(Type.prettyPrint[A])
             val fn = Expr(Type.plainPrint[A])
             MIO.pure(Expr.quote {
-              DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-                Expr.splice(value).toString)
+              DiffResult.Identical(
+                Expr.splice(pn),
+                Expr.splice(fn),
+                Expr.splice(sn),
+                Expr.splice(sn),
+                Expr.splice(value).toString
+              )
             })
         }
     }
@@ -341,8 +367,13 @@ trait DiffMacrosImpl
       val pn = Expr(Type.prettyPrint[A])
       val fn = Expr(Type.plainPrint[A])
       MIO.pure(Rule.matched(Expr.quote {
-        DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-          Expr.splice(sctx.value).toString)
+        DiffResult.Identical(
+          Expr.splice(pn),
+          Expr.splice(fn),
+          Expr.splice(sn),
+          Expr.splice(sn),
+          Expr.splice(sctx.value).toString
+        )
       }))
     }
   }
@@ -402,9 +433,7 @@ trait DiffMacrosImpl
               _ <- deriveDiffRecursively[A](using
                 DiffCtx[A](Type[A], placeholderLeft, placeholderRight, sharedCache, selfType)
               ).parTuple(
-                deriveSnapshotRecursively[A](using
-                  SnapshotCtx[A](Type[A], placeholderVal, sharedCache, selfType)
-                )
+                deriveSnapshotRecursively[A](using SnapshotCtx[A](Type[A], placeholderVal, sharedCache, selfType))
               )
             } yield ()
           }
@@ -452,56 +481,59 @@ trait DiffMacrosImpl
           val prettyNameExpr: Expr[String] = Type.runtimePrettyPrint[A] { tpe =>
             import tpe.Underlying
             if (tpe.Underlying =:= Type[A]) None
-            else summonCachedDiffForName[tpe.Underlying].map { d =>
-              Expr.quote(Expr.splice(d).prettyName)
-            }
+            else
+              summonCachedDiffForName[tpe.Underlying].map { d =>
+                Expr.quote(Expr.splice(d).prettyName)
+              }
           }
 
           val plainNameExpr: Expr[String] = Type.runtimePlainPrint[A] { tpe =>
             import tpe.Underlying
             if (tpe.Underlying =:= Type[A]) None
-            else summonCachedDiffForName[tpe.Underlying].map { d =>
-              Expr.quote(Expr.splice(d).plainName)
-            }
+            else
+              summonCachedDiffForName[tpe.Underlying].map { d =>
+                Expr.quote(Expr.splice(d).plainName)
+              }
           }
 
           val simpleNameExpr: Expr[String] = Type.runtimeShortPrint[A] { tpe =>
             import tpe.Underlying
             if (tpe.Underlying =:= Type[A]) None
-            else summonCachedDiffForName[tpe.Underlying] match {
-              case Some(d) => Some(Expr.quote(Expr.splice(d).simpleName))
-              case None =>
-                val plain = Type.plainPrint[tpe.Underlying]
-                if (plain.contains("[")) None
-                else Some(Expr(Type.shortName[tpe.Underlying]))
-            }
+            else
+              summonCachedDiffForName[tpe.Underlying] match {
+                case Some(d) => Some(Expr.quote(Expr.splice(d).simpleName))
+                case None    =>
+                  val plain = Type.plainPrint[tpe.Underlying]
+                  if (plain.contains("[")) None
+                  else Some(Expr(Type.shortName[tpe.Underlying]))
+              }
           }
 
           val shortNameExpr: Expr[String] = Expr(Type.shortName[A])
 
           val cacheState = runSafe(sharedCache.get)
           nameCache.toValDefs.use { _ =>
-          cacheState.toValDefs.use { _ =>
-            Expr
-              .quote {
-                DiffFactories.instance[A](
-                  Expr.splice(prettyNameExpr),
-                  Expr.splice(plainNameExpr),
-                  Expr.splice(simpleNameExpr),
-                  Expr.splice(shortNameExpr),
-                  (left: A, right: A) => {
-                    val _ = left
-                    val _ = right
-                    Expr.splice(diffCallFor(Expr.quote(left), Expr.quote(right)))
-                  },
-                  (value: A) => {
-                    val _ = value
-                    Expr.splice(snapCallFor(Expr.quote(value)))
-                  }
-                )
-              }
-              .asInstanceOf[Expr[Diff[A]]]
-          }
+            cacheState.toValDefs.use { _ =>
+              Expr
+                .quote {
+                  DiffFactories.instance[A](
+                    Expr.splice(prettyNameExpr),
+                    Expr.splice(plainNameExpr),
+                    Expr.splice(simpleNameExpr),
+                    Expr.splice(shortNameExpr),
+                    (left: A, right: A) => {
+                      val _ = left
+                      val _ = right
+                      Expr.splice(diffCallFor(Expr.quote(left), Expr.quote(right)))
+                    },
+                    (value: A) => {
+                      val _ = value
+                      Expr.splice(snapCallFor(Expr.quote(value)))
+                    }
+                  )
+                }
+                .asInstanceOf[Expr[Diff[A]]]
+            }
           }
         }
       }

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DiffMacrosImpl.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DiffMacrosImpl.scala
@@ -1,0 +1,522 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.internal.runtime._
+
+trait DiffMacrosImpl
+    extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with hearth.kindlings.derivation.compiletime.LoadStandardExtensionsOnce
+    with rules.DiffUseCachedRuleImpl
+    with rules.DiffUseImplicitRuleImpl
+    with rules.DiffBuiltInRuleImpl
+    with rules.DiffValueTypeRuleImpl
+    with rules.DiffOptionRuleImpl
+    with rules.DiffMapRuleImpl
+    with rules.DiffCollectionRuleImpl
+    with rules.DiffSingletonRuleImpl
+    with rules.DiffCaseClassRuleImpl
+    with rules.DiffEnumRuleImpl { this: MacroCommons & StdExtensions =>
+
+  override protected def derivationSettingsNamespace: String = "diffDerivation"
+
+  // ── Type references ───────────────────────────────────────
+
+  protected object DiffTypes {
+    def DiffCtor: Type.Ctor1[Diff] = Type.Ctor1.of[Diff]
+    def Diff[A: Type]: Type[Diff[A]] = DiffCtor.apply[A]
+    val DiffResultType: Type[DiffResult] = Type.of[DiffResult]
+    val StringType: Type[String] = Type.of[String]
+    val BooleanType: Type[Boolean] = Type.of[Boolean]
+    val IntType: Type[Int] = Type.of[Int]
+    val ByteType: Type[Byte] = Type.of[Byte]
+    val ShortType: Type[Short] = Type.of[Short]
+    val LongType: Type[Long] = Type.of[Long]
+    val FloatType: Type[Float] = Type.of[Float]
+    val DoubleType: Type[Double] = Type.of[Double]
+    val CharType: Type[Char] = Type.of[Char]
+    val BigDecimalType: Type[BigDecimal] = Type.of[BigDecimal]
+    val BigIntType: Type[BigInt] = Type.of[BigInt]
+  }
+
+  // ── Diff derivation (two values → DiffResult) ────────────
+
+  final case class DiffCtx[A](
+      tpe: Type[A],
+      left: Expr[A],
+      right: Expr[A],
+      cache: MLocal[ValDefsCache],
+      derivedType: Option[??]
+  ) {
+    def nest[B: Type](newLeft: Expr[B], newRight: Expr[B]): DiffCtx[B] =
+      DiffCtx(Type[B], newLeft, newRight, cache, derivedType)
+  }
+
+  def dctx[A](implicit A: DiffCtx[A]): DiffCtx[A] = A
+  implicit def diffCtxType[A: DiffCtx]: Type[A] = dctx.tpe
+
+  abstract class DiffDerivationRule(val name: String) extends Rule {
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]]
+  }
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  def deriveDiffRecursively[A: DiffCtx]: MIO[Expr[DiffResult]] =
+    Log.namedScope(s"Deriving Diff for ${Type[A].prettyPrint}") {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      Rules(
+        DiffUseCachedRule,
+        DiffUseImplicitRule,
+        DiffBuiltInRule,
+        DiffValueTypeRule,
+        DiffOptionRule,
+        DiffMapRule,
+        DiffCollectionRule,
+        DiffSingletonRule,
+        DiffCaseClassRule,
+        DiffEnumRule
+      )(_[A]).flatMap {
+        case Right(result) =>
+          Log.info(s"Derived Diff for ${Type[A].prettyPrint}") >> MIO.pure(result)
+        case Left(reasons) =>
+          val reasonsStrings = reasons.toListMap
+            .removed(DiffUseCachedRule)
+            .view
+            .map { case (rule, reasons) =>
+              if (reasons.isEmpty) s" - ${rule.name}: not applicable"
+              else s" - ${rule.name}: ${reasons.mkString(", ")}"
+            }
+            .toList
+          MIO.fail(DiffDerivationError.UnsupportedType(Type[A].prettyPrint, reasonsStrings))
+      }
+    }
+
+  // ── Snapshot derivation (one value → DiffResult) ─────────
+
+  final case class SnapshotCtx[A](
+      tpe: Type[A],
+      value: Expr[A],
+      cache: MLocal[ValDefsCache],
+      derivedType: Option[??]
+  ) {
+    def nest[B: Type](newValue: Expr[B]): SnapshotCtx[B] =
+      SnapshotCtx(Type[B], newValue, cache, derivedType)
+  }
+
+  def sctx[A](implicit A: SnapshotCtx[A]): SnapshotCtx[A] = A
+  implicit def snapshotCtxType[A: SnapshotCtx]: Type[A] = sctx.tpe
+
+  abstract class SnapshotDerivationRule(val name: String) extends Rule {
+    def apply[A: SnapshotCtx]: MIO[Rule.Applicability[Expr[DiffResult]]]
+  }
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  def deriveSnapshotRecursively[A: SnapshotCtx]: MIO[Expr[DiffResult]] =
+    Log.namedScope(s"Deriving Snapshot for ${Type[A].prettyPrint}") {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      Rules(
+        SnapshotUseCachedRule,
+        SnapshotUseImplicitRule,
+        SnapshotBuiltInRule,
+        SnapshotSingletonRule,
+        SnapshotCaseClassRule,
+        SnapshotEnumRule,
+        SnapshotFallbackRule
+      )(_[A]).flatMap {
+        case Right(result) =>
+          Log.info(s"Derived Snapshot for ${Type[A].prettyPrint}") >> MIO.pure(result)
+        case Left(reasons) =>
+          val reasonsStrings = reasons.toListMap
+            .removed(SnapshotUseCachedRule)
+            .view
+            .map { case (rule, reasons) =>
+              if (reasons.isEmpty) s" - ${rule.name}: not applicable"
+              else s" - ${rule.name}: ${reasons.mkString(", ")}"
+            }
+            .toList
+          MIO.fail(DiffDerivationError.UnsupportedType(Type[A].prettyPrint, reasonsStrings))
+      }
+    }
+
+  // ── Snapshot rules (inlined — simpler than diff rules) ───
+
+  object SnapshotUseCachedRule extends SnapshotDerivationRule("use cached Snapshot") {
+    def apply[A: SnapshotCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] = {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      implicit val DiffA: Type[Diff[A]] = DiffTypes.Diff[A]
+      sctx.cache.get1Ary[A, DiffResult]("cached-snapshot-method").flatMap {
+        case Some(helper) => MIO.pure(Rule.matched(helper(sctx.value)))
+        case None =>
+          sctx.cache.get0Ary[Diff[A]]("cached-diff-instance").map {
+            case Some(instance) =>
+              Rule.matched(Expr.quote(Expr.splice(instance).snapshot(Expr.splice(sctx.value))))
+            case None =>
+              Rule.yielded(s"No cached Snapshot for ${Type[A].prettyPrint}")
+          }
+      }
+    }
+  }
+
+  object SnapshotUseImplicitRule extends SnapshotDerivationRule("use implicit for Snapshot") {
+    @scala.annotation.nowarn("msg=is never used|unused")
+    def apply[A: SnapshotCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] = {
+      implicit val DiffA: Type[Diff[A]] = DiffTypes.Diff[A]
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      if (sctx.derivedType.exists(_.Underlying =:= Type[A]))
+        MIO.pure(Rule.yielded(s"${Type[A].prettyPrint} is the self-type"))
+      else
+        DiffA.summonExprIgnoring(ignoredImplicits*).toEither match {
+          case Right(instanceExpr) =>
+            val expr = instanceExpr.asInstanceOf[Expr[Diff[A]]]
+            MIO.pure(Rule.matched(
+              Expr.quote(Expr.splice(expr).snapshot(Expr.splice(sctx.value)))
+            ))
+          case Left(_) =>
+            MIO.pure(Rule.yielded(s"No implicit Diff[${Type[A].prettyPrint}]"))
+        }
+    }
+  }
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  object SnapshotBuiltInRule extends SnapshotDerivationRule("built-in Snapshot for primitives") {
+    def apply[A: SnapshotCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] = MIO {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      implicit val ST: Type[String] = DiffTypes.StringType
+      val pn = Expr(Type.prettyPrint[A])
+      val fn = Expr(Type.plainPrint[A])
+      val sn = Expr(Type.shortName[A])
+      if (Type[A] <:< DiffTypes.StringType) {
+        Rule.matched(Expr.quote {
+          DiffRuntime.snapshotString(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+            Expr.splice(sctx.value.upcast[String]))
+        })
+      } else if (
+        Type[A] <:< DiffTypes.BooleanType || Type[A] <:< DiffTypes.ByteType ||
+        Type[A] <:< DiffTypes.ShortType || Type[A] <:< DiffTypes.IntType ||
+        Type[A] <:< DiffTypes.LongType || Type[A] <:< DiffTypes.FloatType ||
+        Type[A] <:< DiffTypes.DoubleType || Type[A] <:< DiffTypes.CharType ||
+        Type[A] <:< DiffTypes.BigDecimalType || Type[A] <:< DiffTypes.BigIntType
+      ) {
+        Rule.matched(Expr.quote {
+          DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+            Expr.splice(sctx.value).toString)
+        })
+      } else {
+        Rule.yielded(s"${Type[A].prettyPrint} is not a built-in type")
+      }
+    }
+  }
+
+  object SnapshotSingletonRule extends SnapshotDerivationRule("Snapshot as singleton") {
+    def apply[A: SnapshotCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      SingletonValue.parse[A].toEither match {
+        case Right(_) =>
+          implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+          val sn = Expr(Type.shortName[A])
+          val pn = Expr(Type.prettyPrint[A])
+          val fn = Expr(Type.plainPrint[A])
+          MIO.pure(Rule.matched(Expr.quote {
+            DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+              Expr.splice(sn))
+          }))
+        case Left(reason) =>
+          MIO.pure(Rule.yielded(reason.toString))
+      }
+  }
+
+  object SnapshotCaseClassRule extends SnapshotDerivationRule("Snapshot as case class") {
+    @scala.annotation.nowarn("msg=is never used|unused")
+    def apply[A: SnapshotCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      CaseClass.parse[A].toEither match {
+        case Right(caseClass) =>
+          implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+          implicit val ST: Type[String] = DiffTypes.StringType
+          val defBuilder = ValDefBuilder.ofDef1[A, DiffResult](s"snapshot_${Type[A].shortName}")
+          for {
+            _ <- sctx.cache.forwardDeclare("cached-snapshot-method", defBuilder)
+            _ <- MIO.scoped { runSafe =>
+              runSafe(sctx.cache.buildCachedWith("cached-snapshot-method", defBuilder) { case (_, value) =>
+                runSafe(deriveSnapshotCaseClass[A](caseClass, value))
+              })
+            }
+            result <- SnapshotUseCachedRule[A]
+          } yield result
+        case Left(reason) =>
+          MIO.pure(Rule.yielded(reason.toString))
+      }
+
+    private def deriveSnapshotCaseClass[A: SnapshotCtx](
+        caseClass: CaseClass[A],
+        value: Expr[A]
+    ): MIO[Expr[DiffResult]] = {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      val fields = caseClass.caseFieldValuesAt(value).toList
+      val pn = Expr(Type.prettyPrint[A])
+      val fn = Expr(Type.plainPrint[A])
+      val sn = Expr(Type.shortName[A])
+
+      hearth.fp.data.NonEmptyList.fromList(fields) match {
+        case Some(fieldValues) =>
+          import hearth.fp.syntax.*
+          fieldValues
+            .traverse { case (fieldName, fieldValue) =>
+              import fieldValue.{Underlying as Field, value as fieldExpr}
+              Log.namedScope(s"Snapshot field $fieldName: ${Field.prettyPrint}") {
+                deriveSnapshotRecursively[Field](using sctx.nest(fieldExpr)).map(r => (fieldName, r))
+              }
+            }
+            .map { results =>
+              val fieldExprs = results.toList.map { case (name, expr) =>
+                Expr.quote((Expr.splice(Expr(name)), Expr.splice(expr)))
+              }
+              val fieldsVec = fieldExprs.foldRight(Expr.quote(Vector.empty[(String, DiffResult)])) { (item, acc) =>
+                Expr.quote(Expr.splice(item) +: Expr.splice(acc))
+              }
+              Expr.quote {
+                DiffResult.Record(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                  Expr.splice(fieldsVec))
+              }
+            }
+        case None =>
+          MIO.pure(Expr.quote {
+            DiffResult.Record(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+              Vector.empty[(String, DiffResult)])
+          })
+      }
+    }
+  }
+
+  @scala.annotation.nowarn("msg=is never used|is unchecked")
+  object SnapshotEnumRule extends SnapshotDerivationRule("Snapshot as enum") {
+    def apply[A: SnapshotCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      Enum.parse[A].toEither match {
+        case Right(enumm) =>
+          implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+          val defBuilder = ValDefBuilder.ofDef1[A, DiffResult](s"snapshot_${Type[A].shortName}")
+          for {
+            _ <- sctx.cache.forwardDeclare("cached-snapshot-method", defBuilder)
+            _ <- MIO.scoped { runSafe =>
+              runSafe(sctx.cache.buildCachedWith("cached-snapshot-method", defBuilder) { case (_, value) =>
+                runSafe(deriveSnapshotEnum[A](enumm, value))
+              })
+            }
+            result <- SnapshotUseCachedRule[A]
+          } yield result
+        case Left(reason) =>
+          MIO.pure(Rule.yielded(reason.toString))
+      }
+
+    private def deriveSnapshotEnum[A: SnapshotCtx](
+        enumm: Enum[A],
+        value: Expr[A]
+    ): MIO[Expr[DiffResult]] = {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      implicit val ST: Type[String] = DiffTypes.StringType
+      enumm
+        .matchOn[MIO, DiffResult](value) { matchedValue =>
+          import matchedValue.{value as caseValue, Underlying as EnumCase}
+          deriveSnapshotRecursively[EnumCase](using sctx.nest(caseValue))
+        }
+        .flatMap {
+          case Some(result) => MIO.pure(result)
+          case None =>
+            val sn = Expr(Type.shortName[A])
+            val pn = Expr(Type.prettyPrint[A])
+            val fn = Expr(Type.plainPrint[A])
+            MIO.pure(Expr.quote {
+              DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                Expr.splice(value).toString)
+            })
+        }
+    }
+  }
+
+  object SnapshotFallbackRule extends SnapshotDerivationRule("Snapshot fallback (toString)") {
+    @scala.annotation.nowarn("msg=is never used|unused")
+    def apply[A: SnapshotCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] = {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      implicit val ST: Type[String] = DiffTypes.StringType
+      val sn = Expr(Type.shortName[A])
+      val pn = Expr(Type.prettyPrint[A])
+      val fn = Expr(Type.plainPrint[A])
+      MIO.pure(Rule.matched(Expr.quote {
+        DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+          Expr.splice(sctx.value).toString)
+      }))
+    }
+  }
+
+  // ── Entry point ──────────────────────────────────────────
+
+  private var nameCache: ValDefsCache = ValDefsCache.empty
+
+  private def summonCachedDiffForName[X: Type]: Option[Expr[Diff[X]]] = {
+    implicit val DiffX: Type[Diff[X]] = DiffTypes.Diff[X]
+    nameCache.get0Ary[Diff[X]]("diff-for-name").orElse {
+      DiffX.summonExprIgnoring(ignoredImplicits*).toOption.map { expr =>
+        val typedExpr = expr.asInstanceOf[Expr[Diff[X]]]
+        val builder = ValDefBuilder.ofLazy[Diff[X]](s"diffName_${Type[X].shortName}")
+        nameCache = builder.buildCachedWith(nameCache, "diff-for-name")(_ => typedExpr)
+        nameCache.get0Ary[Diff[X]]("diff-for-name").get
+      }
+    }
+  }
+
+  protected lazy val ignoredImplicits: Seq[UntypedMethod] =
+    Type
+      .of[Diff.type]
+      .asUntyped
+      .methods
+      .collect { case method if method.name == "derived" => method }
+      .toSeq
+
+  protected def shouldWeLogDiffDerivation: Boolean =
+    Type.of[Diff.LogDerivation].summonExprIgnoring().toOption.isDefined
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  def deriveTypeClass[A: Type]: Expr[Diff[A]] = {
+    val macroName = "Diff.derived"
+    implicit val DiffA: Type[Diff[A]] = DiffTypes.Diff[A]
+    implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+    implicit val ST: Type[String] = DiffTypes.StringType
+    val selfType: Option[??] = Some(Type[A].as_??)
+
+    if (Type[A] =:= Type.of[Nothing].asInstanceOf[Type[A]] || Type[A] =:= Type.of[Any].asInstanceOf[Type[A]])
+      Environment.reportErrorAndAbort(
+        s"$macroName: type parameter was inferred as ${Type[A].prettyPrint}, which is likely unintended."
+      )
+
+    Log
+      .namedScope(s"Deriving $macroName[${Type[A].prettyPrint}] at: ${Environment.currentPosition.prettyPrint}") {
+        MIO.scoped { runSafe =>
+          val sharedCache = ValDefsCache.mlocal
+
+          val placeholderLeft: Expr[A] = Expr.quote(null.asInstanceOf[A])
+          val placeholderRight: Expr[A] = Expr.quote(null.asInstanceOf[A])
+          val placeholderVal: Expr[A] = Expr.quote(null.asInstanceOf[A])
+
+          runSafe {
+            for {
+              _ <- ensureStandardExtensionsLoaded()
+              _ <- deriveDiffRecursively[A](using
+                DiffCtx[A](Type[A], placeholderLeft, placeholderRight, sharedCache, selfType)
+              ).parTuple(
+                deriveSnapshotRecursively[A](using
+                  SnapshotCtx[A](Type[A], placeholderVal, sharedCache, selfType)
+                )
+              )
+            } yield ()
+          }
+
+          val cacheStateAfterRules = runSafe(sharedCache.get)
+          val diffBuilder = ValDefBuilder.ofDef2[A, A, DiffResult](s"diff_${Type[A].shortName}")
+          val snapBuilder = ValDefBuilder.ofDef1[A, DiffResult](s"snapshot_${Type[A].shortName}")
+          val diffBuilt = diffBuilder.isBuilt(cacheStateAfterRules, "cached-diff-method")
+          val snapBuilt = snapBuilder.isBuilt(cacheStateAfterRules, "cached-snapshot-method")
+
+          val diffCallFor: (Expr[A], Expr[A]) => Expr[DiffResult] =
+            if (diffBuilt) {
+              runSafe(sharedCache.get2Ary[A, A, DiffResult]("cached-diff-method")).get
+            } else {
+              val key = s"entry-diff:${Type[A].prettyPrint}"
+              val builder = ValDefBuilder.ofDef2[A, A, DiffResult](s"diff_${Type[A].shortName}")
+              runSafe {
+                MIO.scoped { rs =>
+                  rs(sharedCache.buildCachedWith(key, builder) { case (_, (l, r)) =>
+                    rs(deriveDiffRecursively[A](using DiffCtx[A](Type[A], l, r, sharedCache, selfType)))
+                  })
+                }
+              }
+              runSafe(sharedCache.get2Ary[A, A, DiffResult](key)).get
+            }
+
+          val snapCallFor: Expr[A] => Expr[DiffResult] =
+            if (snapBuilt) {
+              runSafe(sharedCache.get1Ary[A, DiffResult]("cached-snapshot-method")).get
+            } else {
+              val key = s"entry-snap:${Type[A].prettyPrint}"
+              val builder = ValDefBuilder.ofDef1[A, DiffResult](s"snapshot_${Type[A].shortName}")
+              runSafe {
+                MIO.scoped { rs =>
+                  rs(sharedCache.buildCachedWith(key, builder) { case (_, v) =>
+                    rs(deriveSnapshotRecursively[A](using SnapshotCtx[A](Type[A], v, sharedCache, selfType)))
+                  })
+                }
+              }
+              runSafe(sharedCache.get1Ary[A, DiffResult](key)).get
+            }
+
+          nameCache = ValDefsCache.empty
+
+          val prettyNameExpr: Expr[String] = Type.runtimePrettyPrint[A] { tpe =>
+            import tpe.Underlying
+            if (tpe.Underlying =:= Type[A]) None
+            else summonCachedDiffForName[tpe.Underlying].map { d =>
+              Expr.quote(Expr.splice(d).prettyName)
+            }
+          }
+
+          val plainNameExpr: Expr[String] = Type.runtimePlainPrint[A] { tpe =>
+            import tpe.Underlying
+            if (tpe.Underlying =:= Type[A]) None
+            else summonCachedDiffForName[tpe.Underlying].map { d =>
+              Expr.quote(Expr.splice(d).plainName)
+            }
+          }
+
+          val simpleNameExpr: Expr[String] = Type.runtimeShortPrint[A] { tpe =>
+            import tpe.Underlying
+            if (tpe.Underlying =:= Type[A]) None
+            else summonCachedDiffForName[tpe.Underlying] match {
+              case Some(d) => Some(Expr.quote(Expr.splice(d).simpleName))
+              case None =>
+                val plain = Type.plainPrint[tpe.Underlying]
+                if (plain.contains("[")) None
+                else Some(Expr(Type.shortName[tpe.Underlying]))
+            }
+          }
+
+          val shortNameExpr: Expr[String] = Expr(Type.shortName[A])
+
+          val cacheState = runSafe(sharedCache.get)
+          nameCache.toValDefs.use { _ =>
+          cacheState.toValDefs.use { _ =>
+            Expr
+              .quote {
+                DiffFactories.instance[A](
+                  Expr.splice(prettyNameExpr),
+                  Expr.splice(plainNameExpr),
+                  Expr.splice(simpleNameExpr),
+                  Expr.splice(shortNameExpr),
+                  (left: A, right: A) => {
+                    val _ = left
+                    val _ = right
+                    Expr.splice(diffCallFor(Expr.quote(left), Expr.quote(right)))
+                  },
+                  (value: A) => {
+                    val _ = value
+                    Expr.splice(snapCallFor(Expr.quote(value)))
+                  }
+                )
+              }
+              .asInstanceOf[Expr[Diff[A]]]
+          }
+          }
+        }
+      }
+      .flatTap(result => Log.info(s"Derived final result: ${result.prettyPrint}"))
+      .runToExprOrFail(
+        macroName,
+        infoRendering = if (shouldWeLogDiffDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        errorRendering = if (shouldWeLogDiffDerivation) RenderFrom(Log.Level.Info) else DontRender,
+        timeout = derivationTimeout
+      ) { (errorLogs, errors) =>
+        val errorsRendered = errors.map(e => "  - " + e.getMessage).mkString("\n")
+        val hint =
+          "Enable debug logging with: import hearth.kindlings.diffderivation.debug.logDerivationForDiffDerivation"
+        if (errorLogs.nonEmpty) s"Macro derivation failed:\n$errorsRendered\nlogs:\n$errorLogs\n$hint"
+        else s"Macro derivation failed:\n$errorsRendered\n$hint"
+      }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffBuiltInRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffBuiltInRule.scala
@@ -4,8 +4,8 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
-import hearth.kindlings.diffderivation.internal.runtime._
+import hearth.kindlings.diffderivation.*
+import hearth.kindlings.diffderivation.internal.runtime.*
 
 trait DiffBuiltInRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 
@@ -22,8 +22,13 @@ trait DiffBuiltInRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions 
       if (Type[A] <:< DiffTypes.StringType) {
         Rule.matched(Expr.quote {
           DiffRuntime.diffString(
-            Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-            Expr.splice(dctx.left.upcast[String]), Expr.splice(dctx.right.upcast[String]))
+            Expr.splice(pn),
+            Expr.splice(fn),
+            Expr.splice(sn),
+            Expr.splice(sn),
+            Expr.splice(dctx.left.upcast[String]),
+            Expr.splice(dctx.right.upcast[String])
+          )
         })
       } else if (
         Type[A] <:< DiffTypes.BooleanType || Type[A] <:< DiffTypes.ByteType ||
@@ -38,8 +43,8 @@ trait DiffBuiltInRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions 
           if (l == r)
             DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn), l.toString)
           else
-            DiffResult.ValueChanged(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-              l.toString, r.toString)
+            DiffResult
+              .ValueChanged(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn), l.toString, r.toString)
         })
       } else {
         Rule.yielded(s"${Type[A].prettyPrint} is not a built-in type")

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffBuiltInRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffBuiltInRule.scala
@@ -1,0 +1,49 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.internal.runtime._
+
+trait DiffBuiltInRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  object DiffBuiltInRule extends DiffDerivationRule("built-in Diff for primitives/String") {
+
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] = MIO {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      implicit val ST: Type[String] = DiffTypes.StringType
+      val pn = Expr(Type.prettyPrint[A])
+      val fn = Expr(Type.plainPrint[A])
+      val sn = Expr(Type.shortName[A])
+
+      if (Type[A] <:< DiffTypes.StringType) {
+        Rule.matched(Expr.quote {
+          DiffRuntime.diffString(
+            Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+            Expr.splice(dctx.left.upcast[String]), Expr.splice(dctx.right.upcast[String]))
+        })
+      } else if (
+        Type[A] <:< DiffTypes.BooleanType || Type[A] <:< DiffTypes.ByteType ||
+        Type[A] <:< DiffTypes.ShortType || Type[A] <:< DiffTypes.IntType ||
+        Type[A] <:< DiffTypes.LongType || Type[A] <:< DiffTypes.FloatType ||
+        Type[A] <:< DiffTypes.DoubleType || Type[A] <:< DiffTypes.CharType ||
+        Type[A] <:< DiffTypes.BigDecimalType || Type[A] <:< DiffTypes.BigIntType
+      ) {
+        Rule.matched(Expr.quote {
+          val l = Expr.splice(dctx.left)
+          val r = Expr.splice(dctx.right)
+          if (l == r)
+            DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn), l.toString)
+          else
+            DiffResult.ValueChanged(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+              l.toString, r.toString)
+        })
+      } else {
+        Rule.yielded(s"${Type[A].prettyPrint} is not a built-in type")
+      }
+    }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCaseClassRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCaseClassRule.scala
@@ -1,0 +1,76 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.data.NonEmptyList
+import hearth.fp.effect.*
+import hearth.fp.syntax.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+
+trait DiffCaseClassRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  object DiffCaseClassRule extends DiffDerivationRule("Diff as case class") {
+
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      CaseClass.parse[A].toEither match {
+        case Right(caseClass) =>
+          implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+          val defBuilder = ValDefBuilder.ofDef2[A, A, DiffResult](s"diff_${Type[A].shortName}")
+          for {
+            _ <- dctx.cache.forwardDeclare("cached-diff-method", defBuilder)
+            _ <- MIO.scoped { runSafe =>
+              runSafe(dctx.cache.buildCachedWith("cached-diff-method", defBuilder) { case (_, (left, right)) =>
+                runSafe(deriveCaseClassDiff[A](caseClass, left, right))
+              })
+            }
+            result <- DiffUseCachedRule[A]
+          } yield result
+        case Left(reason) =>
+          MIO.pure(Rule.yielded(reason.toString))
+      }
+
+    private def deriveCaseClassDiff[A: DiffCtx](
+        caseClass: CaseClass[A],
+        left: Expr[A],
+        right: Expr[A]
+    ): MIO[Expr[DiffResult]] = {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      val fieldsLeft = caseClass.caseFieldValuesAt(left).toList
+      val fieldsRight = caseClass.caseFieldValuesAt(right).toList
+      val pn = Expr(Type.prettyPrint[A])
+      val fn = Expr(Type.plainPrint[A])
+      val sn = Expr(Type.shortName[A])
+
+      NonEmptyList.fromList(fieldsLeft.zip(fieldsRight)) match {
+        case Some(fieldPairs) =>
+          fieldPairs
+            .traverse { case ((fieldName, fieldValueL), (_, fieldValueR)) =>
+              import fieldValueL.Underlying as Field
+              val fl = fieldValueL.value.asInstanceOf[Expr[Field]]
+              val fr = fieldValueR.value.asInstanceOf[Expr[Field]]
+              Log.namedScope(s"Deriving Diff for field $fieldName: ${Field.prettyPrint}") {
+                deriveDiffRecursively[Field](using dctx.nest(fl, fr)).map(r => (fieldName, r))
+              }
+            }
+            .map { results =>
+              val fieldExprs = results.toList.map { case (name, expr) =>
+                Expr.quote((Expr.splice(Expr(name)), Expr.splice(expr)))
+              }
+              val fieldsVec = fieldExprs.foldRight(Expr.quote(Vector.empty[(String, DiffResult)])) { (item, acc) =>
+                Expr.quote(Expr.splice(item) +: Expr.splice(acc))
+              }
+              Expr.quote {
+                DiffResult.Record(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                  Expr.splice(fieldsVec))
+              }
+            }
+        case None =>
+          MIO.pure(Expr.quote {
+            DiffResult.Record(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+              Vector.empty[(String, DiffResult)])
+          })
+      }
+    }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCaseClassRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCaseClassRule.scala
@@ -6,7 +6,7 @@ import hearth.fp.data.NonEmptyList
 import hearth.fp.effect.*
 import hearth.fp.syntax.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.*
 
 trait DiffCaseClassRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 
@@ -61,14 +61,24 @@ trait DiffCaseClassRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtension
                 Expr.quote(Expr.splice(item) +: Expr.splice(acc))
               }
               Expr.quote {
-                DiffResult.Record(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-                  Expr.splice(fieldsVec))
+                DiffResult.Record(
+                  Expr.splice(pn),
+                  Expr.splice(fn),
+                  Expr.splice(sn),
+                  Expr.splice(sn),
+                  Expr.splice(fieldsVec)
+                )
               }
             }
         case None =>
           MIO.pure(Expr.quote {
-            DiffResult.Record(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-              Vector.empty[(String, DiffResult)])
+            DiffResult.Record(
+              Expr.splice(pn),
+              Expr.splice(fn),
+              Expr.splice(sn),
+              Expr.splice(sn),
+              Vector.empty[(String, DiffResult)]
+            )
           })
       }
     }

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCollectionRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCollectionRule.scala
@@ -1,0 +1,47 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.internal.runtime._
+
+trait DiffCollectionRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  object DiffCollectionRule extends DiffDerivationRule("Diff as collection") {
+
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+        Type[A] match {
+          case IsCollection(isCollection) =>
+            import isCollection.Underlying as Item
+            implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+            implicit val ST: Type[String] = DiffTypes.StringType
+            implicit val DiffItemT: Type[Diff[Item]] = DiffTypes.Diff[Item]
+            val pn = Expr(Type.prettyPrint[A])
+            val fn = Expr(Type.plainPrint[A])
+            val sn = Expr(Type.shortName[A])
+            DiffItemT.summonExprIgnoring(ignoredImplicits*).toEither match {
+              case Right(elemDiffExpr) =>
+                val ed = elemDiffExpr.asInstanceOf[Expr[Diff[Item]]]
+                val iterLeft = isCollection.value.asIterable(dctx.left)
+                val iterRight = isCollection.value.asIterable(dctx.right)
+                MIO.pure(Rule.matched(Expr.quote {
+                  DiffRuntime.diffSeq[Item](
+                    Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                    Expr.splice(iterLeft),
+                    Expr.splice(iterRight),
+                    Expr.splice(ed)
+                  )
+                }))
+              case Left(reason) =>
+                MIO.pure(Rule.yielded(s"No Diff[${Item.prettyPrint}]: $reason"))
+            }
+          case _ =>
+            MIO.pure(Rule.yielded(s"${Type[A].prettyPrint} is not a collection"))
+        }
+      }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCollectionRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCollectionRule.scala
@@ -4,8 +4,8 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
-import hearth.kindlings.diffderivation.internal.runtime._
+import hearth.kindlings.diffderivation.*
+import hearth.kindlings.diffderivation.internal.runtime.*
 
 trait DiffCollectionRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 
@@ -30,7 +30,10 @@ trait DiffCollectionRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensio
                 val iterRight = isCollection.value.asIterable(dctx.right)
                 MIO.pure(Rule.matched(Expr.quote {
                   DiffRuntime.diffSeq[Item](
-                    Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                    Expr.splice(pn),
+                    Expr.splice(fn),
+                    Expr.splice(sn),
+                    Expr.splice(sn),
                     Expr.splice(iterLeft),
                     Expr.splice(iterRight),
                     Expr.splice(ed)

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffEnumRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffEnumRule.scala
@@ -1,0 +1,82 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+
+trait DiffEnumRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  object DiffEnumRule extends DiffDerivationRule("Diff as enum") {
+
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      Enum.parse[A].toEither match {
+        case Right(enumm) =>
+          implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+          val defBuilder = ValDefBuilder.ofDef2[A, A, DiffResult](s"diff_${Type[A].shortName}")
+          for {
+            _ <- dctx.cache.forwardDeclare("cached-diff-method", defBuilder)
+            _ <- MIO.scoped { runSafe =>
+              runSafe(dctx.cache.buildCachedWith("cached-diff-method", defBuilder) { case (_, (left, right)) =>
+                runSafe(deriveEnumDiff[A](enumm, left, right))
+              })
+            }
+            result <- DiffUseCachedRule[A]
+          } yield result
+        case Left(reason) =>
+          MIO.pure(Rule.yielded(reason.toString))
+      }
+
+    @scala.annotation.nowarn("msg=is never used|unused|is unchecked")
+    private def deriveEnumDiff[A: DiffCtx](
+        enumm: Enum[A],
+        left: Expr[A],
+        right: Expr[A]
+    ): MIO[Expr[DiffResult]] = {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      implicit val ST: Type[String] = DiffTypes.StringType
+      val pn = Expr(Type.prettyPrint[A])
+      val fn = Expr(Type.plainPrint[A])
+      val sn = Expr(Type.shortName[A])
+
+      enumm
+        .matchOn[MIO, DiffResult](left) { matchedLeft =>
+          import matchedLeft.{value as caseLeft, Underlying as EnumCase}
+          val caseName = Expr(Type.shortName[EnumCase])
+
+          Log.namedScope(s"Deriving Diff for enum case ${EnumCase.prettyPrint}") {
+            val isInstance = Expr.quote(Expr.splice(right).isInstanceOf[EnumCase])
+
+            deriveSnapshotRecursively[EnumCase](using
+              SnapshotCtx[EnumCase](Type[EnumCase], caseLeft, dctx.cache, dctx.derivedType)
+            ).flatMap { leftSnapshotExpr =>
+              val caseRight = Expr.quote(Expr.splice(right).asInstanceOf[EnumCase])
+              deriveDiffRecursively[EnumCase](using dctx.nest(caseLeft, caseRight)).map { diffResult =>
+                Expr.quote {
+                  if (Expr.splice(isInstance)) {
+                    DiffResult.Variant(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                      Expr.splice(caseName), Expr.splice(diffResult))
+                  } else {
+                    DiffResult.TypeMismatch(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                      Expr.splice(caseName), Expr.splice(leftSnapshotExpr),
+                      Expr.splice(right).getClass.getSimpleName.stripSuffix("$"),
+                      DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                        Expr.splice(right).toString))
+                  }
+                }
+              }
+            }
+          }
+        }
+        .flatMap {
+          case Some(result) => MIO.pure(result)
+          case None =>
+            MIO.pure(Expr.quote {
+              DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                Expr.splice(left).toString)
+            })
+        }
+    }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffEnumRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffEnumRule.scala
@@ -4,7 +4,7 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.*
 
 trait DiffEnumRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 
@@ -55,14 +55,31 @@ trait DiffEnumRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
               deriveDiffRecursively[EnumCase](using dctx.nest(caseLeft, caseRight)).map { diffResult =>
                 Expr.quote {
                   if (Expr.splice(isInstance)) {
-                    DiffResult.Variant(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-                      Expr.splice(caseName), Expr.splice(diffResult))
+                    DiffResult.Variant(
+                      Expr.splice(pn),
+                      Expr.splice(fn),
+                      Expr.splice(sn),
+                      Expr.splice(sn),
+                      Expr.splice(caseName),
+                      Expr.splice(diffResult)
+                    )
                   } else {
-                    DiffResult.TypeMismatch(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-                      Expr.splice(caseName), Expr.splice(leftSnapshotExpr),
+                    DiffResult.TypeMismatch(
+                      Expr.splice(pn),
+                      Expr.splice(fn),
+                      Expr.splice(sn),
+                      Expr.splice(sn),
+                      Expr.splice(caseName),
+                      Expr.splice(leftSnapshotExpr),
                       Expr.splice(right).getClass.getSimpleName.stripSuffix("$"),
-                      DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-                        Expr.splice(right).toString))
+                      DiffResult.Identical(
+                        Expr.splice(pn),
+                        Expr.splice(fn),
+                        Expr.splice(sn),
+                        Expr.splice(sn),
+                        Expr.splice(right).toString
+                      )
+                    )
                   }
                 }
               }
@@ -71,10 +88,15 @@ trait DiffEnumRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
         }
         .flatMap {
           case Some(result) => MIO.pure(result)
-          case None =>
+          case None         =>
             MIO.pure(Expr.quote {
-              DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-                Expr.splice(left).toString)
+              DiffResult.Identical(
+                Expr.splice(pn),
+                Expr.splice(fn),
+                Expr.splice(sn),
+                Expr.splice(sn),
+                Expr.splice(left).toString
+              )
             })
         }
     }

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffMapRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffMapRule.scala
@@ -1,0 +1,54 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.internal.runtime._
+
+trait DiffMapRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  object DiffMapRule extends DiffDerivationRule("Diff as Map") {
+
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a Map") >> {
+        Type[A] match {
+          case IsMap(isMapEx) =>
+            import isMapEx.Underlying as Pair
+            deriveMapDiff[A, Pair](isMapEx.value)
+          case _ =>
+            MIO.pure(Rule.yielded(s"${Type[A].prettyPrint} is not a Map"))
+        }
+      }
+
+    private def deriveMapDiff[A: DiffCtx, Pair: Type](
+        isMap: IsMapOf[A, Pair]
+    ): MIO[Rule.Applicability[Expr[DiffResult]]] = {
+      import isMap.{Key, Value}
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      implicit val DiffVT: Type[Diff[Value]] = DiffTypes.Diff[Value]
+      val pn = Expr(Type.prettyPrint[A])
+      val fn = Expr(Type.plainPrint[A])
+      val sn = Expr(Type.shortName[A])
+      DiffVT.summonExprIgnoring(ignoredImplicits*).toEither match {
+        case Right(valueDiffExpr) =>
+          val vd = valueDiffExpr.asInstanceOf[Expr[Diff[Value]]]
+          val iterLeft = isMap.asIterable(dctx.left)
+          val iterRight = isMap.asIterable(dctx.right)
+          MIO.pure(Rule.matched(Expr.quote {
+            DiffRuntime.diffMap[Key, Value](
+              Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+              Expr.splice(iterLeft).asInstanceOf[Iterable[(Key, Value)]],
+              Expr.splice(iterRight).asInstanceOf[Iterable[(Key, Value)]],
+              (k: Key) => k.toString,
+              Expr.splice(vd)
+            )
+          }))
+        case Left(reason) =>
+          MIO.pure(Rule.yielded(s"No Diff[${Value.prettyPrint}]: $reason"))
+      }
+    }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffMapRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffMapRule.scala
@@ -4,8 +4,8 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
-import hearth.kindlings.diffderivation.internal.runtime._
+import hearth.kindlings.diffderivation.*
+import hearth.kindlings.diffderivation.internal.runtime.*
 
 trait DiffMapRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 
@@ -39,7 +39,10 @@ trait DiffMapRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
           val iterRight = isMap.asIterable(dctx.right)
           MIO.pure(Rule.matched(Expr.quote {
             DiffRuntime.diffMap[Key, Value](
-              Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+              Expr.splice(pn),
+              Expr.splice(fn),
+              Expr.splice(sn),
+              Expr.splice(sn),
               Expr.splice(iterLeft).asInstanceOf[Iterable[(Key, Value)]],
               Expr.splice(iterRight).asInstanceOf[Iterable[(Key, Value)]],
               (k: Key) => k.toString,

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffOptionRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffOptionRule.scala
@@ -1,0 +1,45 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.internal.runtime._
+
+trait DiffOptionRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  object DiffOptionRule extends DiffDerivationRule("Diff as Option") {
+
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as Option") >> {
+        Type[A] match {
+          case IsOption(isOption) =>
+            import isOption.Underlying as Inner
+            implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+            implicit val ST: Type[String] = DiffTypes.StringType
+            implicit val DiffInnerT: Type[Diff[Inner]] = DiffTypes.Diff[Inner]
+            val pn = Expr(Type.prettyPrint[A])
+            val fn = Expr(Type.plainPrint[A])
+            val sn = Expr(Type.shortName[A])
+            DiffInnerT.summonExprIgnoring(ignoredImplicits*).toEither match {
+              case Right(elemDiffExpr) =>
+                val ed = elemDiffExpr.asInstanceOf[Expr[Diff[Inner]]]
+                MIO.pure(Rule.matched(Expr.quote {
+                  DiffRuntime.diffOption[Inner](
+                    Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                    Expr.splice(dctx.left).asInstanceOf[Option[Inner]],
+                    Expr.splice(dctx.right).asInstanceOf[Option[Inner]],
+                    Expr.splice(ed)
+                  )
+                }))
+              case Left(reason) =>
+                MIO.pure(Rule.yielded(s"No Diff[${Inner.prettyPrint}]: $reason"))
+            }
+          case _ =>
+            MIO.pure(Rule.yielded(s"${Type[A].prettyPrint} is not an Option"))
+        }
+      }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffOptionRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffOptionRule.scala
@@ -4,8 +4,8 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
-import hearth.kindlings.diffderivation.internal.runtime._
+import hearth.kindlings.diffderivation.*
+import hearth.kindlings.diffderivation.internal.runtime.*
 
 trait DiffOptionRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 
@@ -28,7 +28,10 @@ trait DiffOptionRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =
                 val ed = elemDiffExpr.asInstanceOf[Expr[Diff[Inner]]]
                 MIO.pure(Rule.matched(Expr.quote {
                   DiffRuntime.diffOption[Inner](
-                    Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+                    Expr.splice(pn),
+                    Expr.splice(fn),
+                    Expr.splice(sn),
+                    Expr.splice(sn),
                     Expr.splice(dctx.left).asInstanceOf[Option[Inner]],
                     Expr.splice(dctx.right).asInstanceOf[Option[Inner]],
                     Expr.splice(ed)

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffSingletonRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffSingletonRule.scala
@@ -4,7 +4,7 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.*
 
 trait DiffSingletonRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 
@@ -17,8 +17,7 @@ trait DiffSingletonRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtension
           val pn = Expr(Type.prettyPrint[A])
           val fn = Expr(Type.plainPrint[A])
           MIO.pure(Rule.matched(Expr.quote {
-            DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
-              Expr.splice(sn))
+            DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn), Expr.splice(sn))
           }))
         case Left(reason) =>
           MIO.pure(Rule.yielded(reason.toString))

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffSingletonRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffSingletonRule.scala
@@ -1,0 +1,27 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+
+trait DiffSingletonRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  object DiffSingletonRule extends DiffDerivationRule("Diff as singleton") {
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      SingletonValue.parse[A].toEither match {
+        case Right(_) =>
+          implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+          val sn = Expr(Type.shortName[A])
+          val pn = Expr(Type.prettyPrint[A])
+          val fn = Expr(Type.plainPrint[A])
+          MIO.pure(Rule.matched(Expr.quote {
+            DiffResult.Identical(Expr.splice(pn), Expr.splice(fn), Expr.splice(sn), Expr.splice(sn),
+              Expr.splice(sn))
+          }))
+        case Left(reason) =>
+          MIO.pure(Rule.yielded(reason.toString))
+      }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffUseCachedRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffUseCachedRule.scala
@@ -4,7 +4,7 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.*
 
 trait DiffUseCachedRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 
@@ -15,9 +15,11 @@ trait DiffUseCachedRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtension
       implicit val DiffA: Type[Diff[A]] = DiffTypes.Diff[A]
       dctx.cache.get0Ary[Diff[A]]("cached-diff-instance").flatMap {
         case Some(instance) =>
-          MIO.pure(Rule.matched(
-            Expr.quote(Expr.splice(instance).diff(Expr.splice(dctx.left), Expr.splice(dctx.right)))
-          ))
+          MIO.pure(
+            Rule.matched(
+              Expr.quote(Expr.splice(instance).diff(Expr.splice(dctx.left), Expr.splice(dctx.right)))
+            )
+          )
         case None =>
           dctx.cache.get2Ary[A, A, DiffResult]("cached-diff-method").map {
             case Some(helper) =>

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffUseCachedRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffUseCachedRule.scala
@@ -1,0 +1,31 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+
+trait DiffUseCachedRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  object DiffUseCachedRule extends DiffDerivationRule("use cached Diff") {
+
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] = {
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      implicit val DiffA: Type[Diff[A]] = DiffTypes.Diff[A]
+      dctx.cache.get0Ary[Diff[A]]("cached-diff-instance").flatMap {
+        case Some(instance) =>
+          MIO.pure(Rule.matched(
+            Expr.quote(Expr.splice(instance).diff(Expr.splice(dctx.left), Expr.splice(dctx.right)))
+          ))
+        case None =>
+          dctx.cache.get2Ary[A, A, DiffResult]("cached-diff-method").map {
+            case Some(helper) =>
+              Rule.matched(helper(dctx.left, dctx.right))
+            case None =>
+              Rule.yielded(s"No cached Diff for ${Type[A].prettyPrint}")
+          }
+      }
+    }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffUseImplicitRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffUseImplicitRule.scala
@@ -4,7 +4,7 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.*
 
 trait DiffUseImplicitRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffUseImplicitRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffUseImplicitRule.scala
@@ -1,0 +1,34 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+
+trait DiffUseImplicitRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  @scala.annotation.nowarn("msg=is never used|unused")
+  object DiffUseImplicitRule extends DiffDerivationRule("use implicit Diff") {
+
+    @scala.annotation.nowarn("msg=is never used|unused")
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] = {
+      implicit val DiffA: Type[Diff[A]] = DiffTypes.Diff[A]
+      implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
+      if (dctx.derivedType.exists(_.Underlying =:= Type[A]))
+        MIO.pure(Rule.yielded(s"${Type[A].prettyPrint} is the self-type"))
+      else
+        DiffA.summonExprIgnoring(ignoredImplicits*).toEither match {
+          case Right(instanceExpr) =>
+            val expr = instanceExpr.asInstanceOf[Expr[Diff[A]]]
+            dctx.cache.buildCachedWith(
+              "cached-diff-instance",
+              ValDefBuilder.ofLazy[Diff[A]](s"diff_${Type[A].shortName}")
+            )(_ => expr) >>
+              DiffUseCachedRule[A]
+          case Left(reason) =>
+            MIO.pure(Rule.yielded(s"No implicit Diff[${Type[A].prettyPrint}]: $reason"))
+        }
+    }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffValueTypeRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffValueTypeRule.scala
@@ -1,0 +1,25 @@
+package hearth.kindlings.diffderivation.internal.compiletime
+package rules
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+import hearth.std.*
+import hearth.kindlings.diffderivation._
+
+trait DiffValueTypeRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
+
+  object DiffValueTypeRule extends DiffDerivationRule("Diff as value type") {
+    def apply[A: DiffCtx]: MIO[Rule.Applicability[Expr[DiffResult]]] =
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
+        Type[A] match {
+          case IsValueType(isValueType) =>
+            import isValueType.Underlying as Inner
+            val leftInner = isValueType.value.unwrap(dctx.left)
+            val rightInner = isValueType.value.unwrap(dctx.right)
+            deriveDiffRecursively[Inner](using dctx.nest(leftInner, rightInner)).map(Rule.matched(_))
+          case _ =>
+            MIO.pure(Rule.yielded(s"${Type[A].prettyPrint} is not a value type"))
+        }
+      }
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffValueTypeRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffValueTypeRule.scala
@@ -4,7 +4,7 @@ package rules
 import hearth.MacroCommons
 import hearth.fp.effect.*
 import hearth.std.*
-import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.*
 
 trait DiffValueTypeRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
 

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/DiffFactories.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/DiffFactories.scala
@@ -1,0 +1,22 @@
+package hearth.kindlings.diffderivation.internal.runtime
+
+import hearth.kindlings.diffderivation.{Diff, DiffResult}
+
+object DiffFactories {
+
+  def instance[A](
+      _prettyName: => String,
+      _plainName: => String,
+      _simpleName: => String,
+      _shortName: => String,
+      diffFn: (A, A) => DiffResult,
+      snapshotFn: A => DiffResult
+  ): Diff[A] = new Diff[A] {
+    lazy val prettyName: String = _prettyName
+    lazy val plainName: String = _plainName
+    lazy val simpleName: String = _simpleName
+    lazy val shortName: String = _shortName
+    def diff(left: A, right: A): DiffResult = diffFn(left, right)
+    def snapshot(value: A): DiffResult = snapshotFn(value)
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/DiffRuntime.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/DiffRuntime.scala
@@ -1,7 +1,7 @@
 package hearth.kindlings.diffderivation.internal.runtime
 
-import hearth.kindlings.diffderivation._
-import hearth.kindlings.diffderivation.DiffResult._
+import hearth.kindlings.diffderivation.*
+import hearth.kindlings.diffderivation.DiffResult.*
 
 object DiffRuntime {
 
@@ -148,10 +148,9 @@ object DiffRuntime {
       shortName: => String,
       left: String,
       right: String
-  ): DiffResult = {
+  ): DiffResult =
     if (left == right) Identical(prettyName, plainName, simpleName, shortName, escapeString(left))
     else StringDiff(prettyName, plainName, simpleName, shortName, StringDiffer.diff(left, right))
-  }
 
   def snapshotString(
       prettyName: => String,

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/DiffRuntime.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/DiffRuntime.scala
@@ -1,0 +1,183 @@
+package hearth.kindlings.diffderivation.internal.runtime
+
+import hearth.kindlings.diffderivation._
+import hearth.kindlings.diffderivation.DiffResult._
+
+object DiffRuntime {
+
+  def diffSeq[A](
+      prettyName: => String,
+      plainName: => String,
+      simpleName: => String,
+      shortName: => String,
+      left: Iterable[A],
+      right: Iterable[A],
+      elemDiff: Diff[A]
+  ): DiffResult = {
+    val leftSeq = left.toIndexedSeq
+    val rightSeq = right.toIndexedSeq
+
+    val rawEdits = Myers.diff[A](leftSeq, rightSeq, (a, b) => elemDiff.diff(a, b).isIdentical)
+
+    rebuildSeqEdits(prettyName, plainName, simpleName, shortName, leftSeq, rightSeq, elemDiff, rawEdits)
+  }
+
+  private def rebuildSeqEdits[A](
+      prettyName: => String,
+      plainName: => String,
+      simpleName: => String,
+      shortName: => String,
+      leftSeq: IndexedSeq[A],
+      rightSeq: IndexedSeq[A],
+      elemDiff: Diff[A],
+      rawEdits: Vector[Edit[A]]
+  ): DiffResult = {
+    var li = 0
+    var ri = 0
+    val resultEdits = Vector.newBuilder[Edit[DiffResult]]
+
+    rawEdits.foreach {
+      case Edit.Equal(_) =>
+        resultEdits += Edit.Equal(elemDiff.diff(leftSeq(li), rightSeq(ri)))
+        li += 1
+        ri += 1
+      case Edit.Insert(v) =>
+        resultEdits += Edit.Insert(elemDiff.snapshot(v))
+        ri += 1
+      case Edit.Delete(v) =>
+        resultEdits += Edit.Delete(elemDiff.snapshot(v))
+        li += 1
+    }
+
+    SeqDiff(prettyName, plainName, simpleName, shortName, resultEdits.result())
+  }
+
+  def diffMap[K, V](
+      prettyName: => String,
+      plainName: => String,
+      simpleName: => String,
+      shortName: => String,
+      left: Iterable[(K, V)],
+      right: Iterable[(K, V)],
+      keyShow: K => String,
+      valueDiff: Diff[V]
+  ): DiffResult = {
+    val leftMap = left.toVector
+    val rightMap = right.toVector
+    val leftKeys = leftMap.map { case (k, _) => keyShow(k) }
+    val rightKeys = rightMap.map { case (k, _) => keyShow(k) }
+
+    val leftByKey = leftMap.map { case (k, v) => keyShow(k) -> v }.toMap
+    val rightByKey = rightMap.map { case (k, v) => keyShow(k) -> v }.toMap
+    val allKeys = (leftKeys ++ rightKeys).distinct
+
+    val entries = allKeys.map { key =>
+      (leftByKey.get(key), rightByKey.get(key)) match {
+        case (Some(lv), Some(rv)) => MapEntry.Matched(key, valueDiff.diff(lv, rv))
+        case (None, Some(rv))     => MapEntry.Added(key, valueDiff.snapshot(rv))
+        case (Some(lv), None)     => MapEntry.Removed(key, valueDiff.snapshot(lv))
+        case (None, None)         => MapEntry.Matched(key, valueDiff.snapshot(leftByKey.values.head))
+      }
+    }
+
+    MapDiff(prettyName, plainName, simpleName, shortName, entries)
+  }
+
+  def diffSet[A](
+      prettyName: => String,
+      plainName: => String,
+      simpleName: => String,
+      shortName: => String,
+      left: Iterable[A],
+      right: Iterable[A],
+      elemDiff: Diff[A]
+  ): DiffResult = {
+    val leftSeq = left.toVector
+    val rightSeq = right.toVector
+    val entries = Vector.newBuilder[SetEntry]
+    val matchedRight = new scala.collection.mutable.BitSet(rightSeq.length)
+
+    leftSeq.foreach { l =>
+      var found = false
+      var j = 0
+      while (j < rightSeq.length && !found) {
+        if (!matchedRight(j)) {
+          val d = elemDiff.diff(l, rightSeq(j))
+          if (d.isIdentical) {
+            entries += SetEntry.Matched(d)
+            matchedRight += j
+            found = true
+          }
+        }
+        j += 1
+      }
+      if (!found) entries += SetEntry.Removed(elemDiff.snapshot(l))
+    }
+
+    var j = 0
+    while (j < rightSeq.length) {
+      if (!matchedRight(j)) entries += SetEntry.Added(elemDiff.snapshot(rightSeq(j)))
+      j += 1
+    }
+
+    SetDiff(prettyName, plainName, simpleName, shortName, entries.result())
+  }
+
+  def diffOption[A](
+      prettyName: => String,
+      plainName: => String,
+      simpleName: => String,
+      shortName: => String,
+      left: Option[A],
+      right: Option[A],
+      elemDiff: Diff[A]
+  ): DiffResult = {
+    val content = (left, right) match {
+      case (Some(l), Some(r)) => OptionalContent.BothPresent(elemDiff.diff(l, r))
+      case (Some(l), None)    => OptionalContent.LeftOnly(elemDiff.snapshot(l))
+      case (None, Some(r))    => OptionalContent.RightOnly(elemDiff.snapshot(r))
+      case (None, None)       => OptionalContent.BothAbsent
+    }
+    OptionalDiff(prettyName, plainName, simpleName, shortName, content)
+  }
+
+  def diffString(
+      prettyName: => String,
+      plainName: => String,
+      simpleName: => String,
+      shortName: => String,
+      left: String,
+      right: String
+  ): DiffResult = {
+    if (left == right) Identical(prettyName, plainName, simpleName, shortName, escapeString(left))
+    else StringDiff(prettyName, plainName, simpleName, shortName, StringDiffer.diff(left, right))
+  }
+
+  def snapshotString(
+      prettyName: => String,
+      plainName: => String,
+      simpleName: => String,
+      shortName: => String,
+      value: String
+  ): DiffResult =
+    Identical(prettyName, plainName, simpleName, shortName, escapeString(value))
+
+  private def escapeString(s: String): String = {
+    val sb = new StringBuilder(s.length + 2)
+    sb += '"'
+    var i = 0
+    while (i < s.length) {
+      s.charAt(i) match {
+        case '"'  => sb ++= "\\\""
+        case '\\' => sb ++= "\\\\"
+        case '\n' => sb ++= "\\n"
+        case '\t' => sb ++= "\\t"
+        case '\r' => sb ++= "\\r"
+        case c    => sb += c
+      }
+      i += 1
+    }
+    sb += '"'
+    sb.result()
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/Myers.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/Myers.scala
@@ -1,0 +1,152 @@
+package hearth.kindlings.diffderivation.internal.runtime
+
+import hearth.kindlings.diffderivation.Edit
+
+object Myers {
+
+  def diff[A](left: IndexedSeq[A], right: IndexedSeq[A], eq: (A, A) => Boolean): Vector[Edit[A]] = {
+    val n = left.length
+    val m = right.length
+
+    if (n == 0 && m == 0) return Vector.empty
+    if (n == 0) return right.iterator.map(Edit.Insert(_)).toVector
+    if (m == 0) return left.iterator.map(Edit.Delete(_)).toVector
+
+    val prefixLen = commonPrefixLength(left, right, eq)
+    if (prefixLen == n && prefixLen == m)
+      return left.iterator.map(Edit.Equal(_)).toVector
+
+    val suffixLen = commonSuffixLength(left, right, eq, prefixLen)
+
+    val trimmedLeft = left.slice(prefixLen, n - suffixLen)
+    val trimmedRight = right.slice(prefixLen, m - suffixLen)
+
+    val prefix = left.iterator.take(prefixLen).map(Edit.Equal(_))
+    val suffix = left.iterator.drop(n - suffixLen).map(Edit.Equal(_))
+
+    if (trimmedLeft.isEmpty) {
+      val middle = trimmedRight.iterator.map(Edit.Insert(_))
+      return (prefix ++ middle ++ suffix).toVector
+    }
+    if (trimmedRight.isEmpty) {
+      val middle = trimmedLeft.iterator.map(Edit.Delete(_))
+      return (prefix ++ middle ++ suffix).toVector
+    }
+
+    val middle = diffCore(trimmedLeft, trimmedRight, eq)
+    (prefix ++ middle ++ suffix).toVector
+  }
+
+  private def commonPrefixLength[A](left: IndexedSeq[A], right: IndexedSeq[A], eq: (A, A) => Boolean): Int = {
+    val limit = math.min(left.length, right.length)
+    var i = 0
+    while (i < limit && eq(left(i), right(i))) i += 1
+    i
+  }
+
+  private def commonSuffixLength[A](
+      left: IndexedSeq[A],
+      right: IndexedSeq[A],
+      eq: (A, A) => Boolean,
+      prefixLen: Int
+  ): Int = {
+    val limit = math.min(left.length, right.length) - prefixLen
+    var i = 0
+    while (i < limit && eq(left(left.length - 1 - i), right(right.length - 1 - i))) i += 1
+    i
+  }
+
+  private def diffCore[A](left: IndexedSeq[A], right: IndexedSeq[A], eq: (A, A) => Boolean): Vector[Edit[A]] = {
+    val n = left.length
+    val m = right.length
+    val max = n + m + 1
+    val size = 2 * max + 1
+    val mid = max
+
+    val v = new Array[Int](size)
+    val trace = new scala.collection.mutable.ArrayBuffer[Array[Int]]()
+
+    var found = false
+    var d = 0
+    while (d < max && !found) {
+      trace += v.clone()
+      var k = -d
+      while (k <= d && !found) {
+        val idx = mid + k
+        var x: Int =
+          if (k == -d || (k != d && v(idx - 1) < v(idx + 1))) v(idx + 1)
+          else v(idx - 1) + 1
+        var y = x - k
+
+        while (x < n && y < m && eq(left(x), right(y))) {
+          x += 1
+          y += 1
+        }
+
+        v(idx) = x
+
+        if (x >= n && y >= m) found = true
+        else k += 2
+      }
+      if (!found) d += 1
+    }
+
+    backtrack(left, right, trace, d)
+  }
+
+  private def backtrack[A](
+      left: IndexedSeq[A],
+      right: IndexedSeq[A],
+      trace: scala.collection.mutable.ArrayBuffer[Array[Int]],
+      d: Int
+  ): Vector[Edit[A]] = {
+    val max = left.length + right.length + 1
+    val mid = max
+
+    var x = left.length
+    var y = right.length
+    val edits = new scala.collection.mutable.ArrayBuffer[Edit[A]]()
+
+    var step = d
+    while (step > 0) {
+      val vPrev = trace(step)
+      val k = x - y
+
+      val prevK: Int =
+        if (k == -step || (k != step && vPrev(mid + k - 1) < vPrev(mid + k + 1))) k + 1
+        else k - 1
+
+      val prevX = vPrev(mid + prevK)
+      val prevY = prevX - prevK
+
+      val xBeforeSnake = if (prevK == k + 1) prevX else prevX + 1
+      val yBeforeSnake = xBeforeSnake - k
+
+      while (x > xBeforeSnake && y > yBeforeSnake) {
+        x -= 1
+        y -= 1
+        edits += Edit.Equal(left(x))
+      }
+
+      if (prevK == k + 1) {
+        y -= 1
+        edits += Edit.Insert(right(y))
+      } else {
+        x -= 1
+        edits += Edit.Delete(left(x))
+      }
+
+      x = prevX
+      y = prevY
+      step -= 1
+    }
+
+    while (x > 0 && y > 0) {
+      x -= 1
+      y -= 1
+      edits += Edit.Equal(left(x))
+    }
+
+    edits.reverseIterator.toVector
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/MyersCleanup.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/MyersCleanup.scala
@@ -24,7 +24,7 @@ object MyersCleanup {
     while (changed) {
       changed = false
       var i = 1
-      while (i < buf.length - 1) {
+      while (i < buf.length - 1)
         buf(i) match {
           case Edit.Equal(eq) =>
             val deleteBefore = countChars(buf, i, -1)
@@ -44,7 +44,6 @@ object MyersCleanup {
             }
           case _ => i += 1
         }
-      }
 
       if (changed) mergeAdjacentInPlace(buf)
     }
@@ -58,7 +57,7 @@ object MyersCleanup {
     buf ++= edits
 
     var i = 1
-    while (i < buf.length - 1) {
+    while (i < buf.length - 1)
       (buf(i - 1), buf(i + 1)) match {
         case (Edit.Equal(eqBefore), Edit.Equal(eqAfter)) =>
           buf(i) match {
@@ -77,7 +76,6 @@ object MyersCleanup {
           i += 1
         case _ => i += 1
       }
-    }
 
     buf.iterator.filter {
       case Edit.Equal("") => false
@@ -94,7 +92,7 @@ object MyersCleanup {
     while (changed) {
       changed = false
       var i = 1
-      while (i < buf.length - 1) {
+      while (i < buf.length - 1)
         buf(i) match {
           case Edit.Equal(eq) if eq.length < editCost =>
             val hasDeleteNeighbor = isDeleteOrInsert(buf, i - 1) && isDeleteOrInsert(buf, i + 1)
@@ -106,7 +104,6 @@ object MyersCleanup {
             i += 1
           case _ => i += 1
         }
-      }
       if (changed) mergeAdjacentInPlace(buf)
     }
 
@@ -129,9 +126,9 @@ object MyersCleanup {
   ): Int = {
     var count = 0
     var j = from + dir
-    while (j >= 0 && j < buf.length) {
+    while (j >= 0 && j < buf.length)
       buf(j) match {
-        case Edit.Equal(_) => return count
+        case Edit.Equal(_)  => return count
         case Edit.Delete(s) =>
           if (!insertsOnly) count += s.length
           j += dir
@@ -139,13 +136,12 @@ object MyersCleanup {
           count += s.length
           j += dir
       }
-    }
     count
   }
 
   private def mergeAdjacentInPlace(buf: scala.collection.mutable.ArrayBuffer[Edit[String]]): Unit = {
     var i = 0
-    while (i < buf.length - 1) {
+    while (i < buf.length - 1)
       (buf(i), buf(i + 1)) match {
         case (Edit.Equal(a), Edit.Equal(b)) =>
           buf(i) = Edit.Equal(a + b)
@@ -158,7 +154,6 @@ object MyersCleanup {
           val _ = buf.remove(i + 1)
         case _ => i += 1
       }
-    }
   }
 
   private def slideBest(

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/MyersCleanup.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/MyersCleanup.scala
@@ -1,0 +1,204 @@
+package hearth.kindlings.diffderivation.internal.runtime
+
+import hearth.kindlings.diffderivation.Edit
+
+object MyersCleanup {
+
+  def merge[A](edits: Vector[Edit[A]]): Vector[Edit[A]] = {
+    if (edits.length <= 1) return edits
+    val builder = Vector.newBuilder[Edit[A]]
+    var i = 0
+    while (i < edits.length) {
+      builder += edits(i)
+      i += 1
+    }
+    builder.result()
+  }
+
+  def semanticCleanup(edits: Vector[Edit[String]]): Vector[Edit[String]] = {
+    if (edits.length < 3) return edits
+    val buf = new scala.collection.mutable.ArrayBuffer[Edit[String]](edits.length)
+    buf ++= edits
+
+    var changed = true
+    while (changed) {
+      changed = false
+      var i = 1
+      while (i < buf.length - 1) {
+        buf(i) match {
+          case Edit.Equal(eq) =>
+            val deleteBefore = countChars(buf, i, -1)
+            val insertBefore = countChars(buf, i, -1, insertsOnly = true)
+            val deleteAfter = countChars(buf, i, 1)
+            val insertAfter = countChars(buf, i, 1, insertsOnly = true)
+            val changesBefore = deleteBefore + insertBefore
+            val changesAfter = deleteAfter + insertAfter
+
+            if (eq.length <= math.max(changesBefore, changesAfter) / 2 && changesBefore > 0 && changesAfter > 0) {
+              buf(i) = Edit.Delete(eq)
+              buf.insert(i + 1, Edit.Insert(eq))
+              changed = true
+              if (i > 0) i -= 1
+            } else {
+              i += 1
+            }
+          case _ => i += 1
+        }
+      }
+
+      if (changed) mergeAdjacentInPlace(buf)
+    }
+
+    buf.toVector
+  }
+
+  def semanticLossless(edits: Vector[Edit[String]]): Vector[Edit[String]] = {
+    if (edits.length < 3) return edits
+    val buf = new scala.collection.mutable.ArrayBuffer[Edit[String]](edits.length)
+    buf ++= edits
+
+    var i = 1
+    while (i < buf.length - 1) {
+      (buf(i - 1), buf(i + 1)) match {
+        case (Edit.Equal(eqBefore), Edit.Equal(eqAfter)) =>
+          buf(i) match {
+            case Edit.Delete(del) =>
+              val (newBefore, newDel, newAfter) = slideBest(eqBefore, del, eqAfter)
+              buf(i - 1) = Edit.Equal(newBefore)
+              buf(i) = Edit.Delete(newDel)
+              buf(i + 1) = Edit.Equal(newAfter)
+            case Edit.Insert(ins) =>
+              val (newBefore, newIns, newAfter) = slideBest(eqBefore, ins, eqAfter)
+              buf(i - 1) = Edit.Equal(newBefore)
+              buf(i) = Edit.Insert(newIns)
+              buf(i + 1) = Edit.Equal(newAfter)
+            case _ => ()
+          }
+          i += 1
+        case _ => i += 1
+      }
+    }
+
+    buf.iterator.filter {
+      case Edit.Equal("") => false
+      case _              => true
+    }.toVector
+  }
+
+  def efficiencyCleanup(edits: Vector[Edit[String]], editCost: Int): Vector[Edit[String]] = {
+    if (edits.length < 3) return edits
+    val buf = new scala.collection.mutable.ArrayBuffer[Edit[String]](edits.length)
+    buf ++= edits
+
+    var changed = true
+    while (changed) {
+      changed = false
+      var i = 1
+      while (i < buf.length - 1) {
+        buf(i) match {
+          case Edit.Equal(eq) if eq.length < editCost =>
+            val hasDeleteNeighbor = isDeleteOrInsert(buf, i - 1) && isDeleteOrInsert(buf, i + 1)
+            if (hasDeleteNeighbor) {
+              buf(i) = Edit.Delete(eq)
+              buf.insert(i + 1, Edit.Insert(eq))
+              changed = true
+            }
+            i += 1
+          case _ => i += 1
+        }
+      }
+      if (changed) mergeAdjacentInPlace(buf)
+    }
+
+    buf.toVector
+  }
+
+  private def isDeleteOrInsert[A](buf: scala.collection.mutable.ArrayBuffer[Edit[A]], idx: Int): Boolean =
+    if (idx < 0 || idx >= buf.length) false
+    else
+      buf(idx) match {
+        case Edit.Equal(_) => false
+        case _             => true
+      }
+
+  private def countChars(
+      buf: scala.collection.mutable.ArrayBuffer[Edit[String]],
+      from: Int,
+      dir: Int,
+      insertsOnly: Boolean = false
+  ): Int = {
+    var count = 0
+    var j = from + dir
+    while (j >= 0 && j < buf.length) {
+      buf(j) match {
+        case Edit.Equal(_) => return count
+        case Edit.Delete(s) =>
+          if (!insertsOnly) count += s.length
+          j += dir
+        case Edit.Insert(s) =>
+          count += s.length
+          j += dir
+      }
+    }
+    count
+  }
+
+  private def mergeAdjacentInPlace(buf: scala.collection.mutable.ArrayBuffer[Edit[String]]): Unit = {
+    var i = 0
+    while (i < buf.length - 1) {
+      (buf(i), buf(i + 1)) match {
+        case (Edit.Equal(a), Edit.Equal(b)) =>
+          buf(i) = Edit.Equal(a + b)
+          val _ = buf.remove(i + 1)
+        case (Edit.Delete(a), Edit.Delete(b)) =>
+          buf(i) = Edit.Delete(a + b)
+          val _ = buf.remove(i + 1)
+        case (Edit.Insert(a), Edit.Insert(b)) =>
+          buf(i) = Edit.Insert(a + b)
+          val _ = buf.remove(i + 1)
+        case _ => i += 1
+      }
+    }
+  }
+
+  private def slideBest(
+      eqBefore: String,
+      edit: String,
+      eqAfter: String
+  ): (String, String, String) = {
+    var bestBefore = eqBefore
+    var bestEdit = edit
+    var bestAfter = eqAfter
+    var bestScore = boundaryScore(eqBefore) + boundaryScore(eqAfter)
+
+    var curBefore = eqBefore
+    var curEdit = edit
+    var curAfter = eqAfter
+
+    while (curAfter.nonEmpty && curEdit.nonEmpty && curEdit.last == curAfter.head) {
+      curBefore = curBefore + curEdit.charAt(0)
+      curEdit = curEdit.substring(1) + curAfter.charAt(0)
+      curAfter = curAfter.substring(1)
+      val score = boundaryScore(curBefore) + boundaryScore(curAfter)
+      if (score >= bestScore) {
+        bestScore = score
+        bestBefore = curBefore
+        bestEdit = curEdit
+        bestAfter = curAfter
+      }
+    }
+
+    (bestBefore, bestEdit, bestAfter)
+  }
+
+  private[runtime] def boundaryScore(text: String): Int = {
+    if (text.isEmpty) return 5
+    val last = text.last
+    if (last == '\n') {
+      if (text.length >= 2 && text.charAt(text.length - 2) == '\n') 4
+      else 3
+    } else if (last == ' ' || last == '\t') 2
+    else if (!last.isLetterOrDigit) 1
+    else 0
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/StringDiffer.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/StringDiffer.scala
@@ -1,0 +1,166 @@
+package hearth.kindlings.diffderivation.internal.runtime
+
+import hearth.kindlings.diffderivation.Edit
+import hearth.kindlings.diffderivation.DiffResult.{CharChunk, StringChunk, WordChunk}
+
+object StringDiffer {
+
+  private val SimilarityThreshold = 0.5
+
+  def diff(left: String, right: String): Vector[StringChunk] = {
+    if (left == right) return Vector(StringChunk.EqualLine(left))
+
+    val leftLines = splitLines(left)
+    val rightLines = splitLines(right)
+
+    val lineEdits = Myers.diff[String](leftLines, rightLines, _ == _)
+    val cleaned = MyersCleanup.semanticLossless(MyersCleanup.semanticCleanup(lineEdits))
+
+    processLineEdits(cleaned)
+  }
+
+  private def splitLines(s: String): IndexedSeq[String] =
+    s.replace("\r\n", "\n").split("\n", -1).toIndexedSeq
+
+  private def processLineEdits(edits: Vector[Edit[String]]): Vector[StringChunk] = {
+    val result = Vector.newBuilder[StringChunk]
+    var i = 0
+    while (i < edits.length) {
+      edits(i) match {
+        case Edit.Equal(line) =>
+          result += StringChunk.EqualLine(line)
+          i += 1
+
+        case Edit.Delete(_) | Edit.Insert(_) =>
+          val deletes = new scala.collection.mutable.ArrayBuffer[String]()
+          val inserts = new scala.collection.mutable.ArrayBuffer[String]()
+          var j = i
+          while (j < edits.length) {
+            edits(j) match {
+              case Edit.Delete(line) => deletes += line; j += 1
+              case Edit.Insert(line) => inserts += line; j += 1
+              case _                 => j = edits.length
+            }
+          }
+          val pairCount = math.min(deletes.length, inserts.length)
+          var p = 0
+          while (p < pairCount) {
+            result += diffLinePair(deletes(p), inserts(p))
+            p += 1
+          }
+          while (p < deletes.length) {
+            result += StringChunk.DeleteLine(deletes(p))
+            p += 1
+          }
+          p = pairCount
+          while (p < inserts.length) {
+            result += StringChunk.InsertLine(inserts(p))
+            p += 1
+          }
+          i = if (j <= edits.length) i + deletes.length + inserts.length else edits.length
+      }
+    }
+    result.result()
+  }
+
+  private def diffLinePair(leftLine: String, rightLine: String): StringChunk = {
+    if (leftLine == rightLine) return StringChunk.EqualLine(leftLine)
+    if (leftLine.isEmpty) return StringChunk.InsertLine(rightLine)
+    if (rightLine.isEmpty) return StringChunk.DeleteLine(leftLine)
+
+    val leftWords = tokenize(leftLine)
+    val rightWords = tokenize(rightLine)
+    val wordEdits = Myers.diff[String](leftWords, rightWords, _ == _)
+    val cleaned = MyersCleanup.semanticLossless(wordEdits)
+
+    val wordChunks = processWordEdits(cleaned)
+    StringChunk.ChangedLine(wordChunks)
+  }
+
+  private def processWordEdits(edits: Vector[Edit[String]]): Vector[WordChunk] = {
+    val result = Vector.newBuilder[WordChunk]
+    var i = 0
+    while (i < edits.length) {
+      edits(i) match {
+        case Edit.Equal(word) =>
+          result += WordChunk.EqualWord(word)
+          i += 1
+
+        case Edit.Delete(_) | Edit.Insert(_) =>
+          val deletes = new scala.collection.mutable.ArrayBuffer[String]()
+          val inserts = new scala.collection.mutable.ArrayBuffer[String]()
+          var j = i
+          while (j < edits.length) {
+            edits(j) match {
+              case Edit.Delete(w) => deletes += w; j += 1
+              case Edit.Insert(w) => inserts += w; j += 1
+              case _              => j = edits.length
+            }
+          }
+          val deleteStr = deletes.mkString
+          val insertStr = inserts.mkString
+          val pairCount = math.min(deletes.length, inserts.length)
+
+          if (pairCount > 0 && deleteStr.nonEmpty && insertStr.nonEmpty) {
+            var p = 0
+            while (p < pairCount) {
+              result += diffWordPair(deletes(p), inserts(p))
+              p += 1
+            }
+            while (p < deletes.length) { result += WordChunk.DeleteWord(deletes(p)); p += 1 }
+            p = pairCount
+            while (p < inserts.length) { result += WordChunk.InsertWord(inserts(p)); p += 1 }
+          } else {
+            deletes.foreach(w => result += WordChunk.DeleteWord(w))
+            inserts.foreach(w => result += WordChunk.InsertWord(w))
+          }
+          i += deletes.length + inserts.length
+      }
+    }
+    result.result()
+  }
+
+  private def diffWordPair(leftWord: String, rightWord: String): WordChunk = {
+    if (leftWord == rightWord) return WordChunk.EqualWord(leftWord)
+
+    val leftChars = leftWord.map(_.toString).toIndexedSeq
+    val rightChars = rightWord.map(_.toString).toIndexedSeq
+    val charEdits = Myers.diff[String](leftChars, rightChars, _ == _)
+
+    val equalCount = charEdits.count { case Edit.Equal(_) => true; case _ => false }
+    val similarity = if (charEdits.isEmpty) 0.0 else equalCount.toDouble / charEdits.length
+
+    if (similarity < SimilarityThreshold) {
+      WordChunk.ChangedWord(Vector(CharChunk.DeleteChar(leftWord), CharChunk.InsertChar(rightWord)))
+    } else {
+      val chars = charEdits.map {
+        case Edit.Equal(c)  => CharChunk.EqualChar(c)
+        case Edit.Insert(c) => CharChunk.InsertChar(c)
+        case Edit.Delete(c) => CharChunk.DeleteChar(c)
+      }
+      WordChunk.ChangedWord(chars)
+    }
+  }
+
+  private def tokenize(line: String): IndexedSeq[String] = {
+    if (line.isEmpty) return IndexedSeq.empty
+    val words = new scala.collection.mutable.ArrayBuffer[String]()
+    val current = new StringBuilder()
+    var i = 0
+    while (i < line.length) {
+      val c = line.charAt(i)
+      if (c == ' ') {
+        if (current.nonEmpty) {
+          words += current.result()
+          current.clear()
+        }
+        words += " "
+      } else {
+        current += c
+      }
+      i += 1
+    }
+    if (current.nonEmpty) words += current.result()
+    words.toIndexedSeq
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/StringDiffer.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/runtime/StringDiffer.scala
@@ -25,7 +25,7 @@ object StringDiffer {
   private def processLineEdits(edits: Vector[Edit[String]]): Vector[StringChunk] = {
     val result = Vector.newBuilder[StringChunk]
     var i = 0
-    while (i < edits.length) {
+    while (i < edits.length)
       edits(i) match {
         case Edit.Equal(line) =>
           result += StringChunk.EqualLine(line)
@@ -35,13 +35,12 @@ object StringDiffer {
           val deletes = new scala.collection.mutable.ArrayBuffer[String]()
           val inserts = new scala.collection.mutable.ArrayBuffer[String]()
           var j = i
-          while (j < edits.length) {
+          while (j < edits.length)
             edits(j) match {
               case Edit.Delete(line) => deletes += line; j += 1
               case Edit.Insert(line) => inserts += line; j += 1
               case _                 => j = edits.length
             }
-          }
           val pairCount = math.min(deletes.length, inserts.length)
           var p = 0
           while (p < pairCount) {
@@ -59,7 +58,6 @@ object StringDiffer {
           }
           i = if (j <= edits.length) i + deletes.length + inserts.length else edits.length
       }
-    }
     result.result()
   }
 
@@ -80,7 +78,7 @@ object StringDiffer {
   private def processWordEdits(edits: Vector[Edit[String]]): Vector[WordChunk] = {
     val result = Vector.newBuilder[WordChunk]
     var i = 0
-    while (i < edits.length) {
+    while (i < edits.length)
       edits(i) match {
         case Edit.Equal(word) =>
           result += WordChunk.EqualWord(word)
@@ -90,13 +88,12 @@ object StringDiffer {
           val deletes = new scala.collection.mutable.ArrayBuffer[String]()
           val inserts = new scala.collection.mutable.ArrayBuffer[String]()
           var j = i
-          while (j < edits.length) {
+          while (j < edits.length)
             edits(j) match {
               case Edit.Delete(w) => deletes += w; j += 1
               case Edit.Insert(w) => inserts += w; j += 1
               case _              => j = edits.length
             }
-          }
           val deleteStr = deletes.mkString
           val insertStr = inserts.mkString
           val pairCount = math.min(deletes.length, inserts.length)
@@ -116,7 +113,6 @@ object StringDiffer {
           }
           i += deletes.length + inserts.length
       }
-    }
     result.result()
   }
 

--- a/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/DiffRendererSpec.scala
+++ b/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/DiffRendererSpec.scala
@@ -36,7 +36,8 @@ final class DiffRendererSpec extends hearth.MacroSuite {
 
     test("render with FullyQualified name style") {
       val result = DiffResult.Identical(pn, "com.example.Foo", "Foo", "Foo", "42")
-      val rendered = DiffRenderer.render(result, RenderConfig(NameStyle.FullyQualified, ColorMode.Plain, Indent.Spaces(2)))
+      val rendered =
+        DiffRenderer.render(result, RenderConfig(NameStyle.FullyQualified, ColorMode.Plain, Indent.Spaces(2)))
       assertEquals(rendered, "42")
     }
 

--- a/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/DiffRendererSpec.scala
+++ b/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/DiffRendererSpec.scala
@@ -1,0 +1,62 @@
+package hearth.kindlings.diffderivation
+
+final class DiffRendererSpec extends hearth.MacroSuite {
+
+  private val pn = "test.Pretty"
+  private val fn = "test.Full"
+  private val sn = "Test"
+  private val sh = "Test"
+
+  group("DiffRenderer") {
+
+    test("render Identical") {
+      val result = DiffResult.Identical(pn, fn, sn, sh, "42")
+      val rendered = DiffRenderer.render(result, RenderConfig.plain)
+      assertEquals(rendered, "42")
+    }
+
+    test("render ValueChanged with plain mode") {
+      val result = DiffResult.ValueChanged(pn, fn, sn, sh, "1", "2")
+      val rendered = DiffRenderer.render(result, RenderConfig.plain)
+      assert(rendered.contains("1"), s"expected left value in: $rendered")
+      assert(rendered.contains("2"), s"expected right value in: $rendered")
+      assert(rendered.contains("->"), s"expected arrow in: $rendered")
+    }
+
+    test("render Record shows type name") {
+      val fields = Vector(
+        "name" -> DiffResult.Identical(pn, fn, "String", "String", "\"Alice\""),
+        "age" -> DiffResult.ValueChanged(pn, fn, "Int", "Int", "30", "31")
+      )
+      val result = DiffResult.Record(pn, fn, "Person", "Person", fields)
+      val rendered = DiffRenderer.render(result, RenderConfig.plain)
+      assert(rendered.contains("Person"), s"expected type name in: $rendered")
+      assert(rendered.contains("age"), s"expected field name in: $rendered")
+    }
+
+    test("render with FullyQualified name style") {
+      val result = DiffResult.Identical(pn, "com.example.Foo", "Foo", "Foo", "42")
+      val rendered = DiffRenderer.render(result, RenderConfig(NameStyle.FullyQualified, ColorMode.Plain, Indent.Spaces(2)))
+      assertEquals(rendered, "42")
+    }
+
+    test("render SeqDiff with plain markers") {
+      val edits = Vector(
+        Edit.Equal(DiffResult.Identical(pn, fn, "Int", "Int", "1")),
+        Edit.Insert(DiffResult.Identical(pn, fn, "Int", "Int", "2")),
+        Edit.Delete(DiffResult.Identical(pn, fn, "Int", "Int", "3"))
+      )
+      val result = DiffResult.SeqDiff(pn, fn, "List[Int]", "List", edits)
+      val rendered = DiffRenderer.render(result, RenderConfig.plain)
+      assert(rendered.contains("+"), s"expected + marker in: $rendered")
+      assert(rendered.contains("-"), s"expected - marker in: $rendered")
+    }
+
+    test("render with Tab indentation") {
+      val fields = Vector("x" -> DiffResult.ValueChanged(pn, fn, "Int", "Int", "1", "2"))
+      val result = DiffResult.Record(pn, fn, "Point", "Point", fields)
+      val rendered = DiffRenderer.render(result, RenderConfig(NameStyle.Simple, ColorMode.Plain, Indent.Tab))
+      assert(rendered.contains("\t"), s"expected tab in: $rendered")
+    }
+  }
+}

--- a/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/DiffSpec.scala
+++ b/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/DiffSpec.scala
@@ -48,7 +48,7 @@ final class DiffSpec extends hearth.MacroSuite {
         assert(!result.isIdentical, s"expected not identical")
         result match {
           case _: DiffResult.TypeMismatch => ()
-          case _ =>
+          case _                          =>
             result match {
               case v: DiffResult.Variant if !v.isIdentical => ()
               case _ => fail(s"expected TypeMismatch or non-identical Variant, got $result")

--- a/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/DiffSpec.scala
+++ b/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/DiffSpec.scala
@@ -1,0 +1,93 @@
+package hearth.kindlings.diffderivation
+
+final class DiffSpec extends hearth.MacroSuite {
+
+  group("Diff.derived") {
+
+    group("case classes") {
+
+      test("identical case classes") {
+        val d = Diff.derived[Person]
+        val result = d.diff(Person("Alice", 30), Person("Alice", 30))
+        assert(result.isIdentical, s"expected identical, got $result")
+      }
+
+      test("changed primitive field") {
+        val d = Diff.derived[Person]
+        val result = d.diff(Person("Alice", 30), Person("Alice", 31))
+        assert(!result.isIdentical, s"expected not identical, got $result")
+        result match {
+          case r: DiffResult.Record =>
+            val ageField = r.fields.find(_._1 == "age")
+            assert(ageField.isDefined, s"expected age field in $result")
+            assert(!ageField.get._2.isIdentical, s"expected age to differ")
+          case _ => fail(s"expected Record, got $result")
+        }
+      }
+
+      test("nested case class") {
+        val d = Diff.derived[PersonWithAddress]
+        val left = PersonWithAddress(Person("Alice", 30), Address("Main St", "NYC"))
+        val right = PersonWithAddress(Person("Alice", 31), Address("Main St", "NYC"))
+        val result = d.diff(left, right)
+        assert(!result.isIdentical, s"expected not identical")
+      }
+    }
+
+    group("sealed traits") {
+
+      test("same variant") {
+        val d = Diff.derived[Shape]
+        val result = d.diff(Circle(1.0), Circle(2.0))
+        assert(!result.isIdentical, s"expected not identical, got $result")
+      }
+
+      test("different variants") {
+        val d = Diff.derived[Shape]
+        val result = d.diff(Circle(1.0), Rectangle(2.0, 3.0))
+        assert(!result.isIdentical, s"expected not identical")
+        result match {
+          case _: DiffResult.TypeMismatch => ()
+          case _ =>
+            result match {
+              case v: DiffResult.Variant if !v.isIdentical => ()
+              case _ => fail(s"expected TypeMismatch or non-identical Variant, got $result")
+            }
+        }
+      }
+
+      test("identical singletons") {
+        val d = Diff.derived[SimpleEnum]
+        val result = d.diff(Yes, Yes)
+        assert(result.isIdentical, s"expected identical, got $result")
+      }
+    }
+
+    group("snapshot") {
+
+      test("snapshot of case class") {
+        val d = Diff.derived[Person]
+        val snap = d.snapshot(Person("Alice", 30))
+        assert(snap.isIdentical, s"snapshot should be identical, got $snap")
+      }
+    }
+
+    group("rendering") {
+
+      test("render changed record in plain mode") {
+        val d = Diff.derived[Person]
+        val result = d.diff(Person("Alice", 30), Person("Bob", 30))
+        val rendered = DiffRenderer.render(result, RenderConfig.plain)
+        assert(rendered.contains("Person"), s"expected Person in: $rendered")
+        assert(rendered.contains("name"), s"expected name field in: $rendered")
+      }
+
+      test("render with simple name style") {
+        val d = Diff.derived[Person]
+        val result = d.diff(Person("Alice", 30), Person("Alice", 31))
+        val rendered = DiffRenderer.render(result, RenderConfig.plain)
+        assert(rendered.contains("Person"), s"expected type name in: $rendered")
+      }
+    }
+  }
+}

--- a/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/MyersSpec.scala
+++ b/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/MyersSpec.scala
@@ -1,0 +1,67 @@
+package hearth.kindlings.diffderivation
+
+import hearth.kindlings.diffderivation.internal.runtime.Myers
+
+final class MyersSpec extends hearth.MacroSuite {
+
+  private val eq: (String, String) => Boolean = _ == _
+  private val eqI: (Int, Int) => Boolean = _ == _
+
+  group("Myers.diff") {
+
+    test("empty sequences") {
+      assertEquals(Myers.diff(IndexedSeq.empty[String], IndexedSeq.empty[String], eq), Vector.empty)
+    }
+
+    test("identical sequences") {
+      val s = IndexedSeq("a", "b", "c")
+      val result = Myers.diff(s, s, eq)
+      assertEquals(result, Vector(Edit.Equal("a"), Edit.Equal("b"), Edit.Equal("c")))
+    }
+
+    test("all inserts") {
+      val result = Myers.diff(IndexedSeq.empty[String], IndexedSeq("a", "b"), eq)
+      assertEquals(result, Vector(Edit.Insert("a"), Edit.Insert("b")))
+    }
+
+    test("all deletes") {
+      val result = Myers.diff(IndexedSeq("a", "b"), IndexedSeq.empty[String], eq)
+      assertEquals(result, Vector(Edit.Delete("a"), Edit.Delete("b")))
+    }
+
+    test("single insert in middle") {
+      val result = Myers.diff(IndexedSeq("a", "c"), IndexedSeq("a", "b", "c"), eq)
+      assertEquals(result, Vector(Edit.Equal("a"), Edit.Insert("b"), Edit.Equal("c")))
+    }
+
+    test("single delete in middle") {
+      val result = Myers.diff(IndexedSeq("a", "b", "c"), IndexedSeq("a", "c"), eq)
+      assertEquals(result, Vector(Edit.Equal("a"), Edit.Delete("b"), Edit.Equal("c")))
+    }
+
+    test("replace element") {
+      val result = Myers.diff(IndexedSeq("a", "b", "c"), IndexedSeq("a", "x", "c"), eq)
+      val hasDelete = result.exists { case Edit.Delete("b") => true; case _ => false }
+      val hasInsert = result.exists { case Edit.Insert("x") => true; case _ => false }
+      assert(hasDelete, "expected Delete(b)")
+      assert(hasInsert, "expected Insert(x)")
+    }
+
+    test("common prefix/suffix optimization") {
+      val left = IndexedSeq(1, 2, 3, 4, 5)
+      val right = IndexedSeq(1, 2, 99, 4, 5)
+      val result = Myers.diff(left, right, eqI)
+      assertEquals(result.head, Edit.Equal(1))
+      assertEquals(result(1), Edit.Equal(2))
+      assertEquals(result.last, Edit.Equal(5))
+    }
+
+    test("complex interleaved edits") {
+      val left = IndexedSeq("a", "b", "c", "d")
+      val right = IndexedSeq("a", "x", "c", "y")
+      val result = Myers.diff(left, right, eq)
+      val equalCount = result.count { case Edit.Equal(_) => true; case _ => false }
+      assert(equalCount == 2, s"expected 2 equals, got $equalCount in $result")
+    }
+  }
+}

--- a/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/StringDifferSpec.scala
+++ b/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/StringDifferSpec.scala
@@ -1,7 +1,7 @@
 package hearth.kindlings.diffderivation
 
 import hearth.kindlings.diffderivation.internal.runtime.StringDiffer
-import hearth.kindlings.diffderivation.DiffResult.{StringChunk, WordChunk, CharChunk}
+import hearth.kindlings.diffderivation.DiffResult.{CharChunk, StringChunk, WordChunk}
 
 final class StringDifferSpec extends hearth.MacroSuite {
 

--- a/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/StringDifferSpec.scala
+++ b/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/StringDifferSpec.scala
@@ -1,0 +1,84 @@
+package hearth.kindlings.diffderivation
+
+import hearth.kindlings.diffderivation.internal.runtime.StringDiffer
+import hearth.kindlings.diffderivation.DiffResult.{StringChunk, WordChunk, CharChunk}
+
+final class StringDifferSpec extends hearth.MacroSuite {
+
+  group("StringDiffer.diff") {
+
+    test("identical strings") {
+      val result = StringDiffer.diff("hello", "hello")
+      assertEquals(result, Vector(StringChunk.EqualLine("hello")))
+    }
+
+    test("single line word change") {
+      val result = StringDiffer.diff("the cat sat", "the dog sat")
+      assert(result.nonEmpty, "expected non-empty result")
+      result.head match {
+        case StringChunk.ChangedLine(words) =>
+          val hasEqual = words.exists { case WordChunk.EqualWord(_) => true; case _ => false }
+          assert(hasEqual, s"expected some equal words in $words")
+        case other =>
+          fail(s"expected ChangedLine, got $other")
+      }
+    }
+
+    test("multi-line with added line") {
+      val left = "line1\nline2\nline3"
+      val right = "line1\nline2\nnewline\nline3"
+      val result = StringDiffer.diff(left, right)
+      val insertCount = result.count { case StringChunk.InsertLine(_) => true; case _ => false }
+      assert(insertCount >= 1, s"expected at least 1 InsertLine, got $result")
+    }
+
+    test("multi-line with removed line") {
+      val left = "line1\nline2\nline3"
+      val right = "line1\nline3"
+      val result = StringDiffer.diff(left, right)
+      val deleteOrChange = result.count {
+        case StringChunk.DeleteLine(_)  => true
+        case StringChunk.ChangedLine(_) => true
+        case _                          => false
+      }
+      assert(deleteOrChange >= 1, s"expected at least 1 delete/change, got $result")
+    }
+
+    test("character-level drill down") {
+      val result = StringDiffer.diff("cat", "car")
+      result.head match {
+        case StringChunk.ChangedLine(words) =>
+          words.head match {
+            case WordChunk.ChangedWord(chars) =>
+              val hasInsert = chars.exists { case CharChunk.InsertChar(_) => true; case _ => false }
+              val hasDelete = chars.exists { case CharChunk.DeleteChar(_) => true; case _ => false }
+              assert(hasInsert && hasDelete, s"expected char-level edits in $chars")
+            case other =>
+              fail(s"expected ChangedWord, got $other")
+          }
+        case other =>
+          fail(s"expected ChangedLine, got $other")
+      }
+    }
+
+    test("empty left string") {
+      val result = StringDiffer.diff("", "hello")
+      val hasInsert = result.exists {
+        case StringChunk.InsertLine(_)  => true
+        case StringChunk.ChangedLine(_) => true
+        case _                          => false
+      }
+      assert(hasInsert, s"expected insert for empty->non-empty, got $result")
+    }
+
+    test("empty right string") {
+      val result = StringDiffer.diff("hello", "")
+      val hasDelete = result.exists {
+        case StringChunk.DeleteLine(_)  => true
+        case StringChunk.ChangedLine(_) => true
+        case _                          => false
+      }
+      assert(hasDelete, s"expected delete for non-empty->empty, got $result")
+    }
+  }
+}

--- a/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/examples.scala
+++ b/diff-derivation/src/test/scala/hearth/kindlings/diffderivation/examples.scala
@@ -1,0 +1,16 @@
+package hearth.kindlings.diffderivation
+
+case class Person(name: String, age: Int)
+case class Address(street: String, city: String)
+case class PersonWithAddress(person: Person, address: Address)
+case class Team(name: String, members: List[Person])
+case class Config(settings: Map[String, Int])
+case class Tree(value: Int, children: List[Tree])
+
+sealed trait Shape
+case class Circle(radius: Double) extends Shape
+case class Rectangle(width: Double, height: Double) extends Shape
+
+sealed trait SimpleEnum
+case object Yes extends SimpleEnum
+case object No extends SimpleEnum

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -55,6 +55,7 @@ nav:
     - "Avro": "avro-derivation.md"
     - "Cats": "cats-derivation.md"
     - "Circe": "circe-derivation.md"
+    - "Diff": "diff-derivation.md"
     - "FastShowPretty": "fast-show-pretty.md"
     - "Jsoniter Scala": "jsoniter-derivation.md"
     - "PureConfig": "pureconfig-derivation.md"

--- a/docs/research/diff-library-comparison.md
+++ b/docs/research/diff-library-comparison.md
@@ -1,0 +1,139 @@
+# Diff Library Comparison: kindlings-diff-derivation vs difflicious vs diffx
+
+## Architecture comparison
+
+### Derivation mechanism
+
+| Aspect | kindlings-diff | difflicious | diffx |
+|--------|---------------|-------------|-------|
+| Derivation engine | Hearth cross-platform macros | Magnolia 1.x | Magnolia 1.x |
+| Scala versions | 2.13 + 3 | 2.13 + 3 | 2.12 + 2.13 + 3 |
+| Platforms | JVM + JS + Native | JVM + JS | JVM + JS |
+| Type name resolution | `runtimePlainPrint`/`runtimeShortPrint`/`runtimePrettyPrint` — runtime-composable for generics | izumi-reflect `LTag` | Plain `String` (compile-time only) |
+| Type name rendering | 4 modes (pretty/plain/simple/short), choice deferred to render time | FQN + short, fixed at derive time | Single string, fixed at derive time |
+
+### DiffResult AST
+
+| Aspect | kindlings-diff | difflicious | diffx |
+|--------|---------------|-------------|-------|
+| Base type | `sealed abstract class` with lazy name fields | `sealed trait` with `PairType` | `sealed trait` |
+| Type names | 4 lazy `String` fields on every node (by-name → lazy val) | `SomeTypeName` (izumi-reflect) | Plain `String name` on container nodes only |
+| Leaf values | Pre-rendered `String` | Pre-rendered `String` | Raw typed `T` (needs `Show` at render time) |
+| One-sided values | `Edit.Insert`/`Edit.Delete` wrapping `DiffResult` | `PairType.ObtainedOnly`/`ExpectedOnly` on nodes | `DiffResultMissing[T]`/`DiffResultAdditional[T]` |
+| String diff | Hierarchical 3-level: `StringChunk`→`WordChunk`→`CharChunk` | None (just `ValueResult.Both`) | Hierarchical but using generic `DiffResult` nodes (loses level info) |
+| Collection diff | `Edit[DiffResult]` vector (Myers-aligned) | Flat `Vector[DiffResult]` (index or greedy matched) | `Map[String, DiffResult]` (string-keyed indices) |
+
+### Collection diffing algorithm
+
+| Aspect | kindlings-diff | difflicious | diffx |
+|--------|---------------|-------------|-------|
+| Algorithm | **Myers O(ND)** with shortest edit script | Greedy O(n·m) matching | Greedy O(n·m) matching |
+| Sequence alignment | LCS-based optimal alignment | `zipAll` by index OR `pairBy` function | `ObjectMatcher`-based greedy |
+| Pre-optimizations | Common prefix/suffix stripping (Neil Fraser) | None | None |
+| Result quality | Minimal edit distance, shows true insertions/deletions/moves | Index-based (misaligns after insert) OR function-based (no optimality guarantee) | Matcher-based (no optimality guarantee) |
+
+### String diffing
+
+| Aspect | kindlings-diff | difflicious | diffx |
+|--------|---------------|-------------|-------|
+| Algorithm | Myers at each level | None | Myers (via java-diff-utils port) |
+| Hierarchy | line → word → char (dedicated AST nodes) | N/A (strings are primitive values) | line → word → char (generic `DiffResult` nodes) |
+| Pre-optimizations | Equality check, common prefix/suffix, single edit (Neil Fraser) | N/A | None |
+| Post-cleanups | Semantic cleanup, semantic lossless alignment (Neil Fraser) | N/A | None |
+| Similarity threshold | Configurable (default 0.5) for word→char drill-down | N/A | 0.5 threshold |
+| Dedicated AST | Yes: `StringChunk`, `WordChunk`, `CharChunk` | N/A | No: reuses `DiffResultString`/`StringLine`/`StringWord` (same `DiffResult` base) |
+
+### Rendering
+
+| Aspect | kindlings-diff | difflicious | diffx |
+|--------|---------------|-------------|-------|
+| Color support | ANSI + plain (configurable) | ANSI via fansi library | ANSI with 4 themes + `NO_COLOR` support |
+| Name style | 4 options: Simple, Short, FQN, Pretty (ANSI) | Fixed (short + FQN available) | Fixed |
+| Indentation | Configurable: Spaces(n) or Tab | Fixed 2 spaces | Fixed 5 spaces |
+| Configuration | `RenderConfig` case class | Hardcoded | `ShowConfig` with per-color functions + `DiffResultTransformer` |
+| Skip identical | Not yet | No | Yes via `ShowConfig.skipIdentical` |
+
+## Feature coverage matrix
+
+### Core features
+
+| Feature | kindlings-diff | difflicious | diffx |
+|---------|---------------|-------------|-------|
+| Case class derivation | ✅ | ✅ | ✅ |
+| Sealed trait / enum | ✅ | ✅ | ✅ |
+| Primitive types | ✅ | ✅ | ✅ |
+| String (structural diff) | ✅ (hierarchical Myers) | ❌ (equality only) | ✅ (hierarchical Myers) |
+| Option | ✅ | ✅ (Magnolia-derived) | ✅ |
+| Either | ❌ (not yet) | ✅ (Magnolia-derived) | ✅ |
+| List/Vector/Seq | ✅ (Myers) | ✅ (zip or pairBy) | ✅ (greedy) |
+| Set | ✅ (greedy match) | ✅ (pairBy) | ✅ (greedy) |
+| Map | ✅ (key match) | ✅ (key match) | ✅ (matcher) |
+| Value types / opaque | ✅ (unwrap) | ✅ (contramap) | ✅ (Magnolia fallback to useEquals) |
+| Recursive types | ✅ (cached defs) | ✅ (lazy Magnolia) | ✅ (lazy Magnolia) |
+| Null handling | ❌ (not yet) | ❌ | ✅ (`nullGuard`) |
+
+### Configuration features
+
+| Feature | kindlings-diff | difflicious | diffx |
+|---------|---------------|-------------|-------|
+| Ignore field at path | ❌ (not yet) | ✅ (`ignoreAt(_.field)`) | ✅ (`modify(_.field).ignore`) |
+| Replace differ at path | ❌ (not yet) | ✅ (`replace(_.field)(newDiffer)`) | ✅ (`modify(_.field).setTo(d)`) |
+| Transform differ at path | ❌ (not yet) | ✅ (`configure(_.field)(f)`) | ✅ (`modify(_.field).using(f)`) |
+| Collection pairBy function | ❌ (not yet — uses Myers) | ✅ (`pairBy(_.id)`) | ✅ (`matchByValue(_.id)`) |
+| Collection pairBy index | N/A (Myers handles alignment) | ✅ (`pairByIndex`) | ✅ (`matchByKey(identity)`) |
+| Approximate numeric | ❌ (not yet) | ❌ | ✅ (`Diff.approximate(epsilon)`) |
+| Custom equality | ❌ (not yet) | ✅ (`Differ.useEquals`) | ✅ (`Diff.useEquals`) |
+| Path syntax (`.each`, `.subType[T]`) | ❌ (not yet) | ✅ (compile-time macros) | ✅ (compile-time macros) |
+
+### Integration features
+
+| Feature | kindlings-diff | difflicious | diffx |
+|---------|---------------|-------------|-------|
+| MUnit | ❌ (not yet) | ✅ | ✅ |
+| ScalaTest | ❌ (not yet) | ✅ | ✅ (should + must) |
+| Weaver | ❌ (not yet) | ✅ | ✅ |
+| Specs2 | ❌ (not yet) | ❌ | ✅ |
+| utest | ❌ (not yet) | ❌ | ✅ |
+| Cats collections | ❌ (not yet) | ✅ (NEL, NEC, NEV, Chain, NEM, NES, Validated) | ✅ (NEL, NEC, NEV, Chain, NEM, NES) |
+| Refined types | ❌ (not yet — Hearth handles opaques) | ❌ | ✅ |
+| Tagging | ❌ (not yet) | ❌ | ✅ |
+
+## What we do better
+
+1. **Myers diff for collections** — neither difflicious nor diffx uses optimal alignment for sequences. Both use greedy O(n·m) matching. Our Myers O(ND) finds the shortest edit script, producing cleaner diffs when elements are inserted or deleted in the middle of a list.
+
+2. **Neil Fraser pre-optimizations** — common prefix/suffix stripping, single-edit detection, and equality fast-path reduce input size before running Myers. Neither library does this.
+
+3. **Neil Fraser post-cleanups** — semantic cleanup removes trivially small equalities surrounded by large changes. Semantic lossless alignment slides edits to word/line boundaries for more human-readable output. Neither library does this.
+
+4. **Dedicated string diff AST** — our `StringChunk`/`WordChunk`/`CharChunk` types preserve the hierarchy level, allowing renderers to apply different styling per level. diffx reuses generic `DiffResult` nodes (loses level information). difflicious has no string diffing at all.
+
+5. **Lazy type names with 4 print modes** — type names are by-name parameters stored as lazy vals, computed only when rendering accesses a specific mode. Both difflicious and diffx compute type names eagerly at diff time.
+
+6. **Runtime-composable type names** — for `def foo[A: Diff]: Diff[Foo[A]]`, our type names are composed at runtime from the `Diff[A]` instance's names. difflicious uses izumi-reflect (heavy dependency). diffx uses compile-time-only strings (breaks for generic defs).
+
+7. **Cross-platform** — JVM + Scala.js + Scala Native, both Scala 2.13 and 3. difflicious only supports JVM + JS. diffx only JVM + JS (and also still supports 2.12).
+
+## What we're missing (future work)
+
+### High priority
+
+- **Path-based configuration** (`modify(_.field).ignore`, `configure(_.field.each)(f)`) — both libraries have this as a core user-facing API. Without it, users can't customize derivation for specific fields.
+- **Either support** — both libraries handle `Either[A, B]` out of the box.
+- **Test framework integrations** (MUnit, ScalaTest, Weaver) — both libraries provide `assertNoDiff`-style assertions. This is how most users interact with a diff library.
+- **`Diff.useEquals[T]`** — custom equality-based differ for types where structural diff isn't desired.
+
+### Medium priority
+
+- **Approximate numeric comparison** — diffx has `Diff.approximate[T](epsilon)`. Useful for floating-point comparisons in tests.
+- **`ShowConfig.skipIdentical`** — diffx can filter out unchanged fields from rendered output, making large diffs more readable.
+- **Cats collection integration** — NonEmptyList, NonEmptyVector, Chain, NonEmptyChain, NonEmptyMap, NonEmptySet, Validated.
+- **Null handling** — diffx's `nullGuard` pattern. Not critical for Scala-only code but useful for Java interop.
+- **`contramap` / `TransformedDiffer`** — difflicious has `ValueDiffer.contramap[S](f: S => T)` for creating differs for newtypes/opaque types without unwrapping.
+
+### Low priority
+
+- **`AlwaysIgnoreDiffer`** — difflicious has `Differ.alwaysIgnore[T]` for permanently ignoring a type regardless of path.
+- **Refined/tagging integrations** — diffx has these. Hearth's opaque/value type handling may cover most of these automatically.
+- **Multiple color themes** — diffx has dark/light/normal themes plus `DIFFX_COLOR_THEME` env var support.
+- **Specs2 / utest integrations** — lower adoption than MUnit/ScalaTest/Weaver.

--- a/docs/user-guide/diff-derivation.md
+++ b/docs/user-guide/diff-derivation.md
@@ -1,0 +1,256 @@
+# Diff Derivation
+
+Structural comparison of nested types using the Myers diff algorithm — derives `Diff[A]` instances that produce rich, hierarchical diff results for case classes, sealed traits, collections, maps, sets, options, and strings.
+
+Inspired by [difflicious](https://github.com/jatcwang/difflicious) and [diffx](https://github.com/softwaremill/diffx), but with key improvements:
+
+- **Myers diff for collections** — optimal sequence alignment (shortest edit script), not greedy matching
+- **Hierarchical string diff** — line → word → character drill-down with Myers at each level
+- **Neil Fraser optimizations** — pre-processing (common prefix/suffix, single-edit fast-path) and post-processing (semantic cleanup, boundary alignment)
+- **Lazy type names** — 4 print modes (pretty/plain/simple/short), computed on demand, runtime-composable for generic types
+- **Configurable rendering** — name style, color mode, indentation
+
+## Installation
+
+!!! example "sbt"
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %% "kindlings-diff-derivation" % "{{ kindlings_version() }}"
+    ```
+
+    Cross-platform (JVM / Scala.js / Scala Native):
+
+    ```scala
+    libraryDependencies += "com.kubuszok" %%% "kindlings-diff-derivation" % "{{ kindlings_version() }}"
+    ```
+
+!!! example "Scala CLI"
+
+    ```scala
+    //> using dep com.kubuszok::kindlings-diff-derivation:{{ kindlings_version() }}
+    ```
+
+## Quick start
+
+??? example "Comparing two case classes"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-diff-derivation:{{ kindlings_version() }}
+
+    import hearth.kindlings.diffderivation._
+
+    case class Person(name: String, age: Int)
+
+    implicit val diffPerson: Diff[Person] = Diff.derived[Person]
+
+    val result = diffPerson.diff(
+      Person("Alice", 30),
+      Person("Alice", 31)
+    )
+
+    println(result.isIdentical) // false
+    println(DiffRenderer.render(result, RenderConfig.plain))
+    // Person(
+    //   name = "Alice",
+    //   age = 30 -> 31,
+    // )
+    ```
+
+??? example "Sealed trait / enum diffing"
+
+    ```scala
+    sealed trait Shape
+    case class Circle(radius: Double) extends Shape
+    case class Rectangle(width: Double, height: Double) extends Shape
+
+    implicit val diffShape: Diff[Shape] = Diff.derived[Shape]
+
+    // Same variant — shows field changes
+    val r1 = diffShape.diff(Circle(1.0), Circle(2.0))
+    println(DiffRenderer.render(r1, RenderConfig.plain))
+    // Shape.Circle(
+    //   radius = 1.0 -> 2.0,
+    // )
+
+    // Different variants — shows type mismatch
+    val r2 = diffShape.diff(Circle(1.0), Rectangle(2.0, 3.0))
+    println(DiffRenderer.render(r2, RenderConfig.plain))
+    // Shape: Circle -> Rectangle
+    //   - ...
+    //   + ...
+    ```
+
+## Type class
+
+The `Diff[A]` type class provides:
+
+```scala
+trait Diff[A] {
+  // 4 lazy type name variants — computed on demand
+  def prettyName: String   // ANSI-colored fully qualified
+  def plainName: String    // fully qualified (e.g. "scala.Option[java.lang.String]")
+  def simpleName: String   // short with type args (e.g. "Option[String]")
+  def shortName: String    // short without args (e.g. "Option")
+
+  // Compare two values
+  def diff(left: A, right: A): DiffResult
+
+  // Structural snapshot of a single value (used for inserts/deletes in collections)
+  def snapshot(value: A): DiffResult
+}
+```
+
+## DiffResult AST
+
+Every `DiffResult` node carries 4 lazy type name strings. The renderer chooses which to display based on `NameStyle`.
+
+| Node | Meaning | `isIdentical` |
+|------|---------|----------------|
+| `Identical` | Both values are the same | `true` |
+| `ValueChanged` | Primitive/opaque values differ | `false` |
+| `Record` | Case class — field-by-field diff | all fields identical |
+| `Variant` | Same sealed trait variant | body is identical |
+| `TypeMismatch` | Different sealed trait variants | `false` |
+| `SeqDiff` | Ordered collection — Myers-aligned edits | all edits are Equal + identical |
+| `MapDiff` | Map — key-matched entries | all entries identical |
+| `SetDiff` | Set — element-matched entries | all entries identical |
+| `OptionalDiff` | Option handling | BothPresent + identical, or BothAbsent |
+| `StringDiff` | Hierarchical string diff (line→word→char) | all chunks are EqualLine |
+
+### Collection edits (Myers)
+
+`SeqDiff` contains `Vector[Edit[DiffResult]]` where:
+
+- `Edit.Equal(subDiff)` — element in both sequences, recursively sub-diffed (may have field-level changes)
+- `Edit.Insert(snapshot)` — element only in the right (new) sequence
+- `Edit.Delete(snapshot)` — element only in the left (old) sequence
+
+Unlike difflicious (zip-by-index) and diffx (greedy matching), Myers finds the **shortest edit script** — the minimum number of insertions and deletions to transform the left sequence into the right.
+
+### String chunks (hierarchical Myers)
+
+`StringDiff` contains `Vector[StringChunk]` with three levels:
+
+**Line level:**
+
+- `EqualLine(text)` — unchanged line
+- `InsertLine(text)` — line added
+- `DeleteLine(text)` — line removed
+- `ChangedLine(words)` — paired delete+insert drilled down to word level
+
+**Word level** (inside `ChangedLine`):
+
+- `EqualWord(text)` — unchanged word
+- `InsertWord(text)` — word added
+- `DeleteWord(text)` — word removed
+- `ChangedWord(chars)` — paired words drilled down to character level
+
+**Character level** (inside `ChangedWord`):
+
+- `EqualChar(text)` — unchanged character(s)
+- `InsertChar(text)` — character(s) added
+- `DeleteChar(text)` — character(s) removed
+
+## Rendering
+
+```scala
+val result: DiffResult = diff.diff(left, right)
+
+// Default: simple names, ANSI colors, 2-space indent
+println(DiffRenderer.render(result))
+
+// Plain text with +/- markers (no ANSI)
+println(DiffRenderer.render(result, RenderConfig.plain))
+
+// Custom config
+val config = RenderConfig(
+  nameStyle = NameStyle.FullyQualified,
+  colorMode = ColorMode.Plain,
+  indent = Indent.Spaces(4)
+)
+println(DiffRenderer.render(result, config))
+```
+
+### Name styles
+
+| Style | Example | TypeName method |
+|-------|---------|----------------|
+| `NameStyle.Simple` | `Option[String]` | `simpleName` |
+| `NameStyle.Short` | `Option` | `shortName` |
+| `NameStyle.FullyQualified` | `scala.Option[java.lang.String]` | `plainName` |
+| `NameStyle.Pretty` | ANSI-colored FQN | `prettyName` |
+
+### Color modes
+
+| Mode | Behavior |
+|------|----------|
+| `ColorMode.Ansi` | ANSI escape codes: red for removed, green for added, yellow for changed |
+| `ColorMode.Plain` | No color codes; uses `+`/`-` markers |
+
+### Indentation
+
+| Style | Behavior |
+|-------|----------|
+| `Indent.Spaces(n)` | `n` spaces per level (default: 2) |
+| `Indent.Tab` | One tab character per level |
+
+## Supported types
+
+### Automatically derived
+
+| Type | Diff behavior |
+|------|--------------|
+| Case classes | Field-by-field recursive diff → `Record` |
+| Sealed traits / enums | Subtype dispatch → `Variant` or `TypeMismatch` |
+| Primitives (`Int`, `Boolean`, `Double`, etc.) | Equality check → `Identical` or `ValueChanged` |
+| `String` | Hierarchical Myers (line→word→char) → `StringDiff` |
+| `BigDecimal`, `BigInt` | Equality check → `Identical` or `ValueChanged` |
+| `Option[A]` | Some/None handling → `OptionalDiff` |
+| `List[A]`, `Vector[A]`, `Seq[A]`, etc. | Myers alignment → `SeqDiff` |
+| `Map[K, V]` | Key matching → `MapDiff` |
+| `Set[A]` | Element matching → `SetDiff` |
+| Value types / opaque types | Unwrap and diff inner type |
+| Singletons (`case object`) | Always identical |
+| Recursive types (`Tree`) | Cached def pattern prevents infinite loops |
+
+## Myers diff algorithm
+
+The core algorithm is Eugene Myers' O(ND) "An O(ND) Difference Algorithm and Its Variations" (1986), finding the shortest edit script between two sequences.
+
+### Neil Fraser pre-optimizations
+
+Applied before running Myers to reduce input size:
+
+1. **Equality check** — skip if both sequences are identical
+2. **Common prefix/suffix stripping** — trim matching head and tail elements
+3. **Single edit detection** — if one side is empty after stripping, the answer is obvious
+
+### Neil Fraser post-cleanups
+
+Applied to Myers output for more human-readable results:
+
+1. **Merge** — consolidate adjacent same-type edits
+2. **Semantic cleanup** — remove trivially small equalities surrounded by large change blocks (strings)
+3. **Semantic lossless** — slide edits to align with word/line boundaries (strings)
+4. **Efficiency cleanup** — remove small equalities where rendering overhead exceeds savings (strings)
+
+## Debugging derivation
+
+Enable derivation logging to see which rules are applied:
+
+```scala
+import hearth.kindlings.diffderivation.debug.logDerivationForDiffDerivation
+
+implicit val diffPerson: Diff[Person] = Diff.derived[Person]
+```
+
+### Configurable timeout
+
+Override the default 5-second derivation timeout:
+
+```
+scalacOptions += "-Xmacro-settings:diffDerivation.timeout=30s"
+```
+
+Supported formats: `30` (seconds), `30s`, `5000ms`, `1m`.


### PR DESCRIPTION
## Summary

- New `diff-derivation` module: standalone type class for structural comparison of nested types
- Myers O(ND) diff algorithm for ordered collections — optimal alignment instead of greedy matching
- Hierarchical 3-level string diff (line → word → char) with Myers at each level
- Neil Fraser pre-optimizations (common prefix/suffix, single-edit fast-path) and post-cleanups (semantic cleanup, boundary alignment)
- Lazy type names (4 print modes: pretty/plain/simple/short) via `runtimePlainPrint`/`runtimeShortPrint`/`runtimePrettyPrint`
- `DiffResult` sealed abstract class with 10 node types, by-name → lazy val type name fields (zero cost until rendering)
- Two-method derivation (`diff` + `snapshot`) following `HashMacrosImpl` pattern with `parTuple`
- 10 diff rules + 7 snapshot rules: case classes, sealed traits, primitives, strings, collections, maps, sets, options, value types, singletons
- Configurable rendering: `NameStyle` (Simple/Short/FQN/Pretty), `ColorMode` (Ansi/Plain), `Indent` (Spaces/Tab)
- Cross-compiled: Scala 2.13 + 3, JVM + Scala.js + Scala Native
- 31 tests passing on both Scala versions
- User guide + comparison analysis with difflicious and diffx

## Test plan

- [x] `sbt --client "diffDerivation/clean ; diffDerivation/test"` — 31 tests pass (Scala 2.13)
- [x] `sbt --client "diffDerivation3/clean ; diffDerivation3/test"` — 31 tests pass (Scala 3)
- [x] CI cross-platform verification (JS, Native)