### PR TITLE
Fix @avroScalePrecision, @avroName on sealed traits, and single-element named tuple decoding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -63,6 +63,9 @@ The most load-bearing entries to keep in mind for any macro work:
 - **`Type.Ctor2.of[Function1].unapply` wrong on Scala 3** — wrap with
   `Type.Ctor2.fromUntyped[Function1](impl.asUntyped)`.
 - **`Type.of[A]` bootstrap cycle in extensions** — see the pitfalls skill.
+- **`IsValueType` intercepts single-element named tuples (Scala 3)** — guard every
+  `HandleAsValueTypeRule` with `if (Type[A].isNamedTuple)` before the `IsValueType`
+  match. See pitfalls skill and `type-class-derivation-skill.md` § REQ-5.
 
 ## Standard extensions, `LambdaBuilder`, and def-caching rules
 

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCaseClassRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCaseClassRule.scala
@@ -7,7 +7,7 @@ import hearth.fp.effect.*
 import hearth.fp.syntax.*
 import hearth.std.*
 
-import hearth.kindlings.avroderivation.annotations.{avroFixed, fieldName, transientField}
+import hearth.kindlings.avroderivation.annotations.{avroFixed, avroScalePrecision, fieldName, transientField}
 import hearth.kindlings.avroderivation.internal.runtime.AvroDerivationUtils
 import org.apache.avro.generic.GenericRecord
 
