### PR TITLE
Update Hearth to 0.3.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.0-49-g68e1781-SNAPSHOT"
+  val hearth = "0.3.0-53-g69f9069-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.0-53-g69f9069-SNAPSHOT"
+  val hearth = "0.3.1"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"


### PR DESCRIPTION
Updates Hearth to the released 0.3.1 (previously validated against snapshot 0.3.0-53-g69f9069-SNAPSHOT of the same code).