### PR TITLE
Add @sensitiveData annotation for Show/ShowPretty/FastShowPretty

### DIFF
--- a/FEATURE_PARITY.md
+++ b/FEATURE_PARITY.md
@@ -145,6 +145,13 @@ Kindlings uses `Int` priority (upstream avro4s uses `Float`). Higher priority va
 | `cats.Bifoldable` | No | Yes | Yes | Parity+ |
 | `cats.Bitraverse` | No | Yes | Yes | Parity+ |
 
+### Annotations
+
+| Feature | kittens | Kindlings | Status |
+|---|---|---|---|
+| `@sensitiveData` — redact field or type in Show/ShowPretty | No | Yes | Improvement |
+| `@sensitiveData("reason")` — redact with custom reason | No | Yes | Improvement |
+
 ### Type support
 
 | Feature | kittens | Kindlings | Status |
@@ -920,3 +927,10 @@ Discriminator metadata is fully propagated to child schemas:
 ## fast-show-pretty
 
 **Original type class** — no replacement target. Provides configurable pretty-printing with indentation support for case classes, collections, maps, and primitives. Cross-compiled for Scala 2.13 + 3, JVM + JS + Native.
+
+### Annotations
+
+| Annotation | Target | Description |
+|---|---|---|
+| `@sensitiveData` | Field or type | Replaces the rendered value with `[redacted]` |
+| `@sensitiveData("reason")` | Field or type | Replaces the rendered value with `[redacted: reason]` |

--- a/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -1,0 +1,29 @@
+package hearth.kindlings.catsderivation
+package internal.compiletime
+
+import hearth.MacroCommonsScala2
+
+trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
+  import c.universe.*
+
+  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    param.asUntyped.symbol.annotations.collectFirst {
+      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+    }
+  }
+
+  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.collectFirst {
+      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+    }
+  }
+
+  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
+    annotation match {
+      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
+      case _                                                => None
+    }
+}

--- a/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/ShowMacros.scala
+++ b/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/ShowMacros.scala
@@ -4,7 +4,10 @@ package internal.compiletime
 import hearth.MacroCommonsScala2
 import scala.reflect.macros.blackbox
 