@@ -36,6 +36,7 @@ trait AvroDecoderHandleAsCaseClassRuleImpl {
       implicit val fieldNameT: Type[fieldName] = DecTypes.FieldName
       implicit val transientFieldT: Type[transientField] = DecTypes.TransientField
       implicit val avroFixedT: Type[avroFixed] = DecTypes.AvroFixed
+      implicit val avroScalePrecisionT: Type[avroScalePrecision] = SfTypes.AvroScalePrecision
 
       val constructor = caseClass.primaryConstructor
       val fieldsList = constructor.parameters.flatten.toList
@@ -107,9 +108,10 @@ trait AvroDecoderHandleAsCaseClassRuleImpl {
             .parTraverse { case ((fName, param), fieldIndex) =>
               import param.tpe.Underlying as Field
               val avroFixedSize = getAnnotationIntArg[avroFixed](param)
+              val decimalOverride = getAnnotationTwoIntArgs[avroScalePrecision](param)
               Log.namedScope(s"Deriving decoder for field $fName: ${Type[Field].prettyPrint}") {
-                avroFixedSize match {
-                  case Some(_) =>
+                (avroFixedSize, decimalOverride) match {
+                  case (Some(_), _) =>
                     val arrayByteType: Type[Array[Byte]] = DecTypes.ArrayByte
                     MIO.pure {
                       implicit val ArrayByteT: Type[Array[Byte]] = arrayByteType
@@ -119,7 +121,20 @@ trait AvroDecoderHandleAsCaseClassRuleImpl {
                       }.as_??
                       (fName, decodedExpr)
                     }
-                  case None =>
+                  case (_, Some((_, scale))) =>
+                    val bigDecimalType: Type[BigDecimal] = Type.of[BigDecimal]
+                    MIO.pure {
+                      implicit val BigDecimalT: Type[BigDecimal] = bigDecimalType
+                      val decodedExpr: Expr_?? = Expr.quote {
+                        val record = Expr.splice(dctx.avroValue).asInstanceOf[GenericRecord]
+                        AvroDerivationUtils.decodeBigDecimal(
+                          record.get(Expr.splice(Expr(fieldIndex))),
+                          Expr.splice(Expr(scale))
+                        ): BigDecimal
+                      }.as_??
+                      (fName, decodedExpr)
+                    }
+                  case _ =>
                     val fieldAvroValue: Expr[Any] = Expr.quote {
                       Expr.splice(dctx.avroValue).asInstanceOf[GenericRecord].get(Expr.splice(Expr(fieldIndex)))
                     }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsEnumRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsEnumRule.scala
@@ -7,6 +7,7 @@ import hearth.fp.effect.*
 import hearth.fp.syntax.*
 import hearth.std.*
 
+import hearth.kindlings.avroderivation.annotations.avroName
 import hearth.kindlings.avroderivation.internal.runtime.AvroDerivationUtils
 import org.apache.avro.generic.GenericRecord
 
@@ -102,57 +103,95 @@ trait AvroDecoderHandleAsEnumRuleImpl {
             // Mixed sealed trait → dispatch based on record schema name
             // For union types, Hearth returns FQN child names (e.g., "pkg.Parrot"), but Avro schema
             // getName returns simple names (e.g., "Parrot"). Extract simple names for comparison.
+            implicit val avroNameT: Type[avroName] = SfTypes.AvroName
+
             def simpleName(fqn: String): String = fqn.lastIndexOf('.') match {
               case -1 => fqn
               case i  => fqn.substring(i + 1)
             }
-            val knownNames: List[String] = children.toList.map(c => simpleName(c._1))
+
+            // Resolve the effective Avro name for each child: @avroName overrides the Scala class name
+            val childNamesResolved: List[(String, Option[String])] = children.toList.map { case (childName, child) =>
+              import child.Underlying as ChildType
+              val avroNameOverride = getTypeAnnotationStringArg[avroName, ChildType]
+              (simpleName(childName), avroNameOverride)
+            }
+            val knownNames: List[String] = childNamesResolved.map {
+              case (_, Some(overrideName)) => overrideName
+              case (simpleName, None)      => simpleName
+            }
 
             children
               .parTraverse { case (childName, child) =>
                 import child.Underlying as ChildType
                 val simpleChildName = simpleName(childName)
+                val avroNameOverride = getTypeAnnotationStringArg[avroName, ChildType]
                 Log.namedScope(s"Deriving decoder for enum case $childName: ${Type[ChildType].prettyPrint}") {
                   deriveDecoderRecursively[ChildType](using dctx.nest[ChildType](dctx.avroValue)).flatMap {
                     decodedExpr =>
                       dctx.getHelper[ChildType].map {
                         case Some(helper) =>
+                          val matchName = avroNameOverride.getOrElse(simpleChildName)
                           (
-                            simpleChildName,
+                            matchName,
                             (valueExpr: Expr[Any], elseExpr: Expr[A]) =>
-                              Expr.quote {
-                                val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
-                                val recordName = record.getSchema.getName
-                                if (
-                                  Expr
-                                    .splice(dctx.config)
-                                    .transformConstructorNames(
-                                      Expr.splice(Expr(simpleChildName))
-                                    ) == recordName
-                                )
-                                  Expr.splice(helper(valueExpr, dctx.config)).asInstanceOf[A]
-                                else
-                                  Expr.splice(elseExpr)
+                              avroNameOverride match {
+                                case Some(explicitName) =>
+                                  Expr.quote {
+                                    val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
+                                    val recordName = record.getSchema.getName
+                                    if (Expr.splice(Expr(explicitName)) == recordName)
+                                      Expr.splice(helper(valueExpr, dctx.config)).asInstanceOf[A]
+                                    else
+                                      Expr.splice(elseExpr)
+                                  }
+                                case None =>
+                                  Expr.quote {
+                                    val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
+                                    val recordName = record.getSchema.getName
+                                    if (
+                                      Expr
+                                        .splice(dctx.config)
+                                        .transformConstructorNames(
+                                          Expr.splice(Expr(simpleChildName))
+                                        ) == recordName
+                                    )
+                                      Expr.splice(helper(valueExpr, dctx.config)).asInstanceOf[A]
+                                    else
+                                      Expr.splice(elseExpr)
+                                  }
                               }
                           )
                         case None =>
-                          // No helper registered (e.g., built-in types) — use the derived expression directly
+                          val matchName = avroNameOverride.getOrElse(simpleChildName)
                           (
-                            simpleChildName,
+                            matchName,
                             (valueExpr: Expr[Any], elseExpr: Expr[A]) =>
-                              Expr.quote {
-                                val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
-                                val recordName = record.getSchema.getName
-                                if (
-                                  Expr
-                                    .splice(dctx.config)
-                                    .transformConstructorNames(
-                                      Expr.splice(Expr(simpleChildName))
-                                    ) == recordName
-                                )
-                                  Expr.splice(decodedExpr).asInstanceOf[A]
-                                else
-                                  Expr.splice(elseExpr)
+                              avroNameOverride match {
+                                case Some(explicitName) =>
+                                  Expr.quote {
+                                    val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
+                                    val recordName = record.getSchema.getName
+                                    if (Expr.splice(Expr(explicitName)) == recordName)
+                                      Expr.splice(decodedExpr).asInstanceOf[A]
+                                    else
+                                      Expr.splice(elseExpr)
+                                  }
+                                case None =>
+                                  Expr.quote {
+                                    val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
+                                    val recordName = record.getSchema.getName
+                                    if (
+                                      Expr
+                                        .splice(dctx.config)
+                                        .transformConstructorNames(
+                                          Expr.splice(Expr(simpleChildName))
+                                        ) == recordName
+                                    )
+                                      Expr.splice(decodedExpr).asInstanceOf[A]
+                                    else
+                                      Expr.splice(elseExpr)
+                                  }
                               }
                           )
                       }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsValueTypeRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsValueTypeRule.scala
@@ -13,55 +13,58 @@ trait AvroDecoderHandleAsValueTypeRuleImpl {
     @scala.annotation.nowarn("msg=is never used")
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            for {
-              innerResult <- deriveDecoderRecursively[Inner](using dctx.nest[Inner](dctx.avroValue))
-            } yield isValueType.value.wrap match {
-              case _: CtorLikeOf.PlainValue[?, ?] =>
-                Rule.matched(isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[A]])
-              case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                val eitherResult = isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[String, A]]]
-                Rule.matched(Expr.quote {
-                  Expr.splice(eitherResult) match {
-                    case scala.Right(v)  => v
-                    case scala.Left(msg) => throw new org.apache.avro.AvroRuntimeException(msg)
-                  }
-                })
-              case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                val eitherResult =
-                  isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[Iterable[String], A]]]
-                Rule.matched(Expr.quote {
-                  Expr.splice(eitherResult) match {
-                    case scala.Right(v)   => v
-                    case scala.Left(errs) => throw new org.apache.avro.AvroRuntimeException(errs.mkString("\n"))
-                  }
-                })
-              case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                val eitherResult =
-                  isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[Throwable, A]]]
-                Rule.matched(Expr.quote {
-                  Expr.splice(eitherResult) match {
-                    case scala.Right(v)  => v
-                    case scala.Left(err) => throw new org.apache.avro.AvroRuntimeException(err.getMessage, err)
-                  }
-                })
-              case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                val eitherResult =
-                  isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                Rule.matched(Expr.quote {
-                  Expr.splice(eitherResult) match {
-                    case scala.Right(v)   => v
-                    case scala.Left(errs) =>
-                      throw new org.apache.avro.AvroRuntimeException(errs.map(_.getMessage).mkString("\n"))
-                  }
-                })
-            }
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              for {
+                innerResult <- deriveDecoderRecursively[Inner](using dctx.nest[Inner](dctx.avroValue))
+              } yield isValueType.value.wrap match {
+                case _: CtorLikeOf.PlainValue[?, ?] =>
+                  Rule.matched(isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[A]])
+                case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                  val eitherResult = isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[String, A]]]
+                  Rule.matched(Expr.quote {
+                    Expr.splice(eitherResult) match {
+                      case scala.Right(v)  => v
+                      case scala.Left(msg) => throw new org.apache.avro.AvroRuntimeException(msg)
+                    }
+                  })
+                case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+                  val eitherResult =
+                    isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[Iterable[String], A]]]
+                  Rule.matched(Expr.quote {
+                    Expr.splice(eitherResult) match {
+                      case scala.Right(v)   => v
+                      case scala.Left(errs) => throw new org.apache.avro.AvroRuntimeException(errs.mkString("\n"))
+                    }
+                  })
+                case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+                  val eitherResult =
+                    isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[Throwable, A]]]
+                  Rule.matched(Expr.quote {
+                    Expr.splice(eitherResult) match {
+                      case scala.Right(v)  => v
+                      case scala.Left(err) => throw new org.apache.avro.AvroRuntimeException(err.getMessage, err)
+                    }
+                  })
+                case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+                  val eitherResult =
+                    isValueType.value.wrap.apply(innerResult).asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+                  Rule.matched(Expr.quote {
+                    Expr.splice(eitherResult) match {
+                      case scala.Right(v)   => v
+                      case scala.Left(errs) =>
+                        throw new org.apache.avro.AvroRuntimeException(errs.map(_.getMessage).mkString("\n"))
+                    }
+                  })
+              }
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsCaseClassRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsCaseClassRule.scala
@@ -7,7 +7,7 @@ import hearth.fp.effect.*
 import hearth.fp.syntax.*
 import hearth.std.*
 