-final private[catsderivation] class ShowMacros(val c: blackbox.Context) extends MacroCommonsScala2 with ShowMacrosImpl {
+final private[catsderivation] class ShowMacros(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with ShowMacrosImpl
+    with AnnotationSupportScala2 {
 
   def deriveShowImpl[A: c.WeakTypeTag]: c.Expr[cats.Show[A]] = deriveShow[A]
 }

--- a/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/ShowPrettyMacros.scala
+++ b/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/ShowPrettyMacros.scala
@@ -6,7 +6,8 @@ import scala.reflect.macros.blackbox
 
 final private[catsderivation] class ShowPrettyMacros(val c: blackbox.Context)
     extends MacroCommonsScala2
-    with ShowPrettyMacrosImpl {
+    with ShowPrettyMacrosImpl
+    with AnnotationSupportScala2 {
 
   def deriveShowPrettyImpl[A: c.WeakTypeTag]: c.Expr[hearth.kindlings.catsderivation.ShowPretty[A]] =
     deriveShowPretty[A]

--- a/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -1,0 +1,29 @@
+package hearth.kindlings.catsderivation
+package internal.compiletime
+
+import hearth.MacroCommonsScala3
+
+trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
+  import quotes.reflect.*
+
+  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    param.asUntyped.annotations.find { term =>
+      term.tpe =:= annTpe
+    }
+  }
+
+  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.find { term =>
+      term.tpe =:= annTpe
+    }
+  }
+
+  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
+    annotation match {
+      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
+      case _                                              => None
+    }
+}

--- a/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/ShowMacros.scala
+++ b/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/ShowMacros.scala
@@ -4,7 +4,10 @@ package internal.compiletime
 import hearth.MacroCommonsScala3
 import scala.quoted.*
 
-final private[catsderivation] class ShowMacros(q: Quotes) extends MacroCommonsScala3(using q), ShowMacrosImpl
+final private[catsderivation] class ShowMacros(q: Quotes)
+    extends MacroCommonsScala3(using q),
+      ShowMacrosImpl,
+      AnnotationSupportScala3
 private[catsderivation] object ShowMacros {
 
   def deriveShowImpl[A: Type](using q: Quotes): Expr[cats.Show[A]] =

--- a/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/ShowPrettyMacros.scala
+++ b/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/ShowPrettyMacros.scala
@@ -6,7 +6,8 @@ import scala.quoted.*
 
 final private[catsderivation] class ShowPrettyMacros(q: Quotes)
     extends MacroCommonsScala3(using q),
-      ShowPrettyMacrosImpl
+      ShowPrettyMacrosImpl,
+      AnnotationSupportScala3
 private[catsderivation] object ShowPrettyMacros {
 
   def deriveShowPrettyImpl[A: Type](using q: Quotes): Expr[hearth.kindlings.catsderivation.ShowPretty[A]] =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/annotations/sensitiveData.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/annotations/sensitiveData.scala
@@ -1,0 +1,7 @@
+package hearth.kindlings.catsderivation.annotations
+
+import scala.annotation.StaticAnnotation
+
+final class sensitiveData(val reason: String) extends StaticAnnotation {
+  def this() = this("")
+}

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupport.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupport.scala
@@ -1,0 +1,25 @@
+package hearth.kindlings.catsderivation.internal.compiletime
+
+import hearth.MacroCommons
+import hearth.std.*
+
+trait AnnotationSupport { this: MacroCommons & StdExtensions =>
+
+  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
+
+  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr]
+
+  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
+
+  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
+    findAnnotationOfType[Ann](param).isDefined
+
+  final def hasTypeAnnotation[Ann: Type, A: Type]: Boolean =
+    findTypeAnnotationOfType[Ann, A].isDefined
+
+  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
+    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+
+  final def getTypeAnnotationStringArg[Ann: Type, A: Type]: Option[String] =
+    findTypeAnnotationOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
+}

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ShowMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ShowMacrosImpl.scala
@@ -7,7 +7,8 @@ import hearth.std.*
 import hearth.kindlings.catsderivation.LogDerivation
 
 trait ShowMacrosImpl
-    extends rules.ShowUseCachedRuleImpl
+    extends AnnotationSupport
+    with rules.ShowUseCachedRuleImpl
     with rules.ShowUseImplicitRuleImpl
     with rules.ShowBuiltInRuleImpl
     with rules.ShowValueTypeRuleImpl
@@ -153,6 +154,8 @@ trait ShowMacrosImpl
     val Double: Type[Double] = Type.of[Double]
     val Char: Type[Char] = Type.of[Char]
     val String: Type[String] = Type.of[String]
+    val SensitiveData: Type[hearth.kindlings.catsderivation.annotations.sensitiveData] =
+      Type.of[hearth.kindlings.catsderivation.annotations.sensitiveData]
   }
 
   def shouldWeLogShowDerivation: Boolean = {

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/ShowCaseClassRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/ShowCaseClassRule.scala
@@ -12,21 +12,32 @@ trait ShowCaseClassRuleImpl {
 
   object ShowCaseClassRule extends ShowDerivationRule("Show as case class") {
 
+    private def redactedText(reason: Option[String]): String =
+      reason.filter(_.nonEmpty).fold("[redacted]")(r => s"[redacted: $r]")
+
     def apply[A: ShowCtx]: MIO[Rule.Applicability[Expr[String]]] =
       Log.info(s"Checking case class for Show[${Type[A].prettyPrint}]") >> {
         CaseClass.parse[A].toEither match {
           case Right(caseClass) =>
-            implicit val StringType: Type[String] = ShowTypes.String
-            val defBuilder = ValDefBuilder.ofDef1[A, String](s"show_${Type[A].shortName}")
-            for {
-              _ <- sctx.cache.forwardDeclare("cached-show-method", defBuilder)
-              _ <- MIO.scoped { runSafe =>
-                runSafe(sctx.cache.buildCachedWith("cached-show-method", defBuilder) { case (_, value) =>
-                  runSafe(deriveCaseClassShow[A](caseClass, value))
-                })
-              }
-              result <- ShowUseCachedRule[A]
-            } yield result
+            implicit val SensitiveDataType: Type[hearth.kindlings.catsderivation.annotations.sensitiveData] =
+              ShowTypes.SensitiveData
+            if (hasTypeAnnotation[hearth.kindlings.catsderivation.annotations.sensitiveData, A]) {
+              val reason =
+                getTypeAnnotationStringArg[hearth.kindlings.catsderivation.annotations.sensitiveData, A]
+              MIO.pure(Rule.matched(Expr(redactedText(reason))))
+            } else {
+              implicit val StringType: Type[String] = ShowTypes.String
+              val defBuilder = ValDefBuilder.ofDef1[A, String](s"show_${Type[A].shortName}")
+              for {
+                _ <- sctx.cache.forwardDeclare("cached-show-method", defBuilder)
+                _ <- MIO.scoped { runSafe =>
+                  runSafe(sctx.cache.buildCachedWith("cached-show-method", defBuilder) { case (_, value) =>
+                    runSafe(deriveCaseClassShow[A](caseClass, value))
+                  })
+                }
+                result <- ShowUseCachedRule[A]
+              } yield result
+            }
           case Left(reason) =>
             MIO.pure(Rule.yielded(reason.toString))
         }
@@ -37,6 +48,9 @@ trait ShowCaseClassRuleImpl {
         value: Expr[A]
     ): MIO[Expr[String]] = {
       val name = Type[A].shortName
+      implicit val SensitiveDataType: Type[hearth.kindlings.catsderivation.annotations.sensitiveData] =
+        ShowTypes.SensitiveData
+      val paramsByName: Map[String, Parameter] = caseClass.primaryConstructor.parameters.flatten.toMap
 
       NonEmptyList.fromList(caseClass.caseFieldValuesAt(value).toList) match {
         case Some(fieldValues) =>
@@ -44,7 +58,15 @@ trait ShowCaseClassRuleImpl {
             .traverse { case (fieldName, fieldValue) =>
               import fieldValue.{Underlying as Field, value as fieldExpr}
               Log.namedScope(s"Deriving Show for $fieldName: ${Field.prettyPrint}") {
-                deriveShowRecursively[Field](using sctx.nest(fieldExpr)).map(r => (fieldName, r))
+                paramsByName.get(fieldName) match {
+                  case Some(param)
+                      if hasAnnotationType[hearth.kindlings.catsderivation.annotations.sensitiveData](param) =>
+                    val reason =
+                      getAnnotationStringArg[hearth.kindlings.catsderivation.annotations.sensitiveData](param)
+                    MIO.pure((fieldName, Expr(redactedText(reason))))
+                  case _ =>
+                    deriveShowRecursively[Field](using sctx.nest(fieldExpr)).map(r => (fieldName, r))
+                }
               }
             }
             .map { fields =>

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/ShowEnumRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/ShowEnumRule.scala
@@ -14,17 +14,26 @@ trait ShowEnumRuleImpl {
       Log.info(s"Checking enum for Show[${Type[A].prettyPrint}]") >> {
         Enum.parse[A].toEither match {
           case Right(enumm) =>
-            implicit val StringType: Type[String] = ShowTypes.String
-            val defBuilder = ValDefBuilder.ofDef1[A, String](s"show_${Type[A].shortName}")
-            for {
-              _ <- sctx.cache.forwardDeclare("cached-show-method", defBuilder)
-              _ <- MIO.scoped { runSafe =>
-                runSafe(sctx.cache.buildCachedWith("cached-show-method", defBuilder) { case (_, value) =>
-                  runSafe(deriveEnumShow[A](enumm, value))
-                })
-              }
-              result <- ShowUseCachedRule[A]
-            } yield result
+            implicit val SensitiveDataType: Type[hearth.kindlings.catsderivation.annotations.sensitiveData] =
+              ShowTypes.SensitiveData
+            if (hasTypeAnnotation[hearth.kindlings.catsderivation.annotations.sensitiveData, A]) {
+              val reason =
+                getTypeAnnotationStringArg[hearth.kindlings.catsderivation.annotations.sensitiveData, A]
+              val text = reason.filter(_.nonEmpty).fold("[redacted]")(r => s"[redacted: $r]")
+              MIO.pure(Rule.matched(Expr(text)))
+            } else {
+              implicit val StringType: Type[String] = ShowTypes.String
+              val defBuilder = ValDefBuilder.ofDef1[A, String](s"show_${Type[A].shortName}")
+              for {
+                _ <- sctx.cache.forwardDeclare("cached-show-method", defBuilder)
+                _ <- MIO.scoped { runSafe =>
+                  runSafe(sctx.cache.buildCachedWith("cached-show-method", defBuilder) { case (_, value) =>
+                    runSafe(deriveEnumShow[A](enumm, value))
+                  })
+                }
+                result <- ShowUseCachedRule[A]
+              } yield result
+            }
           case Left(reason) =>
             MIO.pure(Rule.yielded(reason.toString))
         }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/ShowPrettyCaseClassRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/ShowPrettyCaseClassRule.scala
@@ -13,21 +13,32 @@ trait ShowPrettyCaseClassRuleImpl {
   @scala.annotation.nowarn("msg=is never used")
   object ShowPrettyCaseClassRule extends ShowDerivationRule("ShowPretty as case class") {
 
+    private def redactedText(reason: Option[String]): String =
+      reason.filter(_.nonEmpty).fold("[redacted]")(r => s"[redacted: $r]")
+
     def apply[A: ShowCtx]: MIO[Rule.Applicability[Expr[String]]] =
       Log.info(s"Checking case class for ShowPretty[${Type[A].prettyPrint}]") >> {
         CaseClass.parse[A].toEither match {
           case Right(caseClass) =>
-            implicit val StringType: Type[String] = ShowTypes.String
-            val defBuilder = ValDefBuilder.ofDef1[A, String](s"showPretty_${Type[A].shortName}")
-            for {
-              _ <- sctx.cache.forwardDeclare("cached-show-pretty-method", defBuilder)
-              _ <- MIO.scoped { runSafe =>
-                runSafe(sctx.cache.buildCachedWith("cached-show-pretty-method", defBuilder) { case (_, value) =>
-                  runSafe(deriveCaseClassShowPretty[A](caseClass, value))
-                })
-              }
-              result <- ShowPrettyUseCachedRule[A]
-            } yield result
+            implicit val SensitiveDataType: Type[hearth.kindlings.catsderivation.annotations.sensitiveData] =
+              ShowTypes.SensitiveData
+            if (hasTypeAnnotation[hearth.kindlings.catsderivation.annotations.sensitiveData, A]) {
+              val reason =
+                getTypeAnnotationStringArg[hearth.kindlings.catsderivation.annotations.sensitiveData, A]
+              MIO.pure(Rule.matched(Expr(redactedText(reason))))
+            } else {
+              implicit val StringType: Type[String] = ShowTypes.String
+              val defBuilder = ValDefBuilder.ofDef1[A, String](s"showPretty_${Type[A].shortName}")
+              for {
+                _ <- sctx.cache.forwardDeclare("cached-show-pretty-method", defBuilder)
+                _ <- MIO.scoped { runSafe =>
+                  runSafe(sctx.cache.buildCachedWith("cached-show-pretty-method", defBuilder) { case (_, value) =>
+                    runSafe(deriveCaseClassShowPretty[A](caseClass, value))
+                  })
+                }
+                result <- ShowPrettyUseCachedRule[A]
+              } yield result
+            }
           case Left(reason) =>
             MIO.pure(Rule.yielded(reason.toString))
         }
@@ -45,6 +56,9 @@ trait ShowPrettyCaseClassRuleImpl {
         value: Expr[A]
     ): MIO[Expr[String]] = {
       val name = Type[A].shortName
+      implicit val SensitiveDataType: Type[hearth.kindlings.catsderivation.annotations.sensitiveData] =
+        ShowTypes.SensitiveData
+      val paramsByName: Map[String, Parameter] = caseClass.primaryConstructor.parameters.flatten.toMap
 
       NonEmptyList.fromList(caseClass.caseFieldValuesAt(value).toList) match {
         case Some(fieldValues) =>
@@ -52,7 +66,15 @@ trait ShowPrettyCaseClassRuleImpl {
             .traverse { case (fieldName, fieldValue) =>
               import fieldValue.{Underlying as Field, value as fieldExpr}
               Log.namedScope(s"Deriving ShowPretty for $fieldName: ${Field.prettyPrint}") {
-                deriveShowPrettyRecursively[Field](using sctx.nest(fieldExpr)).map(r => (fieldName, r))
+                paramsByName.get(fieldName) match {
+                  case Some(param)
+                      if hasAnnotationType[hearth.kindlings.catsderivation.annotations.sensitiveData](param) =>
+                    val reason =
+                      getAnnotationStringArg[hearth.kindlings.catsderivation.annotations.sensitiveData](param)
+                    MIO.pure((fieldName, Expr(redactedText(reason))))
+                  case _ =>
+                    deriveShowPrettyRecursively[Field](using sctx.nest(fieldExpr)).map(r => (fieldName, r))
+                }
               }
             }
             .map { fields =>

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/ShowPrettyEnumRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/ShowPrettyEnumRule.scala
@@ -14,17 +14,26 @@ trait ShowPrettyEnumRuleImpl {
       Log.info(s"Checking enum for ShowPretty[${Type[A].prettyPrint}]") >> {
         Enum.parse[A].toEither match {
           case Right(enumm) =>
-            implicit val StringType: Type[String] = ShowTypes.String
-            val defBuilder = ValDefBuilder.ofDef1[A, String](s"showPretty_${Type[A].shortName}")
-            for {
-              _ <- sctx.cache.forwardDeclare("cached-show-pretty-method", defBuilder)
-              _ <- MIO.scoped { runSafe =>
-                runSafe(sctx.cache.buildCachedWith("cached-show-pretty-method", defBuilder) { case (_, value) =>
-                  runSafe(deriveEnumShowPretty[A](enumm, value))
-                })
-              }
-              result <- ShowPrettyUseCachedRule[A]
-            } yield result
+            implicit val SensitiveDataType: Type[hearth.kindlings.catsderivation.annotations.sensitiveData] =
+              ShowTypes.SensitiveData
+            if (hasTypeAnnotation[hearth.kindlings.catsderivation.annotations.sensitiveData, A]) {
+              val reason =
+                getTypeAnnotationStringArg[hearth.kindlings.catsderivation.annotations.sensitiveData, A]
+              val text = reason.filter(_.nonEmpty).fold("[redacted]")(r => s"[redacted: $r]")
+              MIO.pure(Rule.matched(Expr(text)))
+            } else {
+              implicit val StringType: Type[String] = ShowTypes.String
+              val defBuilder = ValDefBuilder.ofDef1[A, String](s"showPretty_${Type[A].shortName}")
+              for {
+                _ <- sctx.cache.forwardDeclare("cached-show-pretty-method", defBuilder)
+                _ <- MIO.scoped { runSafe =>
+                  runSafe(sctx.cache.buildCachedWith("cached-show-pretty-method", defBuilder) { case (_, value) =>
+                    runSafe(deriveEnumShowPretty[A](enumm, value))
+                  })
+                }
+                result <- ShowPrettyUseCachedRule[A]
+              } yield result
+            }
           case Left(reason) =>
             MIO.pure(Rule.yielded(reason.toString))
         }

--- a/cats-derivation/src/test/scala/hearth/kindlings/catsderivation/CatsDerivationSpec.scala
+++ b/cats-derivation/src/test/scala/hearth/kindlings/catsderivation/CatsDerivationSpec.scala
@@ -211,6 +211,66 @@ final class CatsDerivationSpec extends MacroSuite {
     }
   }
 
+  group("Show @sensitiveData") {
+
+    test("field-level redaction") {
+      examples.UserWithPassword.showUserWithPassword.show(
+        examples.UserWithPassword("Alice", "s3cret")
+      ) ==> "UserWithPassword(name = Alice, password = [redacted])"
+    }
+
+    test("field-level redaction with reason") {
+      examples.UserWithPII.showUserWithPII.show(
+        examples.UserWithPII("Alice", "alice@example.com", 30)
+      ) ==> "UserWithPII(name = Alice, email = [redacted: PII], age = 30)"
+    }
+
+    test("type-level redaction") {
+      examples.SecretData.showSecretData.show(examples.SecretData("secret", 42)) ==> "[redacted]"
+    }
+
+    test("type-level redaction with reason") {
+      examples.ClassifiedInfo.showClassifiedInfo.show(
+        examples.ClassifiedInfo("top-secret")
+      ) ==> "[redacted: classified]"
+    }
+
+    test("type-level redaction on sealed trait") {
+      examples.SecretEnum.showSecretEnum.show(examples.SecretCase(42)) ==> "[redacted]"
+    }
+  }
+
+  group("ShowPretty @sensitiveData") {
+
+    test("field-level redaction") {
+      val result = examples.UserWithPassword.showPrettyUserWithPassword.show(
+        examples.UserWithPassword("Alice", "s3cret")
+      )
+      result ==> "UserWithPassword(\n  name = Alice,\n  password = [redacted]\n)"
+    }
+
+    test("field-level redaction with reason") {
+      val result = examples.UserWithPII.showPrettyUserWithPII.show(
+        examples.UserWithPII("Alice", "alice@example.com", 30)
+      )
+      result ==> "UserWithPII(\n  name = Alice,\n  email = [redacted: PII],\n  age = 30\n)"
+    }
+
+    test("type-level redaction") {
+      examples.SecretData.showPrettySecretData.show(examples.SecretData("secret", 42)) ==> "[redacted]"
+    }
+
+    test("type-level redaction with reason") {
+      examples.ClassifiedInfo.showPrettyClassifiedInfo.show(
+        examples.ClassifiedInfo("top-secret")
+      ) ==> "[redacted: classified]"
+    }
+
+    test("type-level redaction on sealed trait") {
+      examples.SecretEnum.showPrettySecretEnum.show(examples.SecretCase(42)) ==> "[redacted]"
+    }
+  }
+
   group("Show enum") {
 
     test("sealed trait with case classes") {

--- a/cats-derivation/src/test/scala/hearth/kindlings/catsderivation/examples.scala
+++ b/cats-derivation/src/test/scala/hearth/kindlings/catsderivation/examples.scala
@@ -200,6 +200,40 @@ object examples {
     implicit val bitraverseTaggedValue: cats.Bitraverse[TaggedValue] = cats.Bitraverse.derived
   }
 
+  // @sensitiveData examples
+  import hearth.kindlings.catsderivation.annotations.sensitiveData
+
+  final case class UserWithPassword(name: String, @sensitiveData password: String)
+  object UserWithPassword {
+    implicit val showUserWithPassword: cats.Show[UserWithPassword] = cats.Show.derived
+    implicit val showPrettyUserWithPassword: ShowPretty[UserWithPassword] = ShowPretty.derived
+  }
+
+  final case class UserWithPII(name: String, @sensitiveData("PII") email: String, age: Int)
+  object UserWithPII {
+    implicit val showUserWithPII: cats.Show[UserWithPII] = cats.Show.derived
+    implicit val showPrettyUserWithPII: ShowPretty[UserWithPII] = ShowPretty.derived
+  }
+
+  @sensitiveData final case class SecretData(value: String, key: Int)
+  object SecretData {
+    implicit val showSecretData: cats.Show[SecretData] = cats.Show.derived
+    implicit val showPrettySecretData: ShowPretty[SecretData] = ShowPretty.derived
+  }
+
+  @sensitiveData("classified") final case class ClassifiedInfo(code: String)
+  object ClassifiedInfo {
+    implicit val showClassifiedInfo: cats.Show[ClassifiedInfo] = cats.Show.derived
+    implicit val showPrettyClassifiedInfo: ShowPretty[ClassifiedInfo] = ShowPretty.derived
+  }
+
+  @sensitiveData sealed trait SecretEnum
+  final case class SecretCase(value: Int) extends SecretEnum
+  object SecretEnum {
+    implicit val showSecretEnum: cats.Show[SecretEnum] = cats.Show.derived
+    implicit val showPrettySecretEnum: ShowPretty[SecretEnum] = ShowPretty.derived
+  }
+
   // Sealed trait with case objects only
   sealed trait Color
   case object Red extends Color

--- a/docs/user-guide/cats-derivation.md
+++ b/docs/user-guide/cats-derivation.md
@@ -219,6 +219,56 @@ Person("Alice", 30).show  // Show.derived[Person] resolved automatically
     // )
     ```
 
+## Annotations
+
+The `Show` and `ShowPretty` type classes support the `@sensitiveData` annotation to redact sensitive values from rendered output.
+
+| Annotation                 | Target        | Description                                           |
+|----------------------------|---------------|-------------------------------------------------------|
+| `@sensitiveData`           | Field or type | Replaces the rendered value with `[redacted]`         |
+| `@sensitiveData("reason")` | Field or type | Replaces the rendered value with `[redacted: reason]` |
+
+Import annotations from `hearth.kindlings.catsderivation.annotations`.
+
+??? example "Redacting sensitive fields in Show"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
+
+    import hearth.kindlings.catsderivation._
+    import hearth.kindlings.catsderivation.extensions._
+    import hearth.kindlings.catsderivation.annotations.sensitiveData
+    import cats._
+    import cats.syntax.all._
+
+    case class User(name: String, @sensitiveData password: String, @sensitiveData("PII") email: String)
+
+    implicit val showUser: Show[User] = Show.derived[User]
+
+    println(User("Alice", "s3cret", "alice@example.com").show)
+    // expected output:
+    // User(name = Alice, password = [redacted], email = [redacted: PII])
+    ```
+
+??? example "Redacting an entire type in ShowPretty"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
+
+    import hearth.kindlings.catsderivation._
+    import hearth.kindlings.catsderivation.annotations.sensitiveData
+
+    @sensitiveData("classified") case class SecretData(code: String, key: Int)
+
+    implicit val showPrettySecret: ShowPretty[SecretData] = ShowPretty.derived[SecretData]
+
+    println(showPrettySecret.show(SecretData("alpha", 42)))
+    // expected output:
+    // [redacted: classified]
+    ```
+
 ## Debugging
 
 Import the debug package to log the derivation process at compile time:

--- a/docs/user-guide/cats-derivation.md
+++ b/docs/user-guide/cats-derivation.md
@@ -258,6 +258,7 @@ Import annotations from `hearth.kindlings.catsderivation.annotations`.
     //> using dep com.kubuszok::kindlings-cats-derivation:{{ kindlings_version() }}
 
     import hearth.kindlings.catsderivation._
+    import hearth.kindlings.catsderivation.extensions._
     import hearth.kindlings.catsderivation.annotations.sensitiveData
 
     @sensitiveData("classified") case class SecretData(code: String, key: Int)

--- a/docs/user-guide/fast-show-pretty.md
+++ b/docs/user-guide/fast-show-pretty.md
@@ -245,6 +245,78 @@ val output2 = FastShowPretty.render(myValue, custom)
     // )
     ```
 
+## Annotations
+
+| Annotation                 | Target        | Description                                           |
+|----------------------------|---------------|-------------------------------------------------------|
+| `@sensitiveData`           | Field or type | Replaces the rendered value with `[redacted]`         |
+| `@sensitiveData("reason")` | Field or type | Replaces the rendered value with `[redacted: reason]` |
+
+Import annotations from `hearth.kindlings.fastshowpretty.annotations`.
+
+??? example "Redacting sensitive fields"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty._
+    import hearth.kindlings.fastshowpretty.annotations.sensitiveData
+
+    case class User(name: String, @sensitiveData password: String)
+
+    println(FastShowPretty.render(User("Alice", "s3cret"), RenderConfig.Default))
+    // expected output:
+    // User(
+    //   name = "Alice",
+    //   password = [redacted]
+    // )
+    ```
+
+??? example "Redacting with a reason"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty._
+    import hearth.kindlings.fastshowpretty.annotations.sensitiveData
+
+    case class User(name: String, @sensitiveData("PII") email: String, age: Int)
+
+    println(FastShowPretty.render(User("Alice", "alice@example.com", 30), RenderConfig.Default))
+    // expected output:
+    // User(
+    //   name = "Alice",
+    //   email = [redacted: PII],
+    //   age = 30
+    // )
+    ```
+
+??? example "Redacting an entire type"
+
+    ```scala
+    //> using scala {{ scala.2_13 }}
+    //> using dep com.kubuszok::kindlings-fast-show-pretty:{{ kindlings_version() }}
+
+    import hearth.kindlings.fastshowpretty._
+    import hearth.kindlings.fastshowpretty.annotations.sensitiveData
+
+    @sensitiveData("financial data") case class CreditCard(number: String, cvv: String)
+    case class Checkout(item: String, card: CreditCard)
+
+    println(FastShowPretty.render(CreditCard("4111-1111-1111-1111", "123"), RenderConfig.Default))
+    // expected output:
+    // [redacted: financial data]
+
+    println(FastShowPretty.render(Checkout("Widget", CreditCard("4111", "123")), RenderConfig.Default))
+    // expected output:
+    // Checkout(
+    //   item = "Widget",
+    //   card = [redacted: financial data]
+    // )
+    ```
+
 ## Primitive rendering
 
 FastShowPretty renders primitives with type-disambiguating suffixes, matching Scala literal syntax:

--- a/fast-show-pretty/src/main/scala-2/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupportScala2.scala
+++ b/fast-show-pretty/src/main/scala-2/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupportScala2.scala
@@ -1,0 +1,29 @@
+package hearth.kindlings.fastshowpretty
+package internal.compiletime
+
+import hearth.MacroCommonsScala2
+
+trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
+  import c.universe.*
+
+  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    param.asUntyped.symbol.annotations.collectFirst {
+      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+    }
+  }
+
+  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.collectFirst {
+      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+    }
+  }
+
+  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
+    annotation match {
+      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
+      case _                                                => None
+    }
+}

--- a/fast-show-pretty/src/main/scala-2/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacros.scala
+++ b/fast-show-pretty/src/main/scala-2/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacros.scala
@@ -6,7 +6,8 @@ import scala.reflect.macros.blackbox
 
 final private[fastshowpretty] class FastShowPrettyMacros(val c: blackbox.Context)
     extends MacroCommonsScala2
-    with FastShowPrettyMacrosImpl {
+    with FastShowPrettyMacrosImpl
+    with AnnotationSupportScala2 {
 
   import c.universe.*
 

--- a/fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupportScala3.scala
+++ b/fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupportScala3.scala
@@ -1,0 +1,29 @@
+package hearth.kindlings.fastshowpretty
+package internal.compiletime
+
+import hearth.MacroCommonsScala3
+
+trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
+  import quotes.reflect.*
+
+  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    param.asUntyped.annotations.find { term =>
+      term.tpe =:= annTpe
+    }
+  }
+
+  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.find { term =>
+      term.tpe =:= annTpe
+    }
+  }
+
+  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
+    annotation match {
+      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
+      case _                                              => None
+    }
+}

--- a/fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacros.scala
+++ b/fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacros.scala
@@ -6,7 +6,8 @@ import scala.quoted.*
 
 final private[fastshowpretty] class FastShowPrettyMacros(q: Quotes)
     extends MacroCommonsScala3(using q),
-      FastShowPrettyMacrosImpl
+      FastShowPrettyMacrosImpl,
+      AnnotationSupportScala3
 private[fastshowpretty] object FastShowPrettyMacros {
 
   def deriveInlineImpl[A: Type](

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/annotations/sensitiveData.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/annotations/sensitiveData.scala
@@ -1,0 +1,7 @@
+package hearth.kindlings.fastshowpretty.annotations
+
+import scala.annotation.StaticAnnotation
+
+final class sensitiveData(val reason: String) extends StaticAnnotation {
+  def this() = this("")
+}

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupport.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupport.scala
@@ -1,0 +1,25 @@
+package hearth.kindlings.fastshowpretty.internal.compiletime
+
+import hearth.MacroCommons
+import hearth.std.*
+
+trait AnnotationSupport { this: MacroCommons & StdExtensions =>
+
+  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
+
+  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr]
+
+  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
+
+  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
+    findAnnotationOfType[Ann](param).isDefined
+
+  final def hasTypeAnnotation[Ann: Type, A: Type]: Boolean =
+    findTypeAnnotationOfType[Ann, A].isDefined
+
+  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
+    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+
+  final def getTypeAnnotationStringArg[Ann: Type, A: Type]: Option[String] =
+    findTypeAnnotationOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
+}

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacrosImpl.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacrosImpl.scala
@@ -8,6 +8,7 @@ import hearth.kindlings.fastshowpretty.{FastShowPretty, RenderConfig}
 
 trait FastShowPrettyMacrosImpl
     extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with AnnotationSupport
     with rules.FastShowPrettyUseCachedDefWhenAvailableRuleImpl
     with rules.FastShowPrettyUseImplicitWhenAvailableRuleImpl
     with rules.FastShowPrettyUseBuiltInSupportRuleImpl
@@ -289,6 +290,8 @@ trait FastShowPrettyMacrosImpl
     val Char: Type[Char] = Type.of[Char]
     val String: Type[String] = Type.of[String]
     val Product: Type[Product] = Type.of[Product]
+    val SensitiveData: Type[hearth.kindlings.fastshowpretty.annotations.sensitiveData] =
+      Type.of[hearth.kindlings.fastshowpretty.annotations.sensitiveData]
   }
 
   // The actual derivation logic in the form of DerivationCtx[A] ?=> MIO[Expr[StringBuilder]].

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/rules/FastShowPrettyHandleAsCaseClassRule.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/rules/FastShowPrettyHandleAsCaseClassRule.scala
@@ -15,17 +15,31 @@ trait FastShowPrettyHandleAsCaseClassRuleImpl { this: FastShowPrettyMacrosImpl &
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a case class") >> {
         CaseClass.parse[A].toEither match {
           case Right(caseClass) =>
-            deriveCaseClassFields[A](caseClass).map(Rule.matched)
+            implicit val SensitiveDataType: Type[hearth.kindlings.fastshowpretty.annotations.sensitiveData] =
+              Types.SensitiveData
+            if (hasTypeAnnotation[hearth.kindlings.fastshowpretty.annotations.sensitiveData, A]) {
+              val reason = getTypeAnnotationStringArg[hearth.kindlings.fastshowpretty.annotations.sensitiveData, A]
+              val text = redactedText(reason)
+              MIO.pure(Rule.matched(Expr.quote(Expr.splice(ctx.sb).append(Expr.splice(Expr(text))))))
+            } else {
+              deriveCaseClassFields[A](caseClass).map(Rule.matched)
+            }
 
           case Left(reason) =>
             MIO.pure(Rule.yielded(reason))
         }
       }
 
+    private def redactedText(reason: Option[String]): String =
+      reason.filter(_.nonEmpty).fold("[redacted]")(r => s"[redacted: $r]")
+
     private def deriveCaseClassFields[A: DerivationCtx](
         caseClass: CaseClass[A]
     ): MIO[Expr[StringBuilder]] = {
       val name = Expr(Type[A].shortName)
+      implicit val SensitiveDataType: Type[hearth.kindlings.fastshowpretty.annotations.sensitiveData] =
+        Types.SensitiveData
+      val paramsByName: Map[String, Parameter] = caseClass.primaryConstructor.parameters.flatten.toMap
 
       NonEmptyList.fromList(caseClass.caseFieldValuesAt(ctx.value).toList) match {
         case Some(fieldValues) =>
@@ -33,9 +47,17 @@ trait FastShowPrettyHandleAsCaseClassRuleImpl { this: FastShowPrettyMacrosImpl &
             .parTraverse { case (fieldName, fieldValue) =>
               import fieldValue.{Underlying as Field, value as fieldExpr}
               Log.namedScope(s"Deriving the value ${ctx.value.prettyPrint}.$fieldName: ${Field.prettyPrint}") {
-                // Use incrementLevel so nested case classes are indented properly
-                deriveResultRecursively[Field](using ctx.incrementLevel.nest(fieldExpr)).map { fieldResult =>
-                  (fieldName, fieldResult)
+                paramsByName.get(fieldName) match {
+                  case Some(param)
+                      if hasAnnotationType[hearth.kindlings.fastshowpretty.annotations.sensitiveData](param) =>
+                    val reason =
+                      getAnnotationStringArg[hearth.kindlings.fastshowpretty.annotations.sensitiveData](param)
+                    val text = redactedText(reason)
+                    MIO.pure((fieldName, Expr.quote(Expr.splice(ctx.sb).append(Expr.splice(Expr(text))))))
+                  case _ =>
+                    deriveResultRecursively[Field](using ctx.incrementLevel.nest(fieldExpr)).map { fieldResult =>
+                      (fieldName, fieldResult)
+                    }
                 }
               }
             }

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/rules/FastShowPrettyHandleAsEnumRule.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/rules/FastShowPrettyHandleAsEnumRule.scala
@@ -13,7 +13,16 @@ trait FastShowPrettyHandleAsEnumRuleImpl { this: FastShowPrettyMacrosImpl & Macr
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as an enum") >> {
         Enum.parse[A].toEither match {
           case Right(enumm) =>
-            deriveEnumCases[A](enumm).map(Rule.matched)
+            implicit val SensitiveDataType: Type[hearth.kindlings.fastshowpretty.annotations.sensitiveData] =
+              Types.SensitiveData
+            if (hasTypeAnnotation[hearth.kindlings.fastshowpretty.annotations.sensitiveData, A]) {
+              val reason =
+                getTypeAnnotationStringArg[hearth.kindlings.fastshowpretty.annotations.sensitiveData, A]
+              val text = reason.filter(_.nonEmpty).fold("[redacted]")(r => s"[redacted: $r]")
+              MIO.pure(Rule.matched(Expr.quote(Expr.splice(ctx.sb).append(Expr.splice(Expr(text))))))
+            } else {
+              deriveEnumCases[A](enumm).map(Rule.matched)
+            }
           case Left(reason) =>
             MIO.pure(Rule.yielded(reason))
         }

--- a/fast-show-pretty/src/test/scala/hearth/kindlings/fastshowpretty/FastShowPrettySpec.scala
+++ b/fast-show-pretty/src/test/scala/hearth/kindlings/fastshowpretty/FastShowPrettySpec.scala
@@ -421,6 +421,53 @@ final class FastShowPrettySpec extends MacroSuite {
       }
     }
 
+    group("@sensitiveData annotation") {
+
+      test("field-level redaction") {
+        val result = FastShowPretty.render(UserWithPassword("Alice", "s3cret"), RenderConfig.Default)
+        result ==>
+          """UserWithPassword(
+            |  name = "Alice",
+            |  password = [redacted]
+            |)""".stripMargin
+      }
+
+      test("field-level redaction with reason") {
+        val result = FastShowPretty.render(UserWithPII("Alice", "alice@example.com", 30), RenderConfig.Default)
+        result ==>
+          """UserWithPII(
+            |  name = "Alice",
+            |  email = [redacted: PII],
+            |  age = 30
+            |)""".stripMargin
+      }
+
+      test("type-level redaction") {
+        val result = FastShowPretty.render(CreditCard("4111-1111-1111-1111", "123"), RenderConfig.Default)
+        result ==> "[redacted]"
+      }
+
+      test("type-level redaction with reason") {
+        val result = FastShowPretty.render(BankAccount("DE89370400440532013000", 1234.56), RenderConfig.Default)
+        result ==> "[redacted: financial data]"
+      }
+
+      test("type-level redaction on sealed trait") {
+        val result = FastShowPretty.render[SecretEnum](SecretA(42), RenderConfig.Default)
+        result ==> "[redacted]"
+      }
+
+      test("type-level redaction as nested field") {
+        case class Checkout(item: String, card: CreditCard)
+        val result = FastShowPretty.render(Checkout("Widget", CreditCard("4111", "123")), RenderConfig.Default)
+        result ==>
+          """Checkout(
+            |  item = "Widget",
+            |  card = [redacted]
+            |)""".stripMargin
+      }
+    }
+
     group("sealed traits") {
 
       test("sealed trait with case class subtypes") {

--- a/fast-show-pretty/src/test/scala/hearth/kindlings/fastshowpretty/examples.scala
+++ b/fast-show-pretty/src/test/scala/hearth/kindlings/fastshowpretty/examples.scala
@@ -11,6 +11,17 @@ final case class ExampleValueClass(a: Int) extends AnyVal
 final case class WrappedString(s: String) extends AnyVal
 class NotAHandledType
 
+import hearth.kindlings.fastshowpretty.annotations.sensitiveData
+
+case class UserWithPassword(name: String, @sensitiveData password: String)
+case class UserWithPII(name: String, @sensitiveData("PII") email: String, age: Int)
+@sensitiveData case class CreditCard(number: String, cvv: String)
+@sensitiveData("financial data") case class BankAccount(iban: String, balance: Double)
+
+@sensitiveData sealed trait SecretEnum
+case class SecretA(value: Int) extends SecretEnum
+case class SecretB(name: String) extends SecretEnum
+
 sealed trait Shape
 case class Circle(radius: Double) extends Shape
 case class Rectangle(width: Double, height: Double) extends Shape


### PR DESCRIPTION
## Summary

- Adds `@sensitiveData` annotation to **fast-show-pretty** and **cats-derivation** modules
- Supports **field-level** (`@sensitiveData password: String`) and **type-level** (`@sensitiveData case class CreditCard(...)`) redaction
- Optional reason string: `@sensitiveData` → `[redacted]`, `@sensitiveData("PII")` → `[redacted: PII]`
- Full cross-compilation support (Scala 2.13 + 3) via `AnnotationSupport` traits following the circe/avro annotation pattern

## Test plan

- [x] FastShowPretty: field-level redaction (with and without reason)
- [x] FastShowPretty: type-level redaction on case class and sealed trait
- [x] FastShowPretty: type-level redaction propagates to nested fields
- [x] cats Show: field-level and type-level redaction
- [x] cats ShowPretty: field-level and type-level redaction
- [x] All tests pass on Scala 2.13 JVM (112 passed)
- [x] All tests pass on Scala 3 JVM (including 71 FastShowPretty, 144 CatsDerivation)