-import hearth.kindlings.avroderivation.annotations.{avroFixed, fieldName, transientField}
+import hearth.kindlings.avroderivation.annotations.{avroFixed, avroScalePrecision, fieldName, transientField}
 import hearth.kindlings.avroderivation.internal.runtime.AvroDerivationUtils
 import org.apache.avro.Schema
 import org.apache.avro.generic.GenericData
@@ -67,6 +67,7 @@ trait AvroEncoderHandleAsCaseClassRuleImpl {
       implicit val fieldNameT: Type[fieldName] = EncTypes.FieldName
       implicit val transientFieldT: Type[transientField] = EncTypes.TransientField
       implicit val avroFixedT: Type[avroFixed] = EncTypes.AvroFixed
+      implicit val avroScalePrecisionT: Type[avroScalePrecision] = SfTypes.AvroScalePrecision
 
       val allFields = caseClass.caseFieldValuesAt(ectx.value).toList
 
@@ -95,16 +96,24 @@ trait AvroEncoderHandleAsCaseClassRuleImpl {
                   import fieldValue.{Underlying as Field, value as fieldExpr}
                   val param = paramsByName.get(fName)
                   val avroFixedSize = param.flatMap(p => getAnnotationIntArg[avroFixed](p))
+                  val decimalOverride = param.flatMap(p => getAnnotationTwoIntArgs[avroScalePrecision](p))
                   Log.namedScope(s"Encoding field ${ectx.value.prettyPrint}.$fName: ${Type[Field].prettyPrint}") {
-                    val encodeMIO: MIO[Expr[Any]] = avroFixedSize match {
-                      case Some(size) =>
+                    val encodeMIO: MIO[Expr[Any]] = (avroFixedSize, decimalOverride) match {
+                      case (Some(size), _) =>
                         MIO.pure(Expr.quote {
                           AvroDerivationUtils.wrapByteArrayAsFixed(
                             Expr.splice(fieldExpr).asInstanceOf[Array[Byte]],
                             Expr.splice(Expr(size))
                           ): Any
                         })
-                      case None =>
+                      case (_, Some((_, scale))) =>
+                        MIO.pure(Expr.quote {
+                          AvroDerivationUtils.encodeBigDecimal(
+                            Expr.splice(fieldExpr).asInstanceOf[BigDecimal],
+                            Expr.splice(Expr(scale))
+                          ): Any
+                        })
+                      case _ =>
                         inlineBuiltInAvroEncode[Field](fieldExpr) match {
                           case Some(enc) => MIO.pure(enc)
                           case None      => deriveEncoderRecursively[Field](using ectx.nest(fieldExpr))

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsValueTypeRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsValueTypeRule.scala
@@ -12,17 +12,20 @@ trait AvroEncoderHandleAsValueTypeRuleImpl {
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Any]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            val unwrappedExpr = isValueType.value.unwrap(ectx.value)
-            for {
-              innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
-            } yield Rule.matched(innerResult)
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              val unwrappedExpr = isValueType.value.unwrap(ectx.value)
+              for {
+                innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
+              } yield Rule.matched(innerResult)
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsValueTypeRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsValueTypeRule.scala
@@ -14,16 +14,19 @@ trait AvroSchemaForHandleAsValueTypeRuleImpl {
 
     def apply[A: SchemaForCtx]: MIO[Rule.Applicability[Expr[Schema]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            for {
-              innerResult <- deriveSchemaRecursively[Inner](using sfctx.nest[Inner])
-            } yield Rule.matched(innerResult)
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              for {
+                innerResult <- deriveSchemaRecursively[Inner](using sfctx.nest[Inner])
+              } yield Rule.matched(innerResult)
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 }

--- a/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/AvroScala3Spec.scala
+++ b/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/AvroScala3Spec.scala
@@ -187,6 +187,15 @@ final class AvroScala3Spec extends MacroSuite {
       val decoded = AvroIO.fromBinary[(name: String, age: Int)](bytes)
       decoded ==> original
     }
+
+    test("single-element named tuple round-trip") {
+      implicit val encoder: AvroEncoder[(field: Int)] = AvroEncoder.derive[(field: Int)]
+      implicit val decoder: AvroDecoder[(field: Int)] = AvroDecoder.derive[(field: Int)]
+      val original: (field: Int) = Tuple1(3)
+      val bytes = AvroIO.toBinary(original)
+      val decoded = AvroIO.fromBinary[(field: Int)](bytes)
+      decoded ==> original
+    }
   }
 
   group("opaque types") {

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroRoundTripSpec.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroRoundTripSpec.scala
@@ -443,6 +443,29 @@ final class AvroRoundTripSpec extends MacroSuite {
           decoded ==> original
         }
       }
+
+      test("@avroScalePrecision on BigDecimal field (issue #110)") {
+        val encoder: AvroEncoder[WithPerFieldDecimal] = AvroEncoder.derive[WithPerFieldDecimal]
+        val decoder: AvroDecoder[WithPerFieldDecimal] = AvroDecoder.derive[WithPerFieldDecimal]
+        val original = WithPerFieldDecimal(price = BigDecimal("123.4567"), label = "test")
+        val bytes = AvroIO.toBinary(original)(encoder)
+        val decoded = AvroIO.fromBinary[WithPerFieldDecimal](bytes)(decoder)
+        decoded ==> original
+      }
+
+      test("@avroName on sealed trait subtypes (issue #108)") {
+        val encoder: AvroEncoder[OuterWithRenamedInner] = AvroEncoder.derive[OuterWithRenamedInner]
+        val decoder: AvroDecoder[OuterWithRenamedInner] = AvroDecoder.derive[OuterWithRenamedInner]
+        val values = List(
+          OuterWithRenamedInner(RenamedFoo("hello")),
+          OuterWithRenamedInner(RenamedBar("world"))
+        )
+        values.foreach { original =>
+          val bytes = AvroIO.toBinary(original)(encoder)
+          val decoded = AvroIO.fromBinary[OuterWithRenamedInner](bytes)(decoder)
+          decoded ==> original
+        }
+      }
     }
   }
 }

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
@@ -290,5 +290,13 @@ case class WithPerFieldDecimal(
     label: String
 )
 
+// @avroName on sealed trait subtypes (issue #108)
+case class OuterWithRenamedInner(inner: RenamedInner)
+sealed trait RenamedInner
+@annotations.avroName("FooRenamed")
+case class RenamedFoo(a: String) extends RenamedInner
+@annotations.avroName("BarRenamed")
+case class RenamedBar(b: String) extends RenamedInner
+
 // Unhandled type for compile-time error tests
 class NotAnAvroType

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsValueTypeRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsValueTypeRule.scala
@@ -15,30 +15,33 @@ trait DecoderHandleAsValueTypeRuleImpl {
 
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[Either[DecodingFailure, A]]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
 
-            DTypes
-              .Decoder[Inner]
-              .summonExprIgnoring(DecoderUseImplicitWhenAvailableRule.ignoredImplicits*)
-              .toEither match {
-              case Right(innerDecoder) =>
-                @scala.annotation.nowarn("msg=is never used")
-                implicit val EitherDFA: Type[Either[DecodingFailure, A]] = DTypes.DecoderResult[A]
-                buildWrapLambda[A, Inner](isValueType.value).map { builder =>
-                  val wrapLambda = builder.build[Either[DecodingFailure, A]]
-                  Rule.matched(Expr.quote {
-                    Expr.splice(innerDecoder).apply(Expr.splice(dctx.cursor)).flatMap(Expr.splice(wrapLambda))
-                  })
-                }
-              case Left(reason) =>
-                MIO.pure(Rule.yielded(s"Value type inner ${Type[Inner].prettyPrint} has no Decoder: $reason"))
-            }
+              DTypes
+                .Decoder[Inner]
+                .summonExprIgnoring(DecoderUseImplicitWhenAvailableRule.ignoredImplicits*)
+                .toEither match {
+                case Right(innerDecoder) =>
+                  @scala.annotation.nowarn("msg=is never used")
+                  implicit val EitherDFA: Type[Either[DecodingFailure, A]] = DTypes.DecoderResult[A]
+                  buildWrapLambda[A, Inner](isValueType.value).map { builder =>
+                    val wrapLambda = builder.build[Either[DecodingFailure, A]]
+                    Rule.matched(Expr.quote {
+                      Expr.splice(innerDecoder).apply(Expr.splice(dctx.cursor)).flatMap(Expr.splice(wrapLambda))
+                    })
+                  }
+                case Left(reason) =>
+                  MIO.pure(Rule.yielded(s"Value type inner ${Type[Inner].prettyPrint} has no Decoder: $reason"))
+              }
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
 
     @scala.annotation.nowarn("msg=is never used")

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/EncoderHandleAsValueTypeRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/EncoderHandleAsValueTypeRule.scala
@@ -14,17 +14,20 @@ trait EncoderHandleAsValueTypeRuleImpl {
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Json]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            val unwrappedExpr = isValueType.value.unwrap(ectx.value)
-            for {
-              innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
-            } yield Rule.matched(innerResult)
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              val unwrappedExpr = isValueType.value.unwrap(ectx.value)
+              for {
+                innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
+              } yield Rule.matched(innerResult)
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 }

--- a/circe-derivation/src/test/scala-3/hearth/kindlings/circederivation/CirceScala3Spec.scala
+++ b/circe-derivation/src/test/scala-3/hearth/kindlings/circederivation/CirceScala3Spec.scala
@@ -128,6 +128,12 @@ final class CirceScala3Spec extends MacroSuite {
         KindlingsEncoder.encode(nt) ==>
           Json.obj("first_name" -> Json.fromString("Alice"), "last_name" -> Json.fromString("Smith"))
       }
+
+      test("single-element named tuple") {
+        val nt: (field: Int) = Tuple1(3)
+        KindlingsEncoder.encode(nt) ==>
+          Json.obj("field" -> Json.fromInt(3))
+      }
     }
 
     group("decoding") {
@@ -149,6 +155,11 @@ final class CirceScala3Spec extends MacroSuite {
         implicit val config: Configuration = Configuration.default.withSnakeCaseMemberNames
         val json = Json.obj("first_name" -> Json.fromString("Alice"), "last_name" -> Json.fromString("Smith"))
         KindlingsDecoder.decode[(firstName: String, lastName: String)](json) ==> Right(("Alice", "Smith"))
+      }
+
+      test("single-element named tuple") {
+        val json = Json.obj("field" -> Json.fromInt(3))
+        KindlingsDecoder.decode[(field: Int)](json) ==> Right(Tuple1(3))
       }
     }
   }

--- a/docs/contributing/cross-compilation-pitfalls-skill.md
+++ b/docs/contributing/cross-compilation-pitfalls-skill.md
@@ -157,6 +157,18 @@ Scala 2 macros cannot handle free type variables in generated trees. Work with `
 and `(Any => Any)`, cast with `.asInstanceOf` at the boundaries — safe due to JVM type
 erasure. See `FunctorMacrosImpl.scala`.
 
+### `IsValueType` intercepts single-element named tuples (Scala 3)
+
+Named tuples are opaque types in Scala 3. `IsValueTypeProviderForOpaque` matches any
+opaque type that has a suitable constructor, and for single-element named tuples like
+`(field: Int)` the underlying `Tuple1[Int]` has a single-arg ctor that qualifies. Since
+`HandleAsValueTypeRule` runs before `HandleAsNamedTupleRule` in the rule pipeline, it
+intercepts and treats the named tuple as a value type wrapping `Int`.
+
+**Fix:** Guard every `HandleAsValueTypeRule` with `Type[A].isNamedTuple` before the
+`IsValueType` pattern match. The method returns `false` on Scala 2, so it is safe to use
+in cross-compiled code. See `type-class-derivation-skill.md` § REQ-5.
+
 ### `MacroExtension` ClassTag erasure
 
 `MacroExtension[A & B & C]` ClassTag only preserves the first component. Use a runtime

--- a/docs/contributing/type-class-derivation-skill.md
+++ b/docs/contributing/type-class-derivation-skill.md
@@ -1725,8 +1725,22 @@ If the type class should support value types (classes extending `AnyVal`), handl
 
 **How to implement:**
 1. Create a `HandleAsValueTypeRule` that pattern-matches `Type[A]` against `IsValueType`
-2. Unwrap the value type via `isValueType.unwrap(ctx.value)` to get the underlying value
-3. Recurse on the underlying type
+2. **Guard against named tuples first:** Before the `IsValueType` match, check `Type[A].isNamedTuple` and yield if true. Named tuples are opaque types in Scala 3, so `IsValueTypeProviderForOpaque` matches single-element named tuples (e.g., `(field: Int)`) and treats them as value types wrapping the inner type. This causes the value type rule to intercept before the named tuple rule, producing incorrect derivation. The guard is cross-platform safe (`isNamedTuple` returns `false` on Scala 2).
+3. Unwrap the value type via `isValueType.unwrap(ctx.value)` to get the underlying value
+4. Recurse on the underlying type
+
+**Pattern:**
+```scala
+def apply[A: Ctx]: MIO[Rule.Applicability[Expr[Result]]] =
+  Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
+    if (Type[A].isNamedTuple)
+      MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+    else Type[A] match {
+      case IsValueType(isValueType) => // ...
+      case _ => MIO.pure(Rule.yielded(...))
+    }
+  }
+```
 
 **Reference:** `FastShowPrettyHandleAsValueTypeRule.scala`.
 
@@ -1734,6 +1748,7 @@ If the type class should support value types (classes extending `AnyVal`), handl
 - Define a value class (e.g., `case class UserId(value: Int) extends AnyVal`)
 - Write a test that derives and uses the type class for it
 - Verify it works on both Scala 2.13 and Scala 3
+- **Test single-element named tuples** (e.g., `(field: Int)`) to ensure they are NOT handled as value types — see REQ-11c
 
 ### REQ-6: Handle optional types via std extensions
 
@@ -1890,6 +1905,8 @@ When the type class is a subtype of an existing type class that has its own auto
 
 Types that only exist in Scala 3 (e.g., Scala 3 `enum` declarations, named tuples) must be tested in `src/test/scala-3/` so they don't break Scala 2.13 compilation.
 
+**Named tuple testing must include single-element tuples.** Single-element named tuples like `(field: Int)` are a critical edge case: they are opaque types in Scala 3 whose underlying type (`Tuple1[Int]`) has a single-argument constructor, causing `IsValueTypeProviderForOpaque` to match them. If the value type rule lacks the `isNamedTuple` guard (see REQ-5), it intercepts before the named tuple rule and produces incorrect derivation. Always include a `(field: Int)` test alongside multi-element named tuple tests.
+
 **Example:**
 ```scala
 // In src/test/scala-3/hearth/kindlings/mymodule/MyTypeClassScala3Spec.scala
@@ -1906,6 +1923,11 @@ final class MyTypeClassScala3Spec extends MacroSuite {
   group("named tuples") {
     test("handles named tuple") {
       val tuple: (name: String, age: Int) = (name = "Alice", age = 30)
+      val result = MyTypeClass.someMethod(tuple)
+      assertEquals(result, /* expected */)
+    }
+    test("handles single-element named tuple") {
+      val tuple: (field: Int) = Tuple1(42)
       val result = MyTypeClass.someMethod(tuple)
       assertEquals(result, /* expected */)
     }

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/rules/FastShowPrettyHandleAsValueTypeRule.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/rules/FastShowPrettyHandleAsValueTypeRule.scala
@@ -12,14 +12,17 @@ trait FastShowPrettyHandleAsValueTypeRuleImpl { this: FastShowPrettyMacrosImpl &
 
     def apply[A: DerivationCtx]: MIO[Rule.Applicability[Expr[StringBuilder]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            deriveValueTypeUnwrapped[A, Inner](isValueType.value)
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              deriveValueTypeUnwrapped[A, Inner](isValueType.value)
 
-          case _ =>
-            yieldUnsupportedType[A]
-        }
+            case _ =>
+              yieldUnsupportedType[A]
+          }
       }
 
     private def deriveValueTypeUnwrapped[A: DerivationCtx, Inner: Type](

--- a/fast-show-pretty/src/test/scala-3/hearth/kindlings/fastshowpretty/FastShowPrettyScala3Spec.scala
+++ b/fast-show-pretty/src/test/scala-3/hearth/kindlings/fastshowpretty/FastShowPrettyScala3Spec.scala
@@ -28,6 +28,15 @@ final class FastShowPrettyScala3Spec extends MacroSuite {
             |)""".stripMargin
       }
 
+      test("single-element named tuple") {
+        val nt: (field: Int) = Tuple1(3)
+        val result = FastShowPretty.render(nt, RenderConfig.Default)
+        result ==>
+          """(
+            |  field = 3
+            |)""".stripMargin
+      }
+
       test("nested named tuple with case class") {
         val nt: (person: Person, score: Int) = (Person("Bob", 25), 100)
         val result = FastShowPretty.render(nt, RenderConfig.Default)

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsValueTypeRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsValueTypeRule.scala
@@ -14,79 +14,82 @@ trait DecoderHandleAsValueTypeRuleImpl {
     @scala.annotation.nowarn("msg=is never used")
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
 
-            LambdaBuilder
-              .of1[Inner]("inner")
-              .traverse { innerExpr =>
-                isValueType.value.wrap match {
-                  case _: CtorLikeOf.PlainValue[?, ?] =>
-                    MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
-                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                    val wrapResult = isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[String, A]]]
-                    MIO.pure(Expr.quote {
-                      Expr.splice(wrapResult) match {
-                        case scala.Right(v)  => v
-                        case scala.Left(msg) => Expr.splice(dctx.reader).decodeError(msg)
-                      }
-                    })
-                  case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                    val wrapResult =
-                      isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[Iterable[String], A]]]
-                    MIO.pure(Expr.quote {
-                      Expr.splice(wrapResult) match {
-                        case scala.Right(v)   => v
-                        case scala.Left(errs) => Expr.splice(dctx.reader).decodeError(errs.mkString("\n"))
-                      }
-                    })
-                  case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                    val wrapResult =
-                      isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[Throwable, A]]]
-                    MIO.pure(Expr.quote {
-                      Expr.splice(wrapResult) match {
-                        case scala.Right(v)  => v
-                        case scala.Left(err) => Expr.splice(dctx.reader).decodeError(err.getMessage)
-                      }
-                    })
-                  case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                    val wrapResult =
-                      isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                    MIO.pure(Expr.quote {
-                      Expr.splice(wrapResult) match {
-                        case scala.Right(v)   => v
-                        case scala.Left(errs) =>
-                          Expr.splice(dctx.reader).decodeError(errs.map(_.getMessage).mkString("\n"))
-                      }
-                    })
-                }
-              }
-              .flatMap { builder =>
-                val wrapLambda = builder.build[A]
-                summonJsonValueCodecCached[Inner] match {
-                  case Right(innerCodec) =>
-                    MIO.pure(Rule.matched(Expr.quote {
-                      Expr
-                        .splice(wrapLambda)
-                        .apply(
-                          Expr
-                            .splice(innerCodec)
-                            .decodeValue(Expr.splice(dctx.reader), Expr.splice(innerCodec).nullValue)
-                        )
-                    }))
-                  case Left(_) =>
-                    deriveDecoderRecursively[Inner](using dctx.nest[Inner](dctx.reader)).map { innerDecoded =>
-                      Rule.matched(Expr.quote {
-                        Expr.splice(wrapLambda).apply(Expr.splice(innerDecoded))
+              LambdaBuilder
+                .of1[Inner]("inner")
+                .traverse { innerExpr =>
+                  isValueType.value.wrap match {
+                    case _: CtorLikeOf.PlainValue[?, ?] =>
+                      MIO.pure(isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[A]])
+                    case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                      val wrapResult = isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[String, A]]]
+                      MIO.pure(Expr.quote {
+                        Expr.splice(wrapResult) match {
+                          case scala.Right(v)  => v
+                          case scala.Left(msg) => Expr.splice(dctx.reader).decodeError(msg)
+                        }
                       })
-                    }
+                    case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+                      val wrapResult =
+                        isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[Iterable[String], A]]]
+                      MIO.pure(Expr.quote {
+                        Expr.splice(wrapResult) match {
+                          case scala.Right(v)   => v
+                          case scala.Left(errs) => Expr.splice(dctx.reader).decodeError(errs.mkString("\n"))
+                        }
+                      })
+                    case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+                      val wrapResult =
+                        isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[Throwable, A]]]
+                      MIO.pure(Expr.quote {
+                        Expr.splice(wrapResult) match {
+                          case scala.Right(v)  => v
+                          case scala.Left(err) => Expr.splice(dctx.reader).decodeError(err.getMessage)
+                        }
+                      })
+                    case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+                      val wrapResult =
+                        isValueType.value.wrap.apply(innerExpr).asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+                      MIO.pure(Expr.quote {
+                        Expr.splice(wrapResult) match {
+                          case scala.Right(v)   => v
+                          case scala.Left(errs) =>
+                            Expr.splice(dctx.reader).decodeError(errs.map(_.getMessage).mkString("\n"))
+                        }
+                      })
+                  }
                 }
-              }
+                .flatMap { builder =>
+                  val wrapLambda = builder.build[A]
+                  summonJsonValueCodecCached[Inner] match {
+                    case Right(innerCodec) =>
+                      MIO.pure(Rule.matched(Expr.quote {
+                        Expr
+                          .splice(wrapLambda)
+                          .apply(
+                            Expr
+                              .splice(innerCodec)
+                              .decodeValue(Expr.splice(dctx.reader), Expr.splice(innerCodec).nullValue)
+                          )
+                      }))
+                    case Left(_) =>
+                      deriveDecoderRecursively[Inner](using dctx.nest[Inner](dctx.reader)).map { innerDecoded =>
+                        Rule.matched(Expr.quote {
+                          Expr.splice(wrapLambda).apply(Expr.splice(innerDecoded))
+                        })
+                      }
+                  }
+                }
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsValueTypeRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsValueTypeRule.scala
@@ -12,17 +12,20 @@ trait EncoderHandleAsValueTypeRuleImpl {
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            val unwrappedExpr = isValueType.value.unwrap(ectx.value)
-            for {
-              innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
-            } yield Rule.matched(innerResult)
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              val unwrappedExpr = isValueType.value.unwrap(ectx.value)
+              for {
+                innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
+              } yield Rule.matched(innerResult)
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 

--- a/jsoniter-derivation/src/test/scala-3/hearth/kindlings/jsoniterderivation/JsoniterScala3Spec.scala
+++ b/jsoniter-derivation/src/test/scala-3/hearth/kindlings/jsoniterderivation/JsoniterScala3Spec.scala
@@ -5,6 +5,24 @@ import hearth.MacroSuite
 
 final class JsoniterScala3Spec extends MacroSuite {
 
+  group("named tuples (Scala 3.7+)") {
+
+    test("single-element named tuple round-trip") {
+      val codec = KindlingsJsonValueCodec.derive[(field: Int)]
+      val json = writeToString[((field: Int))](Tuple1(3))(codec)
+      val decoded = readFromString[((field: Int))](json)(codec)
+      decoded ==> Tuple1(3)
+    }
+
+    test("multi-element named tuple round-trip") {
+      val codec = KindlingsJsonValueCodec.derive[(name: String, age: Int)]
+      val nt: (name: String, age: Int) = ("Alice", 42)
+      val json = writeToString(nt)(codec)
+      val decoded = readFromString[((name: String, age: Int))](json)(codec)
+      decoded ==> ("Alice", 42)
+    }
+  }
+
   group("Scala 3 opaque types") {
 
     test("opaque type in case class round-trip") {

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsValueTypeRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsValueTypeRule.scala
@@ -20,21 +20,24 @@ trait ReaderHandleAsValueTypeRuleImpl {
         implicit val EitherT: Type[Either[ConfigReaderFailures, A]] = RTypes.ReaderResult[A]
         implicit val ConfigCursorT: Type[ConfigCursor] = RTypes.ConfigCursor
         val cursorExpr = rctx.cursor
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            implicit val EitherInnerT: Type[Either[ConfigReaderFailures, Inner]] = RTypes.ReaderResult[Inner]
-            val wrapLambda: Expr[Inner => Either[ConfigReaderFailures, A]] =
-              buildWrap[A, Inner](isValueType.value, cursorExpr)
-            deriveReaderRecursively[Inner](using rctx.nest[Inner](rctx.cursor)).map { innerResult =>
-              Rule.matched(Expr.quote {
-                Expr.splice(innerResult).flatMap(Expr.splice(wrapLambda))
-              })
-            }
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              implicit val EitherInnerT: Type[Either[ConfigReaderFailures, Inner]] = RTypes.ReaderResult[Inner]
+              val wrapLambda: Expr[Inner => Either[ConfigReaderFailures, A]] =
+                buildWrap[A, Inner](isValueType.value, cursorExpr)
+              deriveReaderRecursively[Inner](using rctx.nest[Inner](rctx.cursor)).map { innerResult =>
+                Rule.matched(Expr.quote {
+                  Expr.splice(innerResult).flatMap(Expr.splice(wrapLambda))
+                })
+              }
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
 
     private def buildWrap[A: Type, Inner: Type](

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/WriterHandleAsValueTypeRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/WriterHandleAsValueTypeRule.scala
@@ -14,17 +14,20 @@ trait WriterHandleAsValueTypeRuleImpl {
 
     def apply[A: WriterCtx]: MIO[Rule.Applicability[Expr[ConfigValue]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            val unwrappedExpr = isValueType.value.unwrap(wctx.value)
-            for {
-              innerResult <- deriveWriterRecursively[Inner](using wctx.nest(unwrappedExpr))
-            } yield Rule.matched(innerResult)
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              val unwrappedExpr = isValueType.value.unwrap(wctx.value)
+              for {
+                innerResult <- deriveWriterRecursively[Inner](using wctx.nest(unwrappedExpr))
+              } yield Rule.matched(innerResult)
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 }

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsValueTypeRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsValueTypeRule.scala
@@ -18,21 +18,24 @@ trait ReaderHandleAsValueTypeRuleImpl {
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
         implicit val ErrT: Type[ConfigDecodingError] = RTypes.ConfigDecodingError
         implicit val EitherT: Type[Either[ConfigDecodingError, A]] = RTypes.ReaderResult[A]
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            implicit val EitherInnerT: Type[Either[ConfigDecodingError, Inner]] = RTypes.ReaderResult[Inner]
-            val wrapLambda: Expr[Inner => Either[ConfigDecodingError, A]] =
-              buildWrap[A, Inner](isValueType.value)
-            deriveReaderRecursively[Inner](using rctx.nest[Inner](rctx.value)).map { innerResult =>
-              Rule.matched(Expr.quote {
-                Expr.splice(innerResult).flatMap(Expr.splice(wrapLambda))
-              })
-            }
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              implicit val EitherInnerT: Type[Either[ConfigDecodingError, Inner]] = RTypes.ReaderResult[Inner]
+              val wrapLambda: Expr[Inner => Either[ConfigDecodingError, A]] =
+                buildWrap[A, Inner](isValueType.value)
+              deriveReaderRecursively[Inner](using rctx.nest[Inner](rctx.value)).map { innerResult =>
+                Rule.matched(Expr.quote {
+                  Expr.splice(innerResult).flatMap(Expr.splice(wrapLambda))
+                })
+              }
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
 
     private def buildWrap[A: Type, Inner: Type](

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/WriterHandleAsValueTypeRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/WriterHandleAsValueTypeRule.scala
@@ -14,17 +14,20 @@ trait WriterHandleAsValueTypeRuleImpl {
 
     def apply[A: WriterCtx]: MIO[Rule.Applicability[Expr[ConfigValue]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            val unwrappedExpr = isValueType.value.unwrap(wctx.value)
-            for {
-              innerResult <- deriveWriterRecursively[Inner](using wctx.nest(unwrappedExpr))
-            } yield Rule.matched(innerResult)
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              val unwrappedExpr = isValueType.value.unwrap(wctx.value)
+              for {
+                innerResult <- deriveWriterRecursively[Inner](using wctx.nest(unwrappedExpr))
+              } yield Rule.matched(innerResult)
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 }

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsValueTypeRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsValueTypeRule.scala
@@ -15,33 +15,36 @@ trait DecoderHandleAsValueTypeRuleImpl {
 
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[Either[ConstructError, A]]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
 
-            DTypes
-              .YamlDecoder[Inner]
-              .summonExprIgnoring(DecoderUseImplicitWhenAvailableRule.ignoredImplicits*)
-              .toEither match {
-              case Right(innerDecoder) =>
-                @scala.annotation.nowarn("msg=is never used")
-                implicit val EitherCEA: Type[Either[ConstructError, A]] = DTypes.DecoderResult[A]
-                buildWrapLambda[A, Inner](isValueType.value).map { builder =>
-                  val wrapLambda = builder.build[Either[ConstructError, A]]
-                  Rule.matched(Expr.quote {
-                    Expr
-                      .splice(innerDecoder)
-                      .construct(Expr.splice(dctx.node))(org.virtuslab.yaml.LoadSettings.empty)
-                      .flatMap(Expr.splice(wrapLambda))
-                  })
-                }
-              case Left(reason) =>
-                MIO.pure(Rule.yielded(s"Value type inner ${Type[Inner].prettyPrint} has no YamlDecoder: $reason"))
-            }
+              DTypes
+                .YamlDecoder[Inner]
+                .summonExprIgnoring(DecoderUseImplicitWhenAvailableRule.ignoredImplicits*)
+                .toEither match {
+                case Right(innerDecoder) =>
+                  @scala.annotation.nowarn("msg=is never used")
+                  implicit val EitherCEA: Type[Either[ConstructError, A]] = DTypes.DecoderResult[A]
+                  buildWrapLambda[A, Inner](isValueType.value).map { builder =>
+                    val wrapLambda = builder.build[Either[ConstructError, A]]
+                    Rule.matched(Expr.quote {
+                      Expr
+                        .splice(innerDecoder)
+                        .construct(Expr.splice(dctx.node))(org.virtuslab.yaml.LoadSettings.empty)
+                        .flatMap(Expr.splice(wrapLambda))
+                    })
+                  }
+                case Left(reason) =>
+                  MIO.pure(Rule.yielded(s"Value type inner ${Type[Inner].prettyPrint} has no YamlDecoder: $reason"))
+              }
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
 
     @scala.annotation.nowarn("msg=is never used")

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/EncoderHandleAsValueTypeRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/EncoderHandleAsValueTypeRule.scala
@@ -14,17 +14,20 @@ trait EncoderHandleAsValueTypeRuleImpl {
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Node]]] =
       Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a value type") >> {
-        Type[A] match {
-          case IsValueType(isValueType) =>
-            import isValueType.Underlying as Inner
-            val unwrappedExpr = isValueType.value.unwrap(ectx.value)
-            for {
-              innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
-            } yield Rule.matched(innerResult)
+        if (Type[A].isNamedTuple)
+          MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is a named tuple, not a value type"))
+        else
+          Type[A] match {
+            case IsValueType(isValueType) =>
+              import isValueType.Underlying as Inner
+              val unwrappedExpr = isValueType.value.unwrap(ectx.value)
+              for {
+                innerResult <- deriveEncoderRecursively[Inner](using ectx.nest(unwrappedExpr))
+              } yield Rule.matched(innerResult)
 
-          case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
-        }
+            case _ =>
+              MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a value type"))
+          }
       }
   }
 }

--- a/yaml-derivation/src/test/scala-3/hearth/kindlings/yamlderivation/YamlScala3Spec.scala
+++ b/yaml-derivation/src/test/scala-3/hearth/kindlings/yamlderivation/YamlScala3Spec.scala
@@ -180,6 +180,12 @@ final class YamlScala3Spec extends MacroSuite {
         val node = KindlingsYamlEncoder.encode(nt)
         node ==> mappingOf("first_name" -> scalarNode("Alice"), "last_name" -> scalarNode("Smith"))
       }
+
+      test("single-element named tuple") {
+        val nt: (field: Int) = Tuple1(3)
+        val node = KindlingsYamlEncoder.encode(nt)
+        node ==> mappingOf("field" -> scalarNode("3"))
+      }
     }
 
     group("decoding") {
@@ -201,6 +207,11 @@ final class YamlScala3Spec extends MacroSuite {
         implicit val config: YamlConfig = YamlConfig.default.withSnakeCaseMemberNames
         val node = mappingOf("first_name" -> scalarNode("Alice"), "last_name" -> scalarNode("Smith"))
         KindlingsYamlDecoder.decode[(firstName: String, lastName: String)](node) ==> Right(("Alice", "Smith"))
+      }
+
+      test("single-element named tuple") {
+        val node = mappingOf("field" -> scalarNode("3"))
+        KindlingsYamlDecoder.decode[(field: Int)](node) ==> Right(Tuple1(3))
       }
     }
   }


### PR DESCRIPTION
## Summary

- **`@avroScalePrecision` encoder/decoder support (#110)**: The annotation was only read by schema derivation. Encoder and decoder case class rules now read it and call `encodeBigDecimal`/`decodeBigDecimal` directly, instead of falling through to the built-in support rule (which only checks `config.decimalConfig`).

- **`@avroName` on sealed trait subtypes (#108)**: The decoder enum rule compared `record.getSchema.getName` against the original Scala class name, ignoring `@avroName`. Now checks `getTypeAnnotationStringArg[avroName, ChildType]` for each child and uses the annotation value directly when present.

- **Circe single-element named tuple decoding (#115)**: `IsValueTypeProviderForOpaque` matched named tuples (which are opaque types in Scala 3), causing the value type rule to intercept `(field: Int)` before the named tuple rule. Added `Type.isNamedTuple` guard to both encoder and decoder value type rules.

## Test plan

- [x] Added round-trip test for `WithPerFieldDecimal` with `@avroScalePrecision(12, 4)`
- [x] Added round-trip test for `OuterWithRenamedInner` with `@avroName` subtypes
- [x] Added encoding + decoding tests for single-element named tuple `(field: Int)`
- [x] All existing tests pass on Scala 2.13 and 3 (JVM)