### PR TITLE
Eliminate macro-time throws, dedup AnnotationSupport, document Hearth…

### DIFF
--- a/avro-derivation/src/main/scala-2/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/avro-derivation/src/main/scala-2/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,60 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-
-  override protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: Int)))) => Some(value)
-      case _                                             => None
-    }
-
-  override protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collect {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.collect {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(v1: String)), Literal(Constant(v2: String)))) => Some((v1, v2))
-      case _                                                                            => None
-    }
-
-  override protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(v1: Int)), Literal(Constant(v2: Int)))) => Some((v1, v2))
-      case _                                                                      => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/avro-derivation/src/main/scala-3/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/avro-derivation/src/main/scala-3/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,56 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-
-  override protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int] =
-    annotation match {
-      case Apply(_, List(Literal(IntConstant(value)))) => Some(value)
-      case _                                           => None
-    }
-
-  override protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.filter(_.tpe =:= annTpe).toList
-  }
-
-  override protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.filter(_.tpe =:= annTpe).toList
-  }
-
-  override protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(v1)), Literal(StringConstant(v2)))) => Some((v1, v2))
-      case _                                                                        => None
-    }
-
-  override protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)] =
-    annotation match {
-      case Apply(_, List(Literal(IntConstant(v1)), Literal(IntConstant(v2)))) => Some((v1, v2))
-      case _                                                                  => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupport.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,54 +3,7 @@ package hearth.kindlings.avroderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr]
-
-  protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr]
-
-  protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int]
-
-  protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)]
-
-  protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def hasTypeAnnotation[Ann: Type, A: Type]: Boolean =
-    findTypeAnnotationOfType[Ann, A].isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
-
-  final def getAnnotationIntArg[Ann: Type](param: Parameter): Option[Int] =
-    findAnnotationOfType[Ann](param).flatMap(extractIntLiteralFromAnnotation)
-
-  final def getTypeAnnotationStringArg[Ann: Type, A: Type]: Option[String] =
-    findTypeAnnotationOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
-
-  final def getTypeAnnotationIntArg[Ann: Type, A: Type]: Option[Int] =
-    findTypeAnnotationOfType[Ann, A].flatMap(extractIntLiteralFromAnnotation)
-
-  final def getAllAnnotationStringArgs[Ann: Type](param: Parameter): List[String] =
-    findAllAnnotationsOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
-
-  final def getAllTypeAnnotationStringArgs[Ann: Type, A: Type]: List[String] =
-    findAllTypeAnnotationsOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
-
-  final def getAnnotationTwoIntArgs[Ann: Type](param: Parameter): Option[(Int, Int)] =
-    findAnnotationOfType[Ann](param).flatMap(extractTwoIntLiteralsFromAnnotation)
-
-  final def getAllAnnotationTwoStringArgs[Ann: Type](param: Parameter): List[(String, String)] =
-    findAllAnnotationsOfType[Ann](param).flatMap(extractTwoStringLiteralsFromAnnotation)
-
-  final def getAllTypeAnnotationTwoStringArgs[Ann: Type, A: Type]: List[(String, String)] =
-    findAllTypeAnnotationsOfType[Ann, A].flatMap(extractTwoStringLiteralsFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -10,6 +10,7 @@ import org.apache.avro.Schema
 
 trait DecoderMacrosImpl
     extends AvroDerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.AvroDecoderUseCachedDefWhenAvailableRuleImpl
     with rules.AvroDecoderUseImplicitWhenAvailableRuleImpl
     with rules.AvroDecoderHandleAsLiteralTypeRuleImpl

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCaseClassRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCaseClassRule.scala
@@ -59,13 +59,10 @@ trait AvroDecoderHandleAsCaseClassRuleImpl {
       // Build transient defaults map
       val transientDefaults: Map[String, Expr_??] = transientFields.flatMap { case (fName, param) =>
         param.defaultValue.flatMap { method =>
-          method
-            .fold(
-              onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-              onTypes = _ => Map.empty,
-              onValues = _ => Map.empty
-            )
-            .toOption
+          foldInstanceFree(method, "Default value")(
+            onTypes = _ => Map.empty,
+            onValues = _ => Map.empty
+          ).toOption
             .map { defaultExpr =>
               (fName, defaultExpr)
             }
@@ -174,8 +171,7 @@ trait AvroDecoderHandleAsCaseClassRuleImpl {
             .flatMap { fieldData =>
               val fieldMap: Map[String, Expr_??] =
                 fieldData.toList.map { case (fName, decodedExpr) => (fName, decodedExpr) }.toMap ++ transientDefaults
-              caseClass.primaryConstructor.fold(
-                onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+              foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                 onTypes = _ => Map.empty,
                 onValues = _ => fieldMap
               ) match {

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsNamedTupleRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsNamedTupleRule.scala
@@ -48,8 +48,7 @@ trait AvroDecoderHandleAsNamedTupleRuleImpl {
       NonEmptyList.fromList(fieldsList) match {
         case None =>
           // Empty named tuple — validate input is a record and construct
-          constructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+          foldInstanceFree(constructor, "Constructor")(
             onTypes = _ => Map.empty,
             onValues = _ => Map.empty
           ) match {
@@ -109,8 +108,7 @@ trait AvroDecoderHandleAsNamedTupleRuleImpl {
                 .traverse { decodedValuesExpr =>
                   val fieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
-                  constructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(constructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.1-13-ga748b84-SNAPSHOT"
+  val hearth = "0.3.1-32-gc1117d2-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.1-32-gc1117d2-SNAPSHOT"
+  val hearth = "0.3.1-31-g20a332e-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,27 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacros.scala
+++ b/cats-derivation/src/main/scala-2/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacros.scala
@@ -19,45 +19,4 @@ final private[catsderivation] class FunctorMacros(val c: blackbox.Context)
 
     deriveFunctor[F](fCtor, functorFType)
   }
-
-  protected def extractSingleTypeArg(appliedType: Type[Any]): Option[Type[Any]] = {
-    val tpe = appliedType.asInstanceOf[c.WeakTypeTag[Any]].tpe
-    tpe.dealias.typeArgs match {
-      case arg :: Nil => Some(c.WeakTypeTag[Any](arg).asInstanceOf[Type[Any]])
-      case _          => None
-    }
-  }
-
-  protected def isNestedSelfRecursive(fieldType: Type[Any], parentCtor: UntypedType): Boolean = {
-    val tpe = fieldType.asInstanceOf[c.WeakTypeTag[Any]].tpe
-    val dealiased = tpe.dealias
-    dealiased.typeArgs match {
-      case innerArg :: Nil =>
-        val innerCtor = innerArg.typeConstructor
-        // Compare type symbols for reliable equality
-        innerCtor.typeSymbol == parentCtor.asInstanceOf[c.Type].typeSymbol
-      case _ => false
-    }
-  }
-
-  protected def mkCtor1FromType(appliedType: Type[Any]): Option[(Type.Ctor1[AnyK], UntypedType)] = {
-    val tpe = appliedType.asInstanceOf[c.WeakTypeTag[Any]].tpe
-    val ctor = tpe.typeConstructor
-    if (ctor == tpe) None
-    else {
-      val untyped = ctor.asInstanceOf[UntypedType]
-      Some((Type.Ctor1.fromUntyped[List](untyped).asInstanceOf[Type.Ctor1[AnyK]], untyped))
-    }
-  }
-
-  protected def summonFunctorForFieldType(fieldType: Type[Any]): Option[Expr[Any]] = {
-    val tpe = fieldType.asInstanceOf[c.WeakTypeTag[Any]].tpe
-    val ctor = tpe.typeConstructor
-    val functorCtor = c.universe.weakTypeOf[cats.Functor[List]].typeConstructor
-    val functorGType = c.universe.appliedType(functorCtor, List(ctor))
-    c.inferImplicitValue(functorGType) match {
-      case c.universe.EmptyTree => None
-      case tree                 => Some(c.Expr[Any](tree).asInstanceOf[Expr[Any]])
-    }
-  }
 }

--- a/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,27 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacros.scala
+++ b/cats-derivation/src/main/scala-3/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacros.scala
@@ -12,60 +12,6 @@ final private[catsderivation] class FunctorMacros(q: Quotes) extends MacroCommon
   /** Create Type[cats.Functor[G]] from scala.quoted.Type. */
   def mkFunctorType[G[_]](using scala.quoted.Type[G]): Type[cats.Functor[G]] =
     scala.quoted.Type.of[cats.Functor[G]].asInstanceOf[Type[cats.Functor[G]]]
-
-  protected def mkCtor1FromType(appliedType: Type[Any]): Option[(Type.Ctor1[AnyK], UntypedType)] = {
-    import q.reflect.*
-    val repr = TypeRepr.of(using appliedType.asInstanceOf[scala.quoted.Type[Any]])
-    repr.dealias match {
-      case AppliedType(fieldCtor, _ :: Nil) =>
-        val untyped = fieldCtor.asInstanceOf[UntypedType]
-        Some((Type.Ctor1.fromUntyped[List](untyped).asInstanceOf[Type.Ctor1[AnyK]], untyped))
-      case _ => None
-    }
-  }
-
-  protected def extractSingleTypeArg(appliedType: Type[Any]): Option[Type[Any]] = {
-    import q.reflect.*
-    val repr = TypeRepr.of(using appliedType.asInstanceOf[scala.quoted.Type[Any]])
-    repr.dealias match {
-      case AppliedType(_, arg :: Nil) =>
-        Some(arg.asType match { case '[t] => scala.quoted.Type.of[t].asInstanceOf[Type[Any]] })
-      case _ => None
-    }
-  }
-
-  protected def isNestedSelfRecursive(fieldType: Type[Any], parentCtor: UntypedType): Boolean = {
-    import q.reflect.*
-    val repr = TypeRepr.of(using fieldType.asInstanceOf[scala.quoted.Type[Any]])
-    repr.dealias match {
-      case AppliedType(_, innerArg :: Nil) =>
-        innerArg.dealias match {
-          case AppliedType(innerCtor, _) =>
-            // Compare type symbols for reliable cross-context equality
-            innerCtor.typeSymbol == parentCtor.asInstanceOf[TypeRepr].typeSymbol
-          case _ => false
-        }
-      case _ => false
-    }
-  }
-
-  protected def summonFunctorForFieldType(fieldType: Type[Any]): Option[Expr[Any]] = {
-    import q.reflect.*
-    val repr = TypeRepr.of(using fieldType.asInstanceOf[scala.quoted.Type[Any]])
-    repr.dealias match {
-      case AppliedType(fieldCtor, _ :: Nil) =>
-        val functorCtor = TypeRepr.of[cats.Functor[List]] match {
-          case AppliedType(ctor, _) => ctor
-          case _                    => return None
-        }
-        val functorGType = functorCtor.appliedTo(fieldCtor)
-        Implicits.search(functorGType) match {
-          case iss: ImplicitSearchSuccess => Some(iss.tree.asExpr.asInstanceOf[Expr[Any]])
-          case _                          => None
-        }
-      case _ => None
-    }
-  }
 }
 private[catsderivation] object FunctorMacros {
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AlternativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AlternativeMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -16,7 +18,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   *   - ap[A, B]: needs F[Any] erasure because ff: F[A => B] and fa: F[A] have different type parameters
   *   - combineK[A]: summons Semigroup for field types at macro time, needs concrete types
   */
-trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait AlternativeMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveAlternative[F[_]](
@@ -34,14 +37,8 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
           implicit val IntType: Type[Int] = AltTypes.Int
           implicit val StringType: Type[String] = AltTypes.String
 
-          val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-          }
-          val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-          }
+          val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+          val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
           val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
           val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -62,10 +59,16 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
           }
 
           if (nestedFields.nonEmpty) {
-            throw new RuntimeException(
-              s"Cannot derive Alternative: fields ${nestedFields.mkString(", ")} contain nested type constructors. " +
-                "Only direct type parameter fields (A) and invariant fields are supported."
-            )
+            runSafe {
+              failDerivation[Unit](
+                CatsDerivationError.UnsupportedFieldShape(
+                  "Alternative",
+                  nestedFields.mkString(", "),
+                  "nested type constructors are not supported - " +
+                    "only direct type parameter fields (A) and invariant fields are supported"
+                )
+              )
+            }
           }
 
           val directFieldSet: Set[String] = directFields.toSet
@@ -79,10 +82,7 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
           implicit val AnyType: Type[Any] = AltTypes.Any
           implicit val FAnyType: Type[F[Any]] = FCtor.apply[Any]
 
-          val caseClassAny = CaseClass.parse[F[Any]].toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Any]: $e")
-          }
+          val caseClassAny = runSafe(parseCaseClassMIO[F[Any]]("F[Any]"))
 
           val doEmpty: Expr[F[Any]] = runSafe {
             deriveAltEmptyBody[F](caseClassAny)
@@ -171,29 +171,28 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
   )(implicit FCtor: Type.Ctor1[F], FAnyType: Type[F[Any]], AnyType: Type[Any]): MIO[Expr[F[Any]]] = {
     val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
 
-    val fieldExprs: List[(String, Expr_??)] = fields.map { case (fieldName, param) =>
+    val fieldExprsMIO: MIO[List[(String, Expr_??)]] = fields.traverse { case (fieldName, param) =>
       import param.tpe.Underlying as Field
 
-      val monoidExpr = AltTypes.Monoid[Field].summonExprIgnoring().toEither match {
-        case Right(m)     => m
+      AltTypes.Monoid[Field].summonExprIgnoring().toEither match {
+        case Right(monoidExpr) =>
+          val value: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
+          MIO.pure((fieldName, value.as_??))
         case Left(reason) =>
-          throw new RuntimeException(
-            s"No Monoid instance found for field '$fieldName': ${Field.prettyPrint}: $reason"
+          failDerivation(
+            CatsDerivationError.MissingInstanceForField(
+              "Monoid",
+              fieldName,
+              Type[F[Any]].prettyPrint,
+              Some(s"${Field.prettyPrint}: $reason")
+            )
           )
       }
-      val value: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
-      (fieldName, value.as_??)
     }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => fieldExprs.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct empty result: $error"))
+    fieldExprsMIO.flatMap { fieldExprs =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "empty result")(fieldExprs.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 
@@ -205,39 +204,36 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
   )(implicit AType: Type[A]): MIO[Expr[F[A]]] = {
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
+    parseCaseClassMIO[F[A]]("F[A]").flatMap { caseClass =>
+      val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
 
-    val fieldExprs: List[(String, Expr_??)] = fields.map { case (fieldName, param) =>
-      import param.tpe.Underlying as Field
+      val fieldExprsMIO: MIO[List[(String, Expr_??)]] = fields.traverse { case (fieldName, param) =>
+        import param.tpe.Underlying as Field
 
-      if (directFields.contains(fieldName)) {
-        (fieldName, aExpr.as_??)
-      } else {
-        val monoidExpr = AltTypes.Monoid[Field].summonExprIgnoring().toEither match {
-          case Right(m)     => m
-          case Left(reason) =>
-            throw new RuntimeException(
-              s"No Monoid instance found for invariant field '$fieldName': ${Field.prettyPrint}: $reason"
-            )
+        if (directFields.contains(fieldName)) {
+          MIO.pure((fieldName, aExpr.as_??))
+        } else {
+          AltTypes.Monoid[Field].summonExprIgnoring().toEither match {
+            case Right(monoidExpr) =>
+              val emptyValue: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
+              MIO.pure((fieldName, emptyValue.as_??))
+            case Left(reason) =>
+              failDerivation(
+                CatsDerivationError.MissingInstanceForField(
+                  "Monoid",
+                  fieldName,
+                  Type[F[A]].prettyPrint,
+                  Some(s"${Field.prettyPrint}: $reason")
+                )
+              )
+          }
         }
-        val emptyValue: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
-        (fieldName, emptyValue.as_??)
       }
-    }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => fieldExprs.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[A]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct pure result: $error"))
+      fieldExprsMIO.flatMap { fieldExprs =>
+        constructInstanceFree(caseClass.primaryConstructor, "Constructor", "pure result")(fieldExprs.toMap)
+          .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[A]]])
+      }
     }
   }
 
@@ -251,37 +247,23 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
     implicit val FBType: Type[F[B]] = FCtor.apply[B]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val fields = caseClass.caseFieldValuesAt(faExpr).toList
+    parseCaseClassMIO[F[A]]("F[A]").parTuple(parseCaseClassMIO[F[B]]("F[B]")).flatMap { case (caseClass, caseClassB) =>
+      val fields = caseClass.caseFieldValuesAt(faExpr).toList
 
-    val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+      val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
+        import fieldValue.Underlying as Field
+        val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
 
-      if (directFields.contains(fieldName)) {
-        val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
-        (fieldName, mapped.as_??)
-      } else {
-        (fieldName, fieldExpr.as_??)
+        if (directFields.contains(fieldName)) {
+          val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
+          (fieldName, mapped.as_??)
+        } else {
+          (fieldName, fieldExpr.as_??)
+        }
       }
-    }
 
-    val caseClassB = CaseClass.parse[F[B]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[B]: $e")
-    }
-    caseClassB.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[B]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct mapped result: $error"))
+      constructInstanceFree(caseClassB.primaryConstructor, "Constructor", "mapped result")(mappedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[B]]])
     }
   }
 
@@ -295,8 +277,8 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
     val fieldsFF = caseClass.caseFieldValuesAt(ffExpr).toList
     val fieldsFA = caseClass.caseFieldValuesAt(faExpr).toList
 
-    val apFields: List[(String, Expr_??)] =
-      fieldsFF.zip(fieldsFA).map { case ((fieldName, ffFieldValue), (_, faFieldValue)) =>
+    val apFieldsMIO: MIO[List[(String, Expr_??)]] =
+      fieldsFF.zip(fieldsFA).traverse { case ((fieldName, ffFieldValue), (_, faFieldValue)) =>
         import ffFieldValue.Underlying as Field
         val ffField = ffFieldValue.value.asInstanceOf[Expr[Field]]
         val faField = faFieldValue.value.asInstanceOf[Expr[Field]]
@@ -305,31 +287,30 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
           val applied: Expr[Any] = Expr.quote(
             Expr.splice(ffField).asInstanceOf[Any => Any].apply(Expr.splice(faField).asInstanceOf[Any])
           )
-          (fieldName, applied.as_??)
+          MIO.pure((fieldName, applied.as_??))
         } else {
-          val sgExpr = AltTypes.Semigroup[Field].summonExprIgnoring().toEither match {
-            case Right(sg)    => sg
+          AltTypes.Semigroup[Field].summonExprIgnoring().toEither match {
+            case Right(sgExpr) =>
+              val combined: Expr[Field] = Expr.quote(
+                Expr.splice(sgExpr).combine(Expr.splice(ffField), Expr.splice(faField))
+              )
+              MIO.pure((fieldName, combined.as_??))
             case Left(reason) =>
-              throw new RuntimeException(
-                s"No Semigroup instance found for invariant field '$fieldName': ${Field.prettyPrint}: $reason"
+              failDerivation(
+                CatsDerivationError.MissingInstanceForField(
+                  "Semigroup",
+                  fieldName,
+                  Type[F[Any]].prettyPrint,
+                  Some(s"${Field.prettyPrint}: $reason")
+                )
               )
           }
-          val combined: Expr[Field] = Expr.quote(
-            Expr.splice(sgExpr).combine(Expr.splice(ffField), Expr.splice(faField))
-          )
-          (fieldName, combined.as_??)
         }
       }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => apFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct ap result: $error"))
+    apFieldsMIO.flatMap { apFields =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "ap result")(apFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 
@@ -342,32 +323,31 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons &
     val fieldsX = caseClass.caseFieldValuesAt(xExpr).toList
     val fieldsY = caseClass.caseFieldValuesAt(yExpr).toList
 
-    val combinedFields: List[(String, Expr_??)] =
-      fieldsX.zip(fieldsY).map { case ((fieldName, fieldValueX), (_, fieldValueY)) =>
+    val combinedFieldsMIO: MIO[List[(String, Expr_??)]] =
+      fieldsX.zip(fieldsY).traverse { case ((fieldName, fieldValueX), (_, fieldValueY)) =>
         import fieldValueX.Underlying as Field
         val fx = fieldValueX.value.asInstanceOf[Expr[Field]]
         val fy = fieldValueY.value.asInstanceOf[Expr[Field]]
 
-        val sgExpr = AltTypes.Semigroup[Field].summonExprIgnoring().toEither match {
-          case Right(sg)    => sg
+        AltTypes.Semigroup[Field].summonExprIgnoring().toEither match {
+          case Right(sgExpr) =>
+            val combined: Expr[Field] = Expr.quote(Expr.splice(sgExpr).combine(Expr.splice(fx), Expr.splice(fy)))
+            MIO.pure((fieldName, combined.as_??))
           case Left(reason) =>
-            throw new RuntimeException(
-              s"No Semigroup instance found for field '$fieldName': ${Field.prettyPrint}: $reason"
+            failDerivation(
+              CatsDerivationError.MissingInstanceForField(
+                "Semigroup",
+                fieldName,
+                Type[F[Any]].prettyPrint,
+                Some(s"${Field.prettyPrint}: $reason")
+              )
             )
         }
-        val combined: Expr[Field] = Expr.quote(Expr.splice(sgExpr).combine(Expr.splice(fx), Expr.splice(fy)))
-        (fieldName, combined.as_??)
       }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => combinedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct combined result: $error"))
+    combinedFieldsMIO.flatMap { combinedFields =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "combined result")(combinedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupport.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,23 +3,7 @@ package hearth.kindlings.catsderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def hasTypeAnnotation[Ann: Type, A: Type]: Boolean =
-    findTypeAnnotationOfType[Ann, A].isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
-
-  final def getTypeAnnotationStringArg[Ann: Type, A: Type]: Option[String] =
-    findTypeAnnotationOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplicativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplicativeMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -12,7 +14,10 @@ import hearth.kindlings.catsderivation.LogDerivation
   * cross-quotes support for method-level type parameters inside Expr.quote/Expr.splice. For ap, uses an erased approach
   * since both ff: F[A => B] and fa: F[A] must be treated as F[Any] for field extraction.
   */
-trait ApplicativeMacrosImpl extends rules.ApplicativeCaseClassRuleImpl with CatsDerivationTimeout {
+trait ApplicativeMacrosImpl
+    extends rules.ApplicativeCaseClassRuleImpl
+    with CatsDerivationTimeout
+    with CatsDerivationErrorSupport {
   this: MacroCommons & StdExtensions =>
 
   final case class ApplicativeCaseClassResult[F[_]](
@@ -134,40 +139,37 @@ trait ApplicativeMacrosImpl extends rules.ApplicativeCaseClassRuleImpl with Cats
   )(implicit AType: Type[A]): MIO[Expr[F[A]]] = {
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
+    parseCaseClassMIO[F[A]]("F[A]").flatMap { caseClass =>
+      val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
 
-    val fieldExprs: List[(String, Expr_??)] = fields.map { case (fieldName, param) =>
-      import param.tpe.Underlying as Field
+      val fieldExprsMIO: MIO[List[(String, Expr_??)]] = fields.traverse { case (fieldName, param) =>
+        import param.tpe.Underlying as Field
 
-      if (directFields.contains(fieldName)) {
-        (fieldName, aExpr.as_??)
-      } else {
-        // Invariant field: use Monoid.empty
-        val monoidExpr = ApplicativeTypes.Monoid[Field].summonExprIgnoring().toEither match {
-          case Right(m)     => m
-          case Left(reason) =>
-            throw new RuntimeException(
-              s"No Monoid instance found for invariant field '$fieldName': ${Field.prettyPrint}: $reason"
-            )
+        if (directFields.contains(fieldName)) {
+          MIO.pure((fieldName, aExpr.as_??))
+        } else {
+          // Invariant field: use Monoid.empty
+          ApplicativeTypes.Monoid[Field].summonExprIgnoring().toEither match {
+            case Right(monoidExpr) =>
+              val emptyValue: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
+              MIO.pure((fieldName, emptyValue.as_??))
+            case Left(reason) =>
+              failDerivation(
+                CatsDerivationError.MissingInstanceForField(
+                  "Monoid",
+                  fieldName,
+                  Type[F[A]].prettyPrint,
+                  Some(s"${Field.prettyPrint}: $reason")
+                )
+              )
+          }
         }
-        val emptyValue: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
-        (fieldName, emptyValue.as_??)
       }
-    }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => fieldExprs.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[A]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct pure result: $error"))
+      fieldExprsMIO.flatMap { fieldExprs =>
+        constructInstanceFree(caseClass.primaryConstructor, "Constructor", "pure result")(fieldExprs.toMap)
+          .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[A]]])
+      }
     }
   }
 
@@ -181,37 +183,23 @@ trait ApplicativeMacrosImpl extends rules.ApplicativeCaseClassRuleImpl with Cats
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
     implicit val FBType: Type[F[B]] = FCtor.apply[B]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val fields = caseClass.caseFieldValuesAt(faExpr).toList
+    parseCaseClassMIO[F[A]]("F[A]").parTuple(parseCaseClassMIO[F[B]]("F[B]")).flatMap { case (caseClass, caseClassB) =>
+      val fields = caseClass.caseFieldValuesAt(faExpr).toList
 
-    val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+      val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
+        import fieldValue.Underlying as Field
+        val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
 
-      if (directFields.contains(fieldName)) {
-        val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
-        (fieldName, mapped.as_??)
-      } else {
-        (fieldName, fieldExpr.as_??)
+        if (directFields.contains(fieldName)) {
+          val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
+          (fieldName, mapped.as_??)
+        } else {
+          (fieldName, fieldExpr.as_??)
+        }
       }
-    }
 
-    val caseClassB = CaseClass.parse[F[B]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[B]: $e")
-    }
-    caseClassB.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[B]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct mapped result: $error"))
+      constructInstanceFree(caseClassB.primaryConstructor, "Constructor", "mapped result")(mappedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[B]]])
     }
   }
 
@@ -225,8 +213,8 @@ trait ApplicativeMacrosImpl extends rules.ApplicativeCaseClassRuleImpl with Cats
     val fieldsFF = caseClass.caseFieldValuesAt(ffExpr).toList
     val fieldsFA = caseClass.caseFieldValuesAt(faExpr).toList
 
-    val apFields: List[(String, Expr_??)] =
-      fieldsFF.zip(fieldsFA).map { case ((fieldName, ffFieldValue), (_, faFieldValue)) =>
+    val apFieldsMIO: MIO[List[(String, Expr_??)]] =
+      fieldsFF.zip(fieldsFA).traverse { case ((fieldName, ffFieldValue), (_, faFieldValue)) =>
         import ffFieldValue.Underlying as Field
         val ffField = ffFieldValue.value.asInstanceOf[Expr[Field]]
         val faField = faFieldValue.value.asInstanceOf[Expr[Field]]
@@ -235,31 +223,30 @@ trait ApplicativeMacrosImpl extends rules.ApplicativeCaseClassRuleImpl with Cats
           val applied: Expr[Any] = Expr.quote(
             Expr.splice(ffField).asInstanceOf[Any => Any].apply(Expr.splice(faField).asInstanceOf[Any])
           )
-          (fieldName, applied.as_??)
+          MIO.pure((fieldName, applied.as_??))
         } else {
-          val sgExpr = ApplicativeTypes.Semigroup[Field].summonExprIgnoring().toEither match {
-            case Right(sg)    => sg
+          ApplicativeTypes.Semigroup[Field].summonExprIgnoring().toEither match {
+            case Right(sgExpr) =>
+              val combined: Expr[Field] = Expr.quote(
+                Expr.splice(sgExpr).combine(Expr.splice(ffField), Expr.splice(faField))
+              )
+              MIO.pure((fieldName, combined.as_??))
             case Left(reason) =>
-              throw new RuntimeException(
-                s"No Semigroup instance found for invariant field '$fieldName': ${Field.prettyPrint}: $reason"
+              failDerivation(
+                CatsDerivationError.MissingInstanceForField(
+                  "Semigroup",
+                  fieldName,
+                  Type[F[Any]].prettyPrint,
+                  Some(s"${Field.prettyPrint}: $reason")
+                )
               )
           }
-          val combined: Expr[Field] = Expr.quote(
-            Expr.splice(sgExpr).combine(Expr.splice(ffField), Expr.splice(faField))
-          )
-          (fieldName, combined.as_??)
         }
       }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => apFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct ap result: $error"))
+    apFieldsMIO.flatMap { apFields =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "ap result")(apFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplyMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplyMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -12,7 +14,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * support for method-level type parameters inside Expr.quote/Expr.splice. For ap, uses an erased approach since both
   * ff: F[A => B] and fa: F[A] must be treated as F[Any] for field extraction.
   */
-trait ApplyMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait ApplyMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveApply[F[_]](FCtor0: Type.Ctor1[F], ApplyFType: Type[cats.Apply[F]]): Expr[cats.Apply[F]] = {
@@ -27,14 +30,8 @@ trait ApplyMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
           implicit val IntType: Type[Int] = ApplyTypes.Int
           implicit val StringType: Type[String] = ApplyTypes.String
 
-          val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-          }
-          val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-          }
+          val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+          val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
           val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
           val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -55,10 +52,16 @@ trait ApplyMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
           }
 
           if (nestedFields.nonEmpty) {
-            throw new RuntimeException(
-              s"Cannot derive Apply: fields ${nestedFields.mkString(", ")} contain nested type constructors. " +
-                "Only direct type parameter fields (A) and invariant fields are supported."
-            )
+            runSafe {
+              failDerivation[Unit](
+                CatsDerivationError.UnsupportedFieldShape(
+                  "Apply",
+                  nestedFields.mkString(", "),
+                  "nested type constructors are not supported - " +
+                    "only direct type parameter fields (A) and invariant fields are supported"
+                )
+              )
+            }
           }
 
           val directFieldSet: Set[String] = directFields.toSet
@@ -72,10 +75,7 @@ trait ApplyMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
           implicit val AnyType: Type[Any] = ApplyTypes.Any
           implicit val FAnyType: Type[F[Any]] = FCtor.apply[Any]
 
-          val caseClass = CaseClass.parse[F[Any]].toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Any]: $e")
-          }
+          val caseClass = runSafe(parseCaseClassMIO[F[Any]]("F[Any]"))
 
           val doAp: (Expr[F[Any]], Expr[F[Any]]) => Expr[F[Any]] = (ffExpr, faExpr) =>
             runSafe {
@@ -140,37 +140,23 @@ trait ApplyMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
     implicit val FBType: Type[F[B]] = FCtor.apply[B]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val fields = caseClass.caseFieldValuesAt(faExpr).toList
+    parseCaseClassMIO[F[A]]("F[A]").parTuple(parseCaseClassMIO[F[B]]("F[B]")).flatMap { case (caseClass, caseClassB) =>
+      val fields = caseClass.caseFieldValuesAt(faExpr).toList
 
-    val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+      val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
+        import fieldValue.Underlying as Field
+        val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
 
-      if (directFields.contains(fieldName)) {
-        val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
-        (fieldName, mapped.as_??)
-      } else {
-        (fieldName, fieldExpr.as_??)
+        if (directFields.contains(fieldName)) {
+          val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
+          (fieldName, mapped.as_??)
+        } else {
+          (fieldName, fieldExpr.as_??)
+        }
       }
-    }
 
-    val caseClassB = CaseClass.parse[F[B]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[B]: $e")
-    }
-    caseClassB.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[B]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct mapped result: $error"))
+      constructInstanceFree(caseClassB.primaryConstructor, "Constructor", "mapped result")(mappedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[B]]])
     }
   }
 
@@ -184,8 +170,8 @@ trait ApplyMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
     val fieldsFF = caseClass.caseFieldValuesAt(ffExpr).toList
     val fieldsFA = caseClass.caseFieldValuesAt(faExpr).toList
 
-    val apFields: List[(String, Expr_??)] =
-      fieldsFF.zip(fieldsFA).map { case ((fieldName, ffFieldValue), (_, faFieldValue)) =>
+    val apFieldsMIO: MIO[List[(String, Expr_??)]] =
+      fieldsFF.zip(fieldsFA).traverse { case ((fieldName, ffFieldValue), (_, faFieldValue)) =>
         import ffFieldValue.Underlying as Field
         val ffField = ffFieldValue.value.asInstanceOf[Expr[Field]]
         val faField = faFieldValue.value.asInstanceOf[Expr[Field]]
@@ -195,32 +181,31 @@ trait ApplyMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
           val applied: Expr[Any] = Expr.quote(
             Expr.splice(ffField).asInstanceOf[Any => Any].apply(Expr.splice(faField).asInstanceOf[Any])
           )
-          (fieldName, applied.as_??)
+          MIO.pure((fieldName, applied.as_??))
         } else {
           // Invariant field: combine using Semigroup
-          val sgExpr = ApplyTypes.Semigroup[Field].summonExprIgnoring().toEither match {
-            case Right(sg)    => sg
+          ApplyTypes.Semigroup[Field].summonExprIgnoring().toEither match {
+            case Right(sgExpr) =>
+              val combined: Expr[Field] = Expr.quote(
+                Expr.splice(sgExpr).combine(Expr.splice(ffField), Expr.splice(faField))
+              )
+              MIO.pure((fieldName, combined.as_??))
             case Left(reason) =>
-              throw new RuntimeException(
-                s"No Semigroup instance found for invariant field '$fieldName': ${Field.prettyPrint}: $reason"
+              failDerivation(
+                CatsDerivationError.MissingInstanceForField(
+                  "Semigroup",
+                  fieldName,
+                  Type[F[Any]].prettyPrint,
+                  Some(s"${Field.prettyPrint}: $reason")
+                )
               )
           }
-          val combined: Expr[Field] = Expr.quote(
-            Expr.splice(sgExpr).combine(Expr.splice(ffField), Expr.splice(faField))
-          )
-          (fieldName, combined.as_??)
         }
       }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => apFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct ap result: $error"))
+    apFieldsMIO.flatMap { apFields =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "ap result")(apFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BifoldableMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BifoldableMacrosImpl.scala
@@ -6,7 +6,8 @@ import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
 
-trait BifoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait BifoldableMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveBifoldable[F[_, _]](
@@ -31,18 +32,11 @@ trait BifoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
             implicit val IntType: Type[Int] = BifoldableTypes.Int
             implicit val StringType: Type[String] = BifoldableTypes.String
 
-            val ccIntInt = CaseClass.parse(using FCtor.apply[Int, Int]).toEither match {
-              case Right(cc) => cc
-              case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int, Int]: $e")
-            }
-            val ccStringInt = CaseClass.parse(using FCtor.apply[String, Int]).toEither match {
-              case Right(cc) => cc
-              case Left(e)   => throw new RuntimeException(s"Cannot parse F[String, Int]: $e")
-            }
-            val ccIntString = CaseClass.parse(using FCtor.apply[Int, String]).toEither match {
-              case Right(cc) => cc
-              case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int, String]: $e")
-            }
+            val ccIntInt = runSafe(parseCaseClassMIO[F[Int, Int]]("F[Int, Int]")(using FCtor.apply[Int, Int]))
+            val ccStringInt =
+              runSafe(parseCaseClassMIO[F[String, Int]]("F[String, Int]")(using FCtor.apply[String, Int]))
+            val ccIntString =
+              runSafe(parseCaseClassMIO[F[Int, String]]("F[Int, String]")(using FCtor.apply[Int, String]))
 
             val fieldsP1 = ccIntInt.primaryConstructor.totalParameters.flatten.toList
             val fieldsP2 = ccStringInt.primaryConstructor.totalParameters.flatten.toList
@@ -71,10 +65,7 @@ trait BifoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
             implicit val FAnyAnyType: Type[F[Any, Any]] = FCtor.apply[Any, Any]
             implicit val EvalAnyType: Type[cats.Eval[Any]] = BifoldableTypes.EvalCtor.apply[Any]
 
-            val ccAnyAny = CaseClass.parse[F[Any, Any]].toEither match {
-              case Right(cc) => cc
-              case Left(e)   => throw new RuntimeException(s"Cannot parse F[Any, Any]: $e")
-            }
+            val ccAnyAny = runSafe(parseCaseClassMIO[F[Any, Any]]("F[Any, Any]"))
 
             val doBifoldLeft: (Expr[F[Any, Any]], Expr[Any], Expr[(Any, Any) => Any], Expr[(Any, Any) => Any]) => Expr[
               Any
@@ -190,148 +181,146 @@ trait BifoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
     implicit val EvalAnyType: Type[cats.Eval[Any]] = BifoldableTypes.EvalCtor.apply[Any]
     implicit val FCtor1: Type.Ctor2[F] = FCtor
 
-    Enum.parse[F[Any, Any]].toEither match {
-      case Left(reason) =>
-        MIO.fail(new RuntimeException(s"Cannot parse as enum for Bifoldable: $reason"))
-      case Right(enumm) =>
-        val enumP1 = Enum.parse(using FCtor.apply[Int, Int].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e; case Left(_) => return MIO.fail(new RuntimeException("Cannot parse F[Int,Int] as enum"))
-        }
-        val enumP2 = Enum.parse(using FCtor.apply[String, Int].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e; case Left(_) => return MIO.fail(new RuntimeException("Cannot parse F[String,Int]"))
-        }
-        val enumP3 = Enum.parse(using FCtor.apply[Int, String].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e; case Left(_) => return MIO.fail(new RuntimeException("Cannot parse F[Int,String]"))
-        }
-
-        case class BiChildInfo(leftFields: Set[String], rightFields: Set[String])
-        val childInfo: Map[String, BiChildInfo] = runSafe {
-          val result = scala.collection.mutable.Map.empty[String, BiChildInfo]
-          val c1 = enumP1.directChildren.toList
-          val c2 = enumP2.directChildren.toList
-          val c3 = enumP3.directChildren.toList
-          c1.zip(c2).zip(c3).foreach { case (((cn, ch1), (_, ch2)), (_, ch3)) =>
-            import ch1.Underlying as C1; import ch2.Underlying as C2; import ch3.Underlying as C3
-            (CaseClass.parse[C1].toEither, CaseClass.parse[C2].toEither, CaseClass.parse[C3].toEither) match {
-              case (Right(cc1), Right(cc2), Right(cc3)) =>
-                val f1 = cc1.primaryConstructor.totalParameters.flatten.toList
-                val f2 = cc2.primaryConstructor.totalParameters.flatten.toList
-                val f3 = cc3.primaryConstructor.totalParameters.flatten.toList
-                val left = scala.collection.mutable.Set.empty[String]
-                val right = scala.collection.mutable.Set.empty[String]
-                f1.zip(f2).zip(f3).foreach { case (((n, p1), (_, p2)), (_, p3)) =>
-                  val t1 = p1.tpe.Underlying; val t2 = p2.tpe.Underlying; val t3 = p3.tpe.Underlying
-                  if (!(t1 =:= t2) && (t1 =:= t3)) left += n
-                  else if ((t1 =:= t2) && !(t1 =:= t3)) right += n
-                }
-                result += (cn -> BiChildInfo(left.toSet, right.toSet))
-              case _ => result += (cn -> BiChildInfo(Set.empty, Set.empty))
+    parseEnumMIO[F[Any, Any]]("F[Any, Any]").flatMap { enumm =>
+      parseEnumMIO[Any]("F[Int, Int]")(using FCtor.apply[Int, Int].asInstanceOf[Type[Any]])
+        .parTuple(parseEnumMIO[Any]("F[String, Int]")(using FCtor.apply[String, Int].asInstanceOf[Type[Any]]))
+        .parTuple(parseEnumMIO[Any]("F[Int, String]")(using FCtor.apply[Int, String].asInstanceOf[Type[Any]]))
+        .flatMap { case ((enumP1, enumP2), enumP3) =>
+          case class BiChildInfo(leftFields: Set[String], rightFields: Set[String])
+          val childInfo: Map[String, BiChildInfo] = runSafe {
+            val result = scala.collection.mutable.Map.empty[String, BiChildInfo]
+            val c1 = enumP1.directChildren.toList
+            val c2 = enumP2.directChildren.toList
+            val c3 = enumP3.directChildren.toList
+            c1.zip(c2).zip(c3).foreach { case (((cn, ch1), (_, ch2)), (_, ch3)) =>
+              import ch1.Underlying as C1; import ch2.Underlying as C2; import ch3.Underlying as C3
+              (CaseClass.parse[C1].toEither, CaseClass.parse[C2].toEither, CaseClass.parse[C3].toEither) match {
+                case (Right(cc1), Right(cc2), Right(cc3)) =>
+                  val f1 = cc1.primaryConstructor.totalParameters.flatten.toList
+                  val f2 = cc2.primaryConstructor.totalParameters.flatten.toList
+                  val f3 = cc3.primaryConstructor.totalParameters.flatten.toList
+                  val left = scala.collection.mutable.Set.empty[String]
+                  val right = scala.collection.mutable.Set.empty[String]
+                  f1.zip(f2).zip(f3).foreach { case (((n, p1), (_, p2)), (_, p3)) =>
+                    val t1 = p1.tpe.Underlying; val t2 = p2.tpe.Underlying; val t3 = p3.tpe.Underlying
+                    if (!(t1 =:= t2) && (t1 =:= t3)) left += n
+                    else if ((t1 =:= t2) && !(t1 =:= t3)) right += n
+                  }
+                  result += (cn -> BiChildInfo(left.toSet, right.toSet))
+                case _ => result += (cn -> BiChildInfo(Set.empty, Set.empty))
+              }
             }
+            MIO.pure(result.toMap)
           }
-          MIO.pure(result.toMap)
-        }
 
-        import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
+          import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
 
-        def mkBifoldLeftBody(
-            fabExpr: Expr[F[Any, Any]],
-            cExpr: Expr[Any],
-            fExpr: Expr[(Any, Any) => Any],
-            gExpr: Expr[(Any, Any) => Any]
-        ): Expr[Any] = runSafe {
-          enumm
-            .matchOn[MIO, Any](fabExpr) { matched =>
-              import matched.{value as caseValue, Underlying as CT}
-              val cn = Type[CT].shortName
-              childInfo.get(cn) match {
-                case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
-                case Some(info) =>
-                  CaseClass.parse[CT].toEither match {
-                    case Left(_)   => MIO.pure(cExpr)
-                    case Right(cc) =>
-                      val fields = cc.caseFieldValuesAt(caseValue).toList
-                      var acc = cExpr
-                      fields.foreach { case (fn, fv) =>
-                        import fv.Underlying as Field
-                        val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
-                        if (info.leftFields.contains(fn))
-                          acc = Expr.quote(Expr.splice(fExpr)(Expr.splice(acc), Expr.splice(fe)))
-                        else if (info.rightFields.contains(fn))
-                          acc = Expr.quote(Expr.splice(gExpr)(Expr.splice(acc), Expr.splice(fe)))
-                      }
-                      MIO.pure(acc)
-                  }
-              }
-            }
-            .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
-        }
-
-        def mkBifoldRightBody(
-            fabExpr: Expr[F[Any, Any]],
-            lcExpr: Expr[cats.Eval[Any]],
-            fExpr: Expr[(Any, cats.Eval[Any]) => cats.Eval[Any]],
-            gExpr: Expr[(Any, cats.Eval[Any]) => cats.Eval[Any]]
-        ): Expr[cats.Eval[Any]] = runSafe {
-          enumm
-            .matchOn[MIO, cats.Eval[Any]](fabExpr) { matched =>
-              import matched.{value as caseValue, Underlying as CT}
-              val cn = Type[CT].shortName
-              childInfo.get(cn) match {
-                case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
-                case Some(info) =>
-                  CaseClass.parse[CT].toEither match {
-                    case Left(_)   => MIO.pure(lcExpr)
-                    case Right(cc) =>
-                      val fields = cc.caseFieldValuesAt(caseValue).toList
-                      val covariant: List[(Expr[Any], Boolean)] = fields.collect {
-                        case (fn, fv) if info.leftFields.contains(fn) =>
+          def mkBifoldLeftBody(
+              fabExpr: Expr[F[Any, Any]],
+              cExpr: Expr[Any],
+              fExpr: Expr[(Any, Any) => Any],
+              gExpr: Expr[(Any, Any) => Any]
+          ): Expr[Any] = runSafe {
+            enumm
+              .matchOn[MIO, Any](fabExpr) { matched =>
+                import matched.{value as caseValue, Underlying as CT}
+                val cn = Type[CT].shortName
+                childInfo.get(cn) match {
+                  case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Bifoldable", cn))
+                  case Some(info) =>
+                    CaseClass.parse[CT].toEither match {
+                      case Left(_)   => MIO.pure(cExpr)
+                      case Right(cc) =>
+                        val fields = cc.caseFieldValuesAt(caseValue).toList
+                        var acc = cExpr
+                        fields.foreach { case (fn, fv) =>
                           import fv.Underlying as Field
-                          (fv.value.asInstanceOf[Expr[Field]].upcast[Any], true)
-                        case (fn, fv) if info.rightFields.contains(fn) =>
-                          import fv.Underlying as Field
-                          (fv.value.asInstanceOf[Expr[Field]].upcast[Any], false)
-                      }
-                      val result = covariant.foldRight(lcExpr) { case ((fe, isLeft), acc) =>
-                        if (isLeft) Expr.quote(Expr.splice(fExpr)(Expr.splice(fe), Expr.splice(acc)))
-                        else Expr.quote(Expr.splice(gExpr)(Expr.splice(fe), Expr.splice(acc)))
-                      }
-                      MIO.pure(result)
-                  }
+                          val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
+                          if (info.leftFields.contains(fn))
+                            acc = Expr.quote(Expr.splice(fExpr)(Expr.splice(acc), Expr.splice(fe)))
+                          else if (info.rightFields.contains(fn))
+                            acc = Expr.quote(Expr.splice(gExpr)(Expr.splice(acc), Expr.splice(fe)))
+                        }
+                        MIO.pure(acc)
+                    }
+                }
               }
-            }
-            .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
-        }
+              .flatMap {
+                case Some(r) => MIO.pure(r)
+                case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any, Any]].prettyPrint))
+              }
+          }
 
-        MIO.pure {
-          Expr.quote {
-            CatsDerivationFactories.bifoldableInstance[F](
-              bifoldLeftFn = {
-                (
-                    fab: F[CatsDerivationFactories.W1, CatsDerivationFactories.W2],
-                    cAny: Any,
-                    fAny: (Any, Any) => Any,
-                    gAny: (Any, Any) => Any
-                ) =>
-                  val anyFab: F[Any, Any] = fab.asInstanceOf[F[Any, Any]]
-                  val _ = anyFab; val _ = cAny; val _ = fAny; val _ = gAny
-                  Expr.splice(
-                    mkBifoldLeftBody(Expr.quote(anyFab), Expr.quote(cAny), Expr.quote(fAny), Expr.quote(gAny))
-                  )
-              },
-              bifoldRightFn = {
-                (
-                    fab: F[CatsDerivationFactories.W1, CatsDerivationFactories.W2],
-                    lcAny: cats.Eval[Any],
-                    fAny: (Any, cats.Eval[Any]) => cats.Eval[Any],
-                    gAny: (Any, cats.Eval[Any]) => cats.Eval[Any]
-                ) =>
-                  val anyFab: F[Any, Any] = fab.asInstanceOf[F[Any, Any]]
-                  val _ = anyFab; val _ = lcAny; val _ = fAny; val _ = gAny
-                  Expr.splice(
-                    mkBifoldRightBody(Expr.quote(anyFab), Expr.quote(lcAny), Expr.quote(fAny), Expr.quote(gAny))
-                  )
+          def mkBifoldRightBody(
+              fabExpr: Expr[F[Any, Any]],
+              lcExpr: Expr[cats.Eval[Any]],
+              fExpr: Expr[(Any, cats.Eval[Any]) => cats.Eval[Any]],
+              gExpr: Expr[(Any, cats.Eval[Any]) => cats.Eval[Any]]
+          ): Expr[cats.Eval[Any]] = runSafe {
+            enumm
+              .matchOn[MIO, cats.Eval[Any]](fabExpr) { matched =>
+                import matched.{value as caseValue, Underlying as CT}
+                val cn = Type[CT].shortName
+                childInfo.get(cn) match {
+                  case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Bifoldable", cn))
+                  case Some(info) =>
+                    CaseClass.parse[CT].toEither match {
+                      case Left(_)   => MIO.pure(lcExpr)
+                      case Right(cc) =>
+                        val fields = cc.caseFieldValuesAt(caseValue).toList
+                        val covariant: List[(Expr[Any], Boolean)] = fields.collect {
+                          case (fn, fv) if info.leftFields.contains(fn) =>
+                            import fv.Underlying as Field
+                            (fv.value.asInstanceOf[Expr[Field]].upcast[Any], true)
+                          case (fn, fv) if info.rightFields.contains(fn) =>
+                            import fv.Underlying as Field
+                            (fv.value.asInstanceOf[Expr[Field]].upcast[Any], false)
+                        }
+                        val result = covariant.foldRight(lcExpr) { case ((fe, isLeft), acc) =>
+                          if (isLeft) Expr.quote(Expr.splice(fExpr)(Expr.splice(fe), Expr.splice(acc)))
+                          else Expr.quote(Expr.splice(gExpr)(Expr.splice(fe), Expr.splice(acc)))
+                        }
+                        MIO.pure(result)
+                    }
+                }
               }
-            )
+              .flatMap {
+                case Some(r) => MIO.pure(r)
+                case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any, Any]].prettyPrint))
+              }
+          }
+
+          MIO.pure {
+            Expr.quote {
+              CatsDerivationFactories.bifoldableInstance[F](
+                bifoldLeftFn = {
+                  (
+                      fab: F[CatsDerivationFactories.W1, CatsDerivationFactories.W2],
+                      cAny: Any,
+                      fAny: (Any, Any) => Any,
+                      gAny: (Any, Any) => Any
+                  ) =>
+                    val anyFab: F[Any, Any] = fab.asInstanceOf[F[Any, Any]]
+                    val _ = anyFab; val _ = cAny; val _ = fAny; val _ = gAny
+                    Expr.splice(
+                      mkBifoldLeftBody(Expr.quote(anyFab), Expr.quote(cAny), Expr.quote(fAny), Expr.quote(gAny))
+                    )
+                },
+                bifoldRightFn = {
+                  (
+                      fab: F[CatsDerivationFactories.W1, CatsDerivationFactories.W2],
+                      lcAny: cats.Eval[Any],
+                      fAny: (Any, cats.Eval[Any]) => cats.Eval[Any],
+                      gAny: (Any, cats.Eval[Any]) => cats.Eval[Any]
+                  ) =>
+                    val anyFab: F[Any, Any] = fab.asInstanceOf[F[Any, Any]]
+                    val _ = anyFab; val _ = lcAny; val _ = fAny; val _ = gAny
+                    Expr.splice(
+                      mkBifoldRightBody(Expr.quote(anyFab), Expr.quote(lcAny), Expr.quote(fAny), Expr.quote(gAny))
+                    )
+                }
+              )
+            }
           }
         }
     }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BifunctorMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BifunctorMacrosImpl.scala
@@ -6,7 +6,10 @@ import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
 
-trait BifunctorMacrosImpl extends rules.BifunctorCaseClassRuleImpl with CatsDerivationTimeout {
+trait BifunctorMacrosImpl
+    extends rules.BifunctorCaseClassRuleImpl
+    with CatsDerivationTimeout
+    with CatsDerivationErrorSupport {
   this: MacroCommons & StdExtensions =>
 
   final case class BifunctorCaseClassResult[F[_, _]](
@@ -92,40 +95,27 @@ trait BifunctorMacrosImpl extends rules.BifunctorCaseClassRuleImpl with CatsDeri
     implicit val FABType: Type[F[A, B]] = FCtor.apply[A, B]
     implicit val FCDType: Type[F[C, D]] = FCtor.apply[C, D]
 
-    val caseClass = CaseClass.parse[F[A, B]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A, B]: $e")
-    }
-    val fields = caseClass.caseFieldValuesAt(fabExpr).toList
+    parseCaseClassMIO[F[A, B]]("F[A, B]").parTuple(parseCaseClassMIO[F[C, D]]("F[C, D]")).flatMap {
+      case (caseClass, caseClassCD) =>
+        val fields = caseClass.caseFieldValuesAt(fabExpr).toList
 
-    val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+        val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
+          import fieldValue.Underlying as Field
+          val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
 
-      if (leftFields.contains(fieldName)) {
-        val mapped: Expr[C] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
-        (fieldName, mapped.as_??)
-      } else if (rightFields.contains(fieldName)) {
-        val mapped: Expr[D] = Expr.quote(Expr.splice(gExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[B]])))
-        (fieldName, mapped.as_??)
-      } else {
-        (fieldName, fieldExpr.as_??)
-      }
-    }
+          if (leftFields.contains(fieldName)) {
+            val mapped: Expr[C] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
+            (fieldName, mapped.as_??)
+          } else if (rightFields.contains(fieldName)) {
+            val mapped: Expr[D] = Expr.quote(Expr.splice(gExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[B]])))
+            (fieldName, mapped.as_??)
+          } else {
+            (fieldName, fieldExpr.as_??)
+          }
+        }
 
-    val caseClassCD = CaseClass.parse[F[C, D]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[C, D]: $e")
-    }
-    caseClassCD.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[C, D]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct bimap result: $error"))
+        constructInstanceFree(caseClassCD.primaryConstructor, "Constructor", "bimap result")(mappedFields.toMap)
+          .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[C, D]]])
     }
   }
 
@@ -185,130 +175,114 @@ trait BifunctorMacrosImpl extends rules.BifunctorCaseClassRuleImpl with CatsDeri
     implicit val FAAType: Type[F[Any, Any]] = FCtor.apply[Any, Any]
     implicit val FCtor1: Type.Ctor2[F] = FCtor
 
-    Enum.parse[F[Any, Any]].toEither match {
-      case Left(reason) =>
-        MIO.fail(new RuntimeException(s"Cannot parse as enum for Bifunctor: $reason"))
-      case Right(enumm) =>
-        val enumProbe1 = Enum.parse(using FCtor.apply[Int, Int].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e; case Left(_) => return MIO.fail(new RuntimeException("Cannot parse F[Int,Int] as enum"))
-        }
-        val enumProbe2 = Enum.parse(using FCtor.apply[String, Int].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e
-          case Left(_)  => return MIO.fail(new RuntimeException("Cannot parse F[String,Int] as enum"))
-        }
-        val enumProbe3 = Enum.parse(using FCtor.apply[Int, String].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e
-          case Left(_)  => return MIO.fail(new RuntimeException("Cannot parse F[Int,String] as enum"))
-        }
+    parseEnumMIO[F[Any, Any]]("F[Any, Any]").flatMap { enumm =>
+      parseEnumMIO[Any]("F[Int, Int]")(using FCtor.apply[Int, Int].asInstanceOf[Type[Any]])
+        .parTuple(parseEnumMIO[Any]("F[String, Int]")(using FCtor.apply[String, Int].asInstanceOf[Type[Any]]))
+        .parTuple(parseEnumMIO[Any]("F[Int, String]")(using FCtor.apply[Int, String].asInstanceOf[Type[Any]]))
+        .flatMap { case ((enumProbe1, enumProbe2), enumProbe3) =>
+          case class BiChildInfo(leftFields: Set[String], rightFields: Set[String])
 
-        case class BiChildInfo(leftFields: Set[String], rightFields: Set[String])
-
-        val childInfo: Map[String, BiChildInfo] = runSafe {
-          val result = scala.collection.mutable.Map.empty[String, BiChildInfo]
-          val c1 = enumProbe1.directChildren.toList
-          val c2 = enumProbe2.directChildren.toList
-          val c3 = enumProbe3.directChildren.toList
-          c1.zip(c2).zip(c3).foreach { case (((cn, ch1), (_, ch2)), (_, ch3)) =>
-            import ch1.Underlying as C1
-            import ch2.Underlying as C2
-            import ch3.Underlying as C3
-            val cc1 = CaseClass.parse[C1].toEither
-            val cc2 = CaseClass.parse[C2].toEither
-            val cc3 = CaseClass.parse[C3].toEither
-            (cc1, cc2, cc3) match {
-              case (Right(cI), Right(cII), Right(cIII)) =>
-                val f1 = cI.primaryConstructor.totalParameters.flatten.toList
-                val f2 = cII.primaryConstructor.totalParameters.flatten.toList
-                val f3 = cIII.primaryConstructor.totalParameters.flatten.toList
-                val left = scala.collection.mutable.Set.empty[String]
-                val right = scala.collection.mutable.Set.empty[String]
-                f1.zip(f2).zip(f3).foreach { case (((name, p1), (_, p2)), (_, p3)) =>
-                  val t1 = p1.tpe.Underlying
-                  val t2 = p2.tpe.Underlying
-                  val t3 = p3.tpe.Underlying
-                  val firstChanges = !(t1 =:= t2)
-                  val secondChanges = !(t1 =:= t3)
-                  if (firstChanges && !secondChanges) left += name
-                  else if (!firstChanges && secondChanges) right += name
-                }
-                result += (cn -> BiChildInfo(left.toSet, right.toSet))
-              case _ =>
-                result += (cn -> BiChildInfo(Set.empty, Set.empty))
-            }
-          }
-          MIO.pure(result.toMap)
-        }
-
-        import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
-
-        def mkBimapBody(
-            fabExpr: Expr[F[Any, Any]],
-            fExpr: Expr[Any => Any],
-            gExpr: Expr[Any => Any]
-        ): Expr[F[Any, Any]] = runSafe {
-          enumm
-            .matchOn[MIO, F[Any, Any]](fabExpr) { matched =>
-              import matched.{value as caseValue, Underlying as CT}
-              val cn = Type[CT].shortName
-              childInfo.get(cn) match {
-                case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
-                case Some(info) =>
-                  CaseClass.parse[CT].toEither match {
-                    case Left(_) =>
-                      MIO.pure(caseValue.upcast[F[Any, Any]])
-                    case Right(cc) =>
-                      val fields = cc.caseFieldValuesAt(caseValue).toList
-                      if (fields.isEmpty) {
-                        MIO.pure(caseValue.upcast[F[Any, Any]])
-                      } else {
-                        val mapped: List[(String, Expr_??)] = fields.map { case (fn, fv) =>
-                          import fv.Underlying as Field
-                          val fe = fv.value.asInstanceOf[Expr[Field]]
-                          if (info.leftFields.contains(fn)) {
-                            val m: Expr[Any] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fe.upcast[Any])))
-                            (fn, Expr.quote(Expr.splice(m).asInstanceOf[Field]).as_??)
-                          } else if (info.rightFields.contains(fn)) {
-                            val m: Expr[Any] = Expr.quote(Expr.splice(gExpr)(Expr.splice(fe.upcast[Any])))
-                            (fn, Expr.quote(Expr.splice(m).asInstanceOf[Field]).as_??)
-                          } else {
-                            (fn, fe.as_??)
-                          }
-                        }
-                        cc.primaryConstructor.fold(
-                          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                          onTypes = _ => Map.empty,
-                          onValues = _ => mapped.toMap
-                        ) match {
-                          case Right(expr) => MIO.pure(expr.value.asInstanceOf[Expr[F[Any, Any]]])
-                          case Left(err)   => MIO.fail(new RuntimeException(s"Cannot construct $cn: $err"))
-                        }
-                      }
+          val childInfo: Map[String, BiChildInfo] = runSafe {
+            val result = scala.collection.mutable.Map.empty[String, BiChildInfo]
+            val c1 = enumProbe1.directChildren.toList
+            val c2 = enumProbe2.directChildren.toList
+            val c3 = enumProbe3.directChildren.toList
+            c1.zip(c2).zip(c3).foreach { case (((cn, ch1), (_, ch2)), (_, ch3)) =>
+              import ch1.Underlying as C1
+              import ch2.Underlying as C2
+              import ch3.Underlying as C3
+              val cc1 = CaseClass.parse[C1].toEither
+              val cc2 = CaseClass.parse[C2].toEither
+              val cc3 = CaseClass.parse[C3].toEither
+              (cc1, cc2, cc3) match {
+                case (Right(cI), Right(cII), Right(cIII)) =>
+                  val f1 = cI.primaryConstructor.totalParameters.flatten.toList
+                  val f2 = cII.primaryConstructor.totalParameters.flatten.toList
+                  val f3 = cIII.primaryConstructor.totalParameters.flatten.toList
+                  val left = scala.collection.mutable.Set.empty[String]
+                  val right = scala.collection.mutable.Set.empty[String]
+                  f1.zip(f2).zip(f3).foreach { case (((name, p1), (_, p2)), (_, p3)) =>
+                    val t1 = p1.tpe.Underlying
+                    val t2 = p2.tpe.Underlying
+                    val t3 = p3.tpe.Underlying
+                    val firstChanges = !(t1 =:= t2)
+                    val secondChanges = !(t1 =:= t3)
+                    if (firstChanges && !secondChanges) left += name
+                    else if (!firstChanges && secondChanges) right += name
                   }
+                  result += (cn -> BiChildInfo(left.toSet, right.toSet))
+                case _ =>
+                  result += (cn -> BiChildInfo(Set.empty, Set.empty))
               }
             }
-            .flatMap {
-              case Some(r) => MIO.pure(r)
-              case None    => MIO.fail(new RuntimeException("No children"))
-            }
-        }
+            MIO.pure(result.toMap)
+          }
 
-        MIO.pure {
-          Expr.quote {
-            CatsDerivationFactories.bifunctorInstance[F] {
-              (
-                  fab: F[CatsDerivationFactories.W1, CatsDerivationFactories.W2],
-                  f: CatsDerivationFactories.W1 => CatsDerivationFactories.W3,
-                  g: CatsDerivationFactories.W2 => CatsDerivationFactories.W4
-              ) =>
-                val _ = fab; val _ = f; val _ = g
-                val r$0: F[Any, Any] = Expr.splice {
-                  mkBimapBody(
-                    Expr.quote(fab.asInstanceOf[F[Any, Any]]),
-                    Expr.quote(f.asInstanceOf[Any => Any]),
-                    Expr.quote(g.asInstanceOf[Any => Any])
-                  )
+          import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
+
+          def mkBimapBody(
+              fabExpr: Expr[F[Any, Any]],
+              fExpr: Expr[Any => Any],
+              gExpr: Expr[Any => Any]
+          ): Expr[F[Any, Any]] = runSafe {
+            enumm
+              .matchOn[MIO, F[Any, Any]](fabExpr) { matched =>
+                import matched.{value as caseValue, Underlying as CT}
+                val cn = Type[CT].shortName
+                childInfo.get(cn) match {
+                  case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Bifunctor", cn))
+                  case Some(info) =>
+                    CaseClass.parse[CT].toEither match {
+                      case Left(_) =>
+                        MIO.pure(caseValue.upcast[F[Any, Any]])
+                      case Right(cc) =>
+                        val fields = cc.caseFieldValuesAt(caseValue).toList
+                        if (fields.isEmpty) {
+                          MIO.pure(caseValue.upcast[F[Any, Any]])
+                        } else {
+                          val mapped: List[(String, Expr_??)] = fields.map { case (fn, fv) =>
+                            import fv.Underlying as Field
+                            val fe = fv.value.asInstanceOf[Expr[Field]]
+                            if (info.leftFields.contains(fn)) {
+                              val m: Expr[Any] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fe.upcast[Any])))
+                              (fn, Expr.quote(Expr.splice(m).asInstanceOf[Field]).as_??)
+                            } else if (info.rightFields.contains(fn)) {
+                              val m: Expr[Any] = Expr.quote(Expr.splice(gExpr)(Expr.splice(fe.upcast[Any])))
+                              (fn, Expr.quote(Expr.splice(m).asInstanceOf[Field]).as_??)
+                            } else {
+                              (fn, fe.as_??)
+                            }
+                          }
+                          constructInstanceFree(cc.primaryConstructor, "Constructor", cn)(mapped.toMap)
+                            .map(expr => expr.value.asInstanceOf[Expr[F[Any, Any]]])
+                        }
+                    }
                 }
-                r$0.asInstanceOf[F[CatsDerivationFactories.W3, CatsDerivationFactories.W4]]
+              }
+              .flatMap {
+                case Some(r) => MIO.pure(r)
+                case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any, Any]].prettyPrint))
+              }
+          }
+
+          MIO.pure {
+            Expr.quote {
+              CatsDerivationFactories.bifunctorInstance[F] {
+                (
+                    fab: F[CatsDerivationFactories.W1, CatsDerivationFactories.W2],
+                    f: CatsDerivationFactories.W1 => CatsDerivationFactories.W3,
+                    g: CatsDerivationFactories.W2 => CatsDerivationFactories.W4
+                ) =>
+                  val _ = fab; val _ = f; val _ = g
+                  val r$0: F[Any, Any] = Expr.splice {
+                    mkBimapBody(
+                      Expr.quote(fab.asInstanceOf[F[Any, Any]]),
+                      Expr.quote(f.asInstanceOf[Any => Any]),
+                      Expr.quote(g.asInstanceOf[Any => Any])
+                    )
+                  }
+                  r$0.asInstanceOf[F[CatsDerivationFactories.W3, CatsDerivationFactories.W4]]
+              }
             }
           }
         }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BitraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BitraverseMacrosImpl.scala
@@ -2,11 +2,14 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
 
-trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait BitraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveBitraverse[F[_, _]](
@@ -29,18 +32,11 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
               implicit val IntType: Type[Int] = BitraverseTypes.Int
               implicit val StringType: Type[String] = BitraverseTypes.String
 
-              val ccIntInt = CaseClass.parse(using FCtor.apply[Int, Int]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int, Int]: $e")
-              }
-              val ccStringInt = CaseClass.parse(using FCtor.apply[String, Int]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[String, Int]: $e")
-              }
-              val ccIntString = CaseClass.parse(using FCtor.apply[Int, String]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int, String]: $e")
-              }
+              val ccIntInt = runSafe(parseCaseClassMIO[F[Int, Int]]("F[Int, Int]")(using FCtor.apply[Int, Int]))
+              val ccStringInt =
+                runSafe(parseCaseClassMIO[F[String, Int]]("F[String, Int]")(using FCtor.apply[String, Int]))
+              val ccIntString =
+                runSafe(parseCaseClassMIO[F[Int, String]]("F[Int, String]")(using FCtor.apply[Int, String]))
 
               val fieldsP1 = ccIntInt.primaryConstructor.totalParameters.flatten.toList
               val fieldsP2 = ccStringInt.primaryConstructor.totalParameters.flatten.toList
@@ -50,23 +46,35 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
               val rightFieldSet = scala.collection.mutable.Set.empty[String]
               val covariantFieldOrder = scala.collection.mutable.ListBuffer.empty[(String, Boolean)]
 
-              fieldsP1.zip(fieldsP2).zip(fieldsP3).foreach { case (((name, p1), (_, p2)), (_, p3)) =>
-                val t1 = p1.tpe.Underlying
-                val t2 = p2.tpe.Underlying
-                val t3 = p3.tpe.Underlying
-                val firstChanges = !(t1 =:= t2)
-                val secondChanges = !(t1 =:= t3)
-                if (firstChanges && !secondChanges) {
-                  leftFieldSet += name
-                  covariantFieldOrder += ((name, true))
-                } else if (!firstChanges && secondChanges) {
-                  rightFieldSet += name
-                  covariantFieldOrder += ((name, false))
-                } else if (firstChanges && secondChanges) {
-                  throw new RuntimeException(
-                    s"Cannot derive Bitraverse: field $name depends on both type parameters."
-                  )
-                }
+              runSafe {
+                fieldsP1
+                  .zip(fieldsP2)
+                  .zip(fieldsP3)
+                  .traverse { case (((name, p1), (_, p2)), (_, p3)) =>
+                    val t1 = p1.tpe.Underlying
+                    val t2 = p2.tpe.Underlying
+                    val t3 = p3.tpe.Underlying
+                    val firstChanges = !(t1 =:= t2)
+                    val secondChanges = !(t1 =:= t3)
+                    if (firstChanges && !secondChanges) {
+                      leftFieldSet += name
+                      covariantFieldOrder += ((name, true))
+                      MIO.void
+                    } else if (!firstChanges && secondChanges) {
+                      rightFieldSet += name
+                      covariantFieldOrder += ((name, false))
+                      MIO.void
+                    } else if (firstChanges && secondChanges) {
+                      failDerivation[Unit](
+                        CatsDerivationError.UnsupportedFieldShape(
+                          "Bitraverse",
+                          name,
+                          "the field depends on both type parameters"
+                        )
+                      )
+                    } else MIO.void
+                  }
+                  .void
               }
 
               val allCovariantFields: Set[String] = leftFieldSet.toSet ++ rightFieldSet.toSet
@@ -109,14 +117,9 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
                         (fieldName, fieldValue.value.asInstanceOf[Expr[Field]].as_??)
                       }
                     }
-                    caseClass.primaryConstructor.fold(
-                      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                      onTypes = _ => Map.empty,
-                      onValues = _ => mappedFields.toMap
-                    ) match {
-                      case Right(expr) => MIO.pure(expr.value.asInstanceOf[Expr[F[Any, Any]]])
-                      case Left(e)     => MIO.fail(new RuntimeException(s"Cannot construct bimap result: $e"))
-                    }
+                    constructInstanceFree(caseClass.primaryConstructor, "Constructor", "bimap result")(
+                      mappedFields.toMap
+                    ).map(expr => expr.value.asInstanceOf[Expr[F[Any, Any]]])
                   }
 
               val doBifoldLeft
@@ -249,9 +252,10 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
           case Left(_) =>
             Enum.parse[F[Any, Any]].toEither match {
               case Left(reason2) =>
-                MIO.fail(
-                  new RuntimeException(
-                    s"$macroName: Cannot derive: not a case class and not a sealed trait ($reason2)."
+                failDerivation(
+                  CatsDerivationError.CannotParseEnum(
+                    Type[F[Any, Any]].prettyPrint,
+                    s"not a case class and not a sealed trait ($reason2). $macroName cannot derive for this type."
                   )
                 )
               case Right(enumm) =>
@@ -311,8 +315,11 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
       FAnyAnyType: Type[F[Any, Any]],
       AnyType: Type[Any],
       ListAnyType: Type[List[Any]]
-  ): MIO[Expr[(List[Any], Any) => Any]] = {
-    val lambda =
+  ): MIO[Expr[(List[Any], Any) => Any]] =
+    // LambdaBuilder callbacks are synchronous and cannot return MIO, so failures inside the
+    // callback throw the typed CatsDerivationError; the enclosing MIO(...) converts the
+    // NonFatal throw into a proper MIO error-channel failure.
+    MIO {
       LambdaBuilder.of2[List[Any], Any]("newVals", "original").buildWith { case (newValsExpr, originalExpr) =>
         val fabExpr: Expr[F[Any, Any]] = Expr.quote(Expr.splice(originalExpr).asInstanceOf[F[Any, Any]])
         val fields = caseClass.caseFieldValuesAt(fabExpr).toList
@@ -328,18 +335,16 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
             (fieldName, fieldValue.value.asInstanceOf[Expr[Field]].as_??)
           }
         }
-        caseClass.primaryConstructor.fold(
-          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+        foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
           onTypes = _ => Map.empty,
           onValues = _ => fieldExprs.toMap
         ) match {
           case Right(constructExpr) => constructExpr.value.asInstanceOf[Expr[Any]]
           case Left(error)          =>
-            throw new RuntimeException(s"Cannot construct bitraversed result: $error")
+            throw CatsDerivationError.CannotConstructResult("bitraversed result", error)
         }
       }
-    MIO.pure(lambda)
-  }
+    }
 
   @scala.annotation.nowarn(
     "msg=is never used|unused explicit parameter|unused local definition|unused implicit parameter"
@@ -357,14 +362,10 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
     implicit val ListAnyType: Type[List[Any]] = BitraverseTypes.ListAny
     implicit val FCtor1: Type.Ctor2[F] = FCtor
 
-    val enumP1 = Enum.parse(using FCtor.apply[Int, Int].asInstanceOf[Type[Any]]).toEither match {
-      case Right(e) => e; case Left(_) => return MIO.fail(new RuntimeException("Cannot parse F[Int,Int]"))
-    }
-    val enumP2 = Enum.parse(using FCtor.apply[String, Int].asInstanceOf[Type[Any]]).toEither match {
-      case Right(e) => e; case Left(_) => return MIO.fail(new RuntimeException("Cannot parse F[String,Int]"))
-    }
-    val enumP3 = Enum.parse(using FCtor.apply[Int, String].asInstanceOf[Type[Any]]).toEither match {
-      case Right(e) => e; case Left(_) => return MIO.fail(new RuntimeException("Cannot parse F[Int,String]"))
+    val ((enumP1, enumP2), enumP3) = runSafe {
+      parseEnumMIO[Any]("F[Int, Int]")(using FCtor.apply[Int, Int].asInstanceOf[Type[Any]])
+        .parTuple(parseEnumMIO[Any]("F[String, Int]")(using FCtor.apply[String, Int].asInstanceOf[Type[Any]]))
+        .parTuple(parseEnumMIO[Any]("F[Int, String]")(using FCtor.apply[Int, String].asInstanceOf[Type[Any]]))
     }
 
     case class BiChildInfo(leftFields: Set[String], rightFields: Set[String])
@@ -403,7 +404,7 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
             import matched.{value as cv, Underlying as CT}
             val cn = Type[CT].shortName
             childInfo.get(cn) match {
-              case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
+              case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Bitraverse", cn))
               case Some(info) =>
                 CaseClass.parse[CT].toEither match {
                   case Left(_)   => MIO.pure(cv.upcast[F[Any, Any]])
@@ -418,18 +419,15 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
                         (fn, Expr.quote(Expr.splice(gExpr)(Expr.splice(fe.upcast[Any])).asInstanceOf[Field]).as_??)
                       else (fn, fe.as_??)
                     }
-                    cc.primaryConstructor.fold(
-                      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                      onTypes = _ => Map.empty,
-                      onValues = _ => mapped.toMap
-                    ) match {
-                      case Right(e) => MIO.pure(e.value.asInstanceOf[Expr[F[Any, Any]]])
-                      case Left(e)  => MIO.fail(new RuntimeException(s"Cannot construct $cn: $e"))
-                    }
+                    constructInstanceFree(cc.primaryConstructor, "Constructor", cn)(mapped.toMap)
+                      .map(e => e.value.asInstanceOf[Expr[F[Any, Any]]])
                 }
             }
           }
-          .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
+          .flatMap {
+            case Some(r) => MIO.pure(r)
+            case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any, Any]].prettyPrint))
+          }
       }
 
     def mkBifoldLeftBody(
@@ -443,7 +441,7 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
           import matched.{value as cv, Underlying as CT}
           val cn = Type[CT].shortName
           childInfo.get(cn) match {
-            case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
+            case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Bitraverse", cn))
             case Some(info) =>
               CaseClass.parse[CT].toEither match {
                 case Left(_)   => MIO.pure(cExpr)
@@ -462,7 +460,10 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
               }
           }
         }
-        .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
+        .flatMap {
+          case Some(r) => MIO.pure(r)
+          case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any, Any]].prettyPrint))
+        }
     }
 
     def mkBifoldRightBody(
@@ -476,7 +477,7 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
           import matched.{value as cv, Underlying as CT}
           val cn = Type[CT].shortName
           childInfo.get(cn) match {
-            case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
+            case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Bitraverse", cn))
             case Some(info) =>
               CaseClass.parse[CT].toEither match {
                 case Left(_)   => MIO.pure(lcExpr)
@@ -496,7 +497,10 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
               }
           }
         }
-        .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
+        .flatMap {
+          case Some(r) => MIO.pure(r)
+          case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any, Any]].prettyPrint))
+        }
     }
 
     def mkBitraverseBody(
@@ -510,7 +514,7 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
           import matched.{value as cv, Underlying as CT}
           val cn = Type[CT].shortName
           childInfo.get(cn) match {
-            case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
+            case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Bitraverse", cn))
             case Some(info) =>
               CaseClass.parse[CT].toEither match {
                 case Left(_) =>
@@ -553,30 +557,33 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
                         .upcast[Any]
                     )
                   } else {
+                    // LambdaBuilder callbacks are synchronous and cannot return MIO, so failures
+                    // inside the callback throw the typed CatsDerivationError; the enclosing
+                    // MIO(...) converts the NonFatal throw into an MIO error-channel failure.
                     val reconLambda: Expr[List[Any] => Any] = runSafe {
-                      val lambda = LambdaBuilder.of1[List[Any]]("newVals").buildWith { nvExpr =>
-                        var currentList: Expr[List[Any]] = nvExpr
-                        val fieldExprs: List[(String, Expr_??)] = fields.map { case (fn2, fv2) =>
-                          import fv2.Underlying as Field2
-                          if (covariantFields.contains(fn2)) {
-                            val h = Expr.quote(Expr.splice(currentList).head)
-                            val t = Expr.quote(Expr.splice(currentList).tail)
-                            currentList = t
-                            (fn2, Expr.quote(Expr.splice(h).asInstanceOf[Field2]).as_??)
-                          } else {
-                            (fn2, fv2.value.asInstanceOf[Expr[Field2]].as_??)
+                      MIO {
+                        LambdaBuilder.of1[List[Any]]("newVals").buildWith { nvExpr =>
+                          var currentList: Expr[List[Any]] = nvExpr
+                          val fieldExprs: List[(String, Expr_??)] = fields.map { case (fn2, fv2) =>
+                            import fv2.Underlying as Field2
+                            if (covariantFields.contains(fn2)) {
+                              val h = Expr.quote(Expr.splice(currentList).head)
+                              val t = Expr.quote(Expr.splice(currentList).tail)
+                              currentList = t
+                              (fn2, Expr.quote(Expr.splice(h).asInstanceOf[Field2]).as_??)
+                            } else {
+                              (fn2, fv2.value.asInstanceOf[Expr[Field2]].as_??)
+                            }
+                          }
+                          foldInstanceFree(cc.primaryConstructor, "Constructor")(
+                            onTypes = _ => Map.empty,
+                            onValues = _ => fieldExprs.toMap
+                          ) match {
+                            case Right(e) => e.value.asInstanceOf[Expr[Any]]
+                            case Left(e)  => throw CatsDerivationError.CannotConstructResult(cn, e)
                           }
                         }
-                        cc.primaryConstructor.fold(
-                          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                          onTypes = _ => Map.empty,
-                          onValues = _ => fieldExprs.toMap
-                        ) match {
-                          case Right(e) => e.value.asInstanceOf[Expr[Any]]
-                          case Left(e)  => throw new RuntimeException(s"Cannot construct $cn: $e")
-                        }
                       }
-                      MIO.pure(lambda)
                     }
                     val gListExpr = gFieldExprs.foldRight(
                       Expr.quote(
@@ -606,7 +613,10 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
               }
           }
         }
-        .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
+        .flatMap {
+          case Some(r) => MIO.pure(r)
+          case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any, Any]].prettyPrint))
+        }
     }
 
     MIO.pure {

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationError.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationError.scala
@@ -5,10 +5,7 @@ package hearth.kindlings.catsderivation.internal.compiletime
   * Routed through the MIO error channel (`Log.error(err.message) >> MIO.fail(err)`) instead of throwing, so that the
   * compiler reports a proper derivation error rather than crashing.
   */
-sealed private[compiletime] trait CatsDerivationError
-    extends util.control.NoStackTrace
-    with Product
-    with Serializable {
+sealed private[compiletime] trait CatsDerivationError extends util.control.NoStackTrace with Product with Serializable {
   def message: String
   override def getMessage(): String = message
 }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationError.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationError.scala
@@ -1,0 +1,71 @@
+package hearth.kindlings.catsderivation.internal.compiletime
+
+/** Macro-time derivation errors shared by all cats-derivation macros.
+  *
+  * Routed through the MIO error channel (`Log.error(err.message) >> MIO.fail(err)`) instead of throwing, so that the
+  * compiler reports a proper derivation error rather than crashing.
+  */
+sealed private[compiletime] trait CatsDerivationError
+    extends util.control.NoStackTrace
+    with Product
+    with Serializable {
+  def message: String
+  override def getMessage(): String = message
+}
+private[compiletime] object CatsDerivationError {
+
+  /** A probe type (e.g. `F[Int]`, `F[A]`, an enum child) could not be parsed as a case class. */
+  final case class CannotParseCaseClass(tpeName: String, reason: String) extends CatsDerivationError {
+    override def message: String = s"Cannot parse $tpeName as a case class: $reason"
+  }
+
+  /** A type could not be parsed as an enum (sealed trait / Scala 3 enum). */
+  final case class CannotParseEnum(tpeName: String, reason: String) extends CatsDerivationError {
+    override def message: String = s"Cannot parse $tpeName as an enum: $reason"
+  }
+
+  /** Calling the primary constructor (or another instance-free method) failed. */
+  final case class CannotConstructResult(tpeName: String, reason: String) extends CatsDerivationError {
+    override def message: String = s"Cannot construct $tpeName: $reason"
+  }
+
+  /** No implicit instance could be summoned (nor derived) for a field. */
+  final case class MissingInstanceForField(
+      typeClassName: String,
+      fieldName: String,
+      ownerName: String,
+      reason: Option[String] = None
+  ) extends CatsDerivationError {
+    override def message: String =
+      s"Cannot find or derive $typeClassName for field $fieldName in $ownerName" +
+        reason.fold("")(r => s": $r")
+  }
+
+  /** A self-recursive field was classified, but no self-instance reference was provided to the body builder. */
+  final case class MissingSelfReference(typeClassName: String) extends CatsDerivationError {
+    override def message: String =
+      s"Self-recursive field encountered but no self $typeClassName reference is available"
+  }
+
+  /** A field's shape is not supported by the derivation (e.g. not direct/invariant/nested in classification). */
+  final case class UnsupportedFieldShape(typeClassName: String, fieldName: String, detail: String)
+      extends CatsDerivationError {
+    override def message: String =
+      s"Unsupported field shape for $typeClassName derivation at field '$fieldName': $detail"
+  }
+
+  /** Enum dispatch found a child for which no derivation info was prepared. */
+  final case class MissingDerivationInfo(typeClassName: String, childName: String) extends CatsDerivationError {
+    override def message: String = s"No $typeClassName derivation info for enum child $childName"
+  }
+
+  /** Enum has no children to match on. */
+  final case class EnumHasNoChildren(tpeName: String) extends CatsDerivationError {
+    override def message: String = s"Enum $tpeName has no children to match on"
+  }
+
+  /** Catch-all for shapes that do not fit the cases above. */
+  final case class DerivationFailed(typeClassName: String, detail: String) extends CatsDerivationError {
+    override def message: String = s"$typeClassName derivation failed: $detail"
+  }
+}

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationErrorSupport.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationErrorSupport.scala
@@ -14,18 +14,18 @@ private[compiletime] trait CatsDerivationErrorSupport extends hearth.kindlings.d
   import CatsDerivationError.*
 
   /** Logs the error and fails the MIO computation with it. */
-  protected final def failDerivation[A](err: CatsDerivationError): MIO[A] =
+  final protected def failDerivation[A](err: CatsDerivationError): MIO[A] =
     Log.error(err.message) >> MIO.fail(err)
 
   /** Parses `A` as a case class or fails the derivation with [[CatsDerivationError.CannotParseCaseClass]]. */
-  protected final def parseCaseClassMIO[A: Type](label: => String): MIO[CaseClass[A]] =
+  final protected def parseCaseClassMIO[A: Type](label: => String): MIO[CaseClass[A]] =
     CaseClass.parse[A].toEither match {
       case Right(cc) => MIO.pure(cc)
       case Left(e)   => failDerivation(CannotParseCaseClass(label, e.toString))
     }
 
   /** Parses `A` as an enum or fails the derivation with [[CatsDerivationError.CannotParseEnum]]. */
-  protected final def parseEnumMIO[A: Type](label: => String): MIO[Enum[A]] =
+  final protected def parseEnumMIO[A: Type](label: => String): MIO[Enum[A]] =
     Enum.parse[A].toEither match {
       case Right(e)  => MIO.pure(e)
       case Left(err) => failDerivation(CannotParseEnum(label, err.toString))
@@ -34,7 +34,7 @@ private[compiletime] trait CatsDerivationErrorSupport extends hearth.kindlings.d
   /** Calls an instance-free method (usually the primary constructor) with the given arguments, failing the derivation
     * with [[CatsDerivationError.CannotConstructResult]] on any error (including the impossible instance branch).
     */
-  protected final def constructInstanceFree(method: Method, what: String, tpeName: => String)(
+  final protected def constructInstanceFree(method: Method, what: String, tpeName: => String)(
       values: Map[String, Expr_??]
   ): MIO[Expr_??] =
     foldInstanceFree(method, what)(onTypes = _ => Map.empty, onValues = _ => values) match {

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationErrorSupport.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/CatsDerivationErrorSupport.scala
@@ -1,0 +1,44 @@
+package hearth.kindlings.catsderivation.internal.compiletime
+
+import hearth.MacroCommons
+import hearth.fp.effect.*
+
+/** Shared helpers routing macro-time failures into the MIO error channel.
+  *
+  * Replaces the historical `throw new RuntimeException(...)` calls (which crashed the compiler) with proper
+  * [[CatsDerivationError]] failures reported through Hearth's MIO error channel.
+  */
+private[compiletime] trait CatsDerivationErrorSupport extends hearth.kindlings.derivation.compiletime.MethodFolds {
+  this: MacroCommons =>
+
+  import CatsDerivationError.*
+
+  /** Logs the error and fails the MIO computation with it. */
+  protected final def failDerivation[A](err: CatsDerivationError): MIO[A] =
+    Log.error(err.message) >> MIO.fail(err)
+
+  /** Parses `A` as a case class or fails the derivation with [[CatsDerivationError.CannotParseCaseClass]]. */
+  protected final def parseCaseClassMIO[A: Type](label: => String): MIO[CaseClass[A]] =
+    CaseClass.parse[A].toEither match {
+      case Right(cc) => MIO.pure(cc)
+      case Left(e)   => failDerivation(CannotParseCaseClass(label, e.toString))
+    }
+
+  /** Parses `A` as an enum or fails the derivation with [[CatsDerivationError.CannotParseEnum]]. */
+  protected final def parseEnumMIO[A: Type](label: => String): MIO[Enum[A]] =
+    Enum.parse[A].toEither match {
+      case Right(e)  => MIO.pure(e)
+      case Left(err) => failDerivation(CannotParseEnum(label, err.toString))
+    }
+
+  /** Calls an instance-free method (usually the primary constructor) with the given arguments, failing the derivation
+    * with [[CatsDerivationError.CannotConstructResult]] on any error (including the impossible instance branch).
+    */
+  protected final def constructInstanceFree(method: Method, what: String, tpeName: => String)(
+      values: Map[String, Expr_??]
+  ): MIO[Expr_??] =
+    foldInstanceFree(method, what)(onTypes = _ => Map.empty, onValues = _ => values) match {
+      case Right(expr) => MIO.pure(expr)
+      case Left(error) => failDerivation(CannotConstructResult(tpeName, error))
+    }
+}

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ConsKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ConsKMacrosImpl.scala
@@ -17,7 +17,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   *
   * Uses erased approach: builds body for F[Any] with Any, wraps with asInstanceOf.
   */
-trait ConsKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait ConsKMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   /** Bridge method: summon ConsK for the type constructor of a nested field type.
     *
@@ -46,14 +47,8 @@ trait ConsKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
               implicit val IntType: Type[Int] = ConsKTypes.Int
               implicit val StringType: Type[String] = ConsKTypes.String
 
-              val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-              }
-              val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-              }
+              val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+              val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
               val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
               val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -78,10 +73,15 @@ trait ConsKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
               }
 
               if (directFields.isEmpty && nestedFieldConsKs.isEmpty) {
-                throw new RuntimeException(
-                  "Cannot derive ConsK: no type-parameter-dependent fields found. " +
-                    "Need at least one field of type A or G[A] where ConsK[G] exists."
-                )
+                runSafe {
+                  failDerivation[Unit](
+                    CatsDerivationError.DerivationFailed(
+                      "ConsK",
+                      "no type-parameter-dependent fields found - " +
+                        "need at least one field of type A or G[A] where ConsK[G] exists"
+                    )
+                  )
+                }
               }
 
               val directFieldSet: Set[String] = directFields.toSet
@@ -108,9 +108,10 @@ trait ConsKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
               }
             }
           case Left(reason) =>
-            MIO.fail(
-              new RuntimeException(
-                s"$macroName: Cannot derive for type: $reason. Can only be derived for case classes."
+            failDerivation(
+              CatsDerivationError.CannotParseCaseClass(
+                Type[F[Any]].prettyPrint,
+                s"$reason. $macroName can only be derived for case classes."
               )
             )
         }
@@ -178,23 +179,16 @@ trait ConsKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdEx
     }
 
     if (carried.isDefined) {
-      MIO.fail(
-        new RuntimeException(
-          "Cannot derive ConsK: no container field found to absorb the consed element. " +
-            "Need at least one field of type G[A] where ConsK[G] exists (e.g., List[A], Vector[A])."
+      failDerivation(
+        CatsDerivationError.DerivationFailed(
+          "ConsK",
+          "no container field found to absorb the consed element - " +
+            "need at least one field of type G[A] where ConsK[G] exists (e.g., List[A], Vector[A])"
         )
       )
     } else {
-      caseClass.primaryConstructor.fold(
-        onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-        onTypes = _ => Map.empty,
-        onValues = _ => resultFields.toMap
-      ) match {
-        case Right(constructExpr) =>
-          MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-        case Left(error) =>
-          MIO.fail(new RuntimeException(s"Cannot construct ConsK result: $error"))
-      }
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "ConsK result")(resultFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ContravariantMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ContravariantMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -12,7 +14,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * for method-level type parameters inside Expr.quote/Expr.splice. Supports Function1[A, R] fields where A is the type
   * parameter (contravariant position).
   */
-trait ContravariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait ContravariantMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveContravariant[F[_]](
@@ -30,14 +33,8 @@ trait ContravariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons
           implicit val IntType: Type[Int] = ContravariantTypes.Int
           implicit val StringType: Type[String] = ContravariantTypes.String
 
-          val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-          }
-          val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-          }
+          val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+          val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
           val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
           val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -49,47 +46,69 @@ trait ContravariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons
             Type.Ctor2.fromUntyped[Function1](impl.asUntyped)
           }
 
-          fieldsInt.zip(fieldsString).foreach { case ((name, pInt), (_, pString)) =>
-            val tInt = pInt.tpe.Underlying
-            val tString = pString.tpe.Underlying
-            if (tInt =:= tString) {
-              // Invariant field — no transformation needed
-            } else if (tInt =:= IntType && tString =:= StringType) {
-              throw new RuntimeException(
-                s"Cannot derive Contravariant: field '$name' uses the type parameter directly (covariant position). " +
-                  "Contravariant requires the type parameter to appear only in contravariant positions."
-              )
-            } else {
-              // Nested field — check if it's Function1 with A in contravariant position
-              (Function1Ctor2.unapply(tInt), Function1Ctor2.unapply(tString)) match {
-                case (Some((arg1Int, arg2Int)), Some((arg1String, arg2String))) =>
-                  import arg1Int.Underlying as A1Int
-                  import arg2Int.Underlying as A2Int
-                  import arg1String.Underlying as A1String
-                  import arg2String.Underlying as A2String
-
-                  val firstArgChanges = !(A1Int =:= A1String)
-                  val secondArgChanges = !(A2Int =:= A2String)
-
-                  if (firstArgChanges && !secondArgChanges) {
-                    contravariantFields += name
-                  } else if (!firstArgChanges && secondArgChanges) {
-                    throw new RuntimeException(
-                      s"Cannot derive Contravariant: field '$name' has the type parameter in covariant position " +
-                        "(Function1 return type)."
+          runSafe {
+            fieldsInt
+              .zip(fieldsString)
+              .traverse { case ((name, pInt), (_, pString)) =>
+                val tInt = pInt.tpe.Underlying
+                val tString = pString.tpe.Underlying
+                if (tInt =:= tString) {
+                  // Invariant field — no transformation needed
+                  MIO.void
+                } else if (tInt =:= IntType && tString =:= StringType) {
+                  failDerivation[Unit](
+                    CatsDerivationError.UnsupportedFieldShape(
+                      "Contravariant",
+                      name,
+                      "the field uses the type parameter directly (covariant position) - " +
+                        "Contravariant requires the type parameter to appear only in contravariant positions"
                     )
-                  } else {
-                    throw new RuntimeException(
-                      s"Cannot derive Contravariant: field '$name' has the type parameter in both positions of Function1."
-                    )
-                  }
-                case _ =>
-                  throw new RuntimeException(
-                    s"Cannot derive Contravariant: field '$name' contains a nested type constructor that is not Function1. " +
-                      "Only Function1[A, R] fields and invariant fields are currently supported."
                   )
+                } else {
+                  // Nested field — check if it's Function1 with A in contravariant position
+                  (Function1Ctor2.unapply(tInt), Function1Ctor2.unapply(tString)) match {
+                    case (Some((arg1Int, arg2Int)), Some((arg1String, arg2String))) =>
+                      import arg1Int.Underlying as A1Int
+                      import arg2Int.Underlying as A2Int
+                      import arg1String.Underlying as A1String
+                      import arg2String.Underlying as A2String
+
+                      val firstArgChanges = !(A1Int =:= A1String)
+                      val secondArgChanges = !(A2Int =:= A2String)
+
+                      if (firstArgChanges && !secondArgChanges) {
+                        contravariantFields += name
+                        MIO.void
+                      } else if (!firstArgChanges && secondArgChanges) {
+                        failDerivation[Unit](
+                          CatsDerivationError.UnsupportedFieldShape(
+                            "Contravariant",
+                            name,
+                            "the field has the type parameter in covariant position (Function1 return type)"
+                          )
+                        )
+                      } else {
+                        failDerivation[Unit](
+                          CatsDerivationError.UnsupportedFieldShape(
+                            "Contravariant",
+                            name,
+                            "the field has the type parameter in both positions of Function1"
+                          )
+                        )
+                      }
+                    case _ =>
+                      failDerivation[Unit](
+                        CatsDerivationError.UnsupportedFieldShape(
+                          "Contravariant",
+                          name,
+                          "the field contains a nested type constructor that is not Function1 - " +
+                            "only Function1[A, R] fields and invariant fields are currently supported"
+                        )
+                      )
+                  }
+                }
               }
-            }
+              .void
           }
 
           val contravariantFieldSet: Set[String] = contravariantFields.toSet
@@ -147,45 +166,30 @@ trait ContravariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
     implicit val FBType: Type[F[B]] = FCtor.apply[B]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val caseClassB = CaseClass.parse[F[B]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[B]: $e")
-    }
+    parseCaseClassMIO[F[A]]("F[A]").parTuple(parseCaseClassMIO[F[B]]("F[B]")).flatMap { case (caseClass, caseClassB) =>
+      val fields = caseClass.caseFieldValuesAt(faExpr).toList
+      val fieldsB = caseClassB.primaryConstructor.totalParameters.flatten.toList
 
-    val fields = caseClass.caseFieldValuesAt(faExpr).toList
-    val fieldsB = caseClassB.primaryConstructor.totalParameters.flatten.toList
+      val fieldBTypes: Map[String, Type[Any]] =
+        fieldsB.map { case (name, param) => (name, param.tpe.Underlying.asInstanceOf[Type[Any]]) }.toMap
 
-    val fieldBTypes: Map[String, Type[Any]] =
-      fieldsB.map { case (name, param) => (name, param.tpe.Underlying.asInstanceOf[Type[Any]]) }.toMap
+      val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
+        import fieldValue.Underlying as Field
+        val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
 
-    val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-
-      if (contravariantFields.contains(fieldName)) {
-        // Use F[B]'s field type — the composed tree produces the correct B-parameterized type at runtime
-        val bFieldType = fieldBTypes(fieldName).asInstanceOf[Type[Field]]
-        val composed: Expr[Field] =
-          mkComposeExpr[Field](fieldExpr.asInstanceOf[Expr[Any]], fExpr.asInstanceOf[Expr[Any]])(bFieldType)
-        (fieldName, composed.as_??(bFieldType))
-      } else {
-        (fieldName, fieldExpr.as_??)
+        if (contravariantFields.contains(fieldName)) {
+          // Use F[B]'s field type — the composed tree produces the correct B-parameterized type at runtime
+          val bFieldType = fieldBTypes(fieldName).asInstanceOf[Type[Field]]
+          val composed: Expr[Field] =
+            mkComposeExpr[Field](fieldExpr.asInstanceOf[Expr[Any]], fExpr.asInstanceOf[Expr[Any]])(bFieldType)
+          (fieldName, composed.as_??(bFieldType))
+        } else {
+          (fieldName, fieldExpr.as_??)
+        }
       }
-    }
 
-    caseClassB.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[B]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct contramapped result: $error"))
+      constructInstanceFree(caseClassB.primaryConstructor, "Constructor", "contramapped result")(mappedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[B]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyKMacrosImpl.scala
@@ -2,12 +2,15 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
 
 /** EmptyK derivation: constructs empty F[A] by summoning Empty for each field type in F[Any]. */
-trait EmptyKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait EmptyKMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveEmptyK[F[_]](FCtor0: Type.Ctor1[F], EmptyKFType: Type[alleycats.EmptyK[F]]): Expr[alleycats.EmptyK[F]] = {
@@ -38,9 +41,10 @@ trait EmptyKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdE
               }
             }
           case Left(reason) =>
-            MIO.fail(
-              new RuntimeException(
-                s"$macroName: Cannot derive for type: $reason. Can only be derived for case classes."
+            failDerivation(
+              CatsDerivationError.CannotParseCaseClass(
+                Type[F[Any]].prettyPrint,
+                s"$reason. $macroName can only be derived for case classes."
               )
             )
         }
@@ -66,29 +70,28 @@ trait EmptyKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdE
   )(implicit FCtor: Type.Ctor1[F], FAnyType: Type[F[Any]], AnyType: Type[Any]): MIO[Expr[F[Any]]] = {
     val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
 
-    val fieldExprs: List[(String, Expr_??)] = fields.map { case (fieldName, param) =>
+    val fieldExprsMIO: MIO[List[(String, Expr_??)]] = fields.traverse { case (fieldName, param) =>
       import param.tpe.Underlying as Field
 
-      val emptyExpr = EmptyKTypes.Empty[Field].summonExprIgnoring().toEither match {
-        case Right(e)     => e
+      EmptyKTypes.Empty[Field].summonExprIgnoring().toEither match {
+        case Right(emptyExpr) =>
+          val value: Expr[Field] = Expr.quote(Expr.splice(emptyExpr).empty)
+          MIO.pure((fieldName, value.as_??))
         case Left(reason) =>
-          throw new RuntimeException(
-            s"No Empty instance found for field '$fieldName': ${Field.prettyPrint}: $reason"
+          failDerivation(
+            CatsDerivationError.MissingInstanceForField(
+              "Empty",
+              fieldName,
+              Type[F[Any]].prettyPrint,
+              Some(s"${Field.prettyPrint}: $reason")
+            )
           )
       }
-      val value: Expr[Field] = Expr.quote(Expr.splice(emptyExpr).empty)
-      (fieldName, value.as_??)
     }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => fieldExprs.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct empty result: $error"))
+    fieldExprsMIO.flatMap { fieldExprs =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "empty result")(fieldExprs.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyMacrosImpl.scala
@@ -14,7 +14,8 @@ trait EmptyMacrosImpl
     with rules.EmptyBuiltInRuleImpl
     with rules.EmptyCaseClassRuleImpl
     with rules.EmptyEnumRuleImpl
-    with CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+    with CatsDerivationTimeout
+    with CatsDerivationErrorSupport { this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used")
   def deriveEmpty[A: Type]: Expr[alleycats.Empty[A]] = {

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FoldableMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FoldableMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -11,7 +13,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * Uses free type variables A and B directly in the generated code, relying on Hearth 0.2.0-264+ cross-quotes support
   * for method-level type parameters inside Expr.quote/Expr.splice.
   */
-trait FoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait FoldableMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   protected def summonFoldableForFieldType(fieldType: Type[Any]): Option[Expr[Any]]
 
@@ -39,14 +42,8 @@ trait FoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
             implicit val IntType: Type[Int] = FoldableTypes.Int
             implicit val StringType: Type[String] = FoldableTypes.String
 
-            val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-              case Right(cc) => cc
-              case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-            }
-            val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-              case Right(cc) => cc
-              case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-            }
+            val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+            val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
             val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
             val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -78,10 +75,15 @@ trait FoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
                 }
               }
               if (unsupported.nonEmpty) {
-                throw new RuntimeException(
-                  s"Cannot derive Foldable: fields ${unsupported.mkString(", ")} contain nested type constructors " +
-                    "without Foldable instances."
-                )
+                runSafe {
+                  failDerivation[Unit](
+                    CatsDerivationError.UnsupportedFieldShape(
+                      "Foldable",
+                      unsupported.mkString(", "),
+                      "the fields contain nested type constructors without Foldable instances"
+                    )
+                  )
+                }
               }
             }
 
@@ -96,10 +98,7 @@ trait FoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
             implicit val FAnyType: Type[F[Any]] = FCtor.apply[Any]
             implicit val EvalAnyType: Type[cats.Eval[Any]] = FoldableTypes.EvalCtor.apply[Any]
 
-            val ccAny = CaseClass.parse[F[Any]].toEither match {
-              case Right(cc) => cc
-              case Left(e)   => throw new RuntimeException(s"Cannot parse F[Any]: $e")
-            }
+            val ccAny = runSafe(parseCaseClassMIO[F[Any]]("F[Any]"))
 
             val doFoldLeft: (Expr[F[Any]], Expr[Any], Expr[(Any, Any) => Any]) => Expr[Any] =
               (faExpr, bExpr, fExpr) =>
@@ -235,221 +234,252 @@ trait FoldableMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
 
     val parentCtor = FCtor.asUntyped
 
-    Enum.parse[F[Any]].toEither match {
-      case Left(reason) =>
-        MIO.fail(new RuntimeException(s"Cannot parse as enum for Foldable: $reason"))
-      case Right(enumm) =>
-        val enumInt = Enum.parse(using FCtor.apply[Int].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e
-          case Left(_)  => return MIO.fail(new RuntimeException("Cannot parse F[Int] as enum"))
-        }
-        val enumString = Enum.parse(using FCtor.apply[String].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e
-          case Left(_)  => return MIO.fail(new RuntimeException("Cannot parse F[String] as enum"))
-        }
+    parseEnumMIO[F[Any]]("F[Any]").flatMap { enumm =>
+      parseEnumMIO[Any]("F[Int]")(using FCtor.apply[Int].asInstanceOf[Type[Any]])
+        .parTuple(parseEnumMIO[Any]("F[String]")(using FCtor.apply[String].asInstanceOf[Type[Any]]))
+        .flatMap { case (enumInt, enumString) =>
+          case class ChildFieldInfo(
+              directFields: Set[String],
+              nestedFoldables: Map[String, Expr[Any]],
+              selfRecursiveFields: Set[String]
+          )
 
-        case class ChildFieldInfo(
-            directFields: Set[String],
-            nestedFoldables: Map[String, Expr[Any]],
-            selfRecursiveFields: Set[String]
-        )
+          val childInfo: Map[String, ChildFieldInfo] = runSafe {
+            val childrenInt = enumInt.directChildren.toList
+            val childrenString = enumString.directChildren.toList
 
-        val childInfo: Map[String, ChildFieldInfo] = runSafe {
-          val result = scala.collection.mutable.Map.empty[String, ChildFieldInfo]
-          val childrenInt = enumInt.directChildren.toList
-          val childrenString = enumString.directChildren.toList
-
-          childrenInt.zip(childrenString).foreach { case ((childName, childI), (_, childS)) =>
-            import childI.Underlying as ChildI
-            import childS.Underlying as ChildS
-            val ccI = CaseClass.parse[ChildI].toEither
-            val ccS = CaseClass.parse[ChildS].toEither
-            (ccI, ccS) match {
-              case (Right(cI), Right(cS)) =>
-                val fieldsI = cI.primaryConstructor.totalParameters.flatten.toList
-                val fieldsS = cS.primaryConstructor.totalParameters.flatten.toList
-                val direct = scala.collection.mutable.Set.empty[String]
-                val nested = scala.collection.mutable.Map.empty[String, Expr[Any]]
-                val selfRec = scala.collection.mutable.Set.empty[String]
-                fieldsI.zip(fieldsS).foreach { case ((name, pI), (_, pS)) =>
-                  val tI = pI.tpe.Underlying
-                  val tS = pS.tpe.Underlying
-                  if (tI =:= IntType && tS =:= StringType) direct += name
-                  else if (tI =:= tS) ()
-                  else {
-                    val param = fieldsI.find(_._1 == name).get._2
-                    import param.tpe.Underlying as FT
-                    summonFoldableForFieldType(Type[FT].asInstanceOf[Type[Any]]) match {
-                      case Some(expr) => nested += (name -> expr)
-                      case None       =>
-                        mkCtor1FromTypeFoldable(Type[FT].asInstanceOf[Type[Any]]) match {
-                          case Some(ut) if ut == parentCtor => selfRec += name
-                          case _ => throw new RuntimeException(s"No Foldable for nested field $name in $childName")
+            childrenInt
+              .zip(childrenString)
+              .traverse { case ((childName, childI), (_, childS)) =>
+                import childI.Underlying as ChildI
+                import childS.Underlying as ChildS
+                val ccI = CaseClass.parse[ChildI].toEither
+                val ccS = CaseClass.parse[ChildS].toEither
+                (ccI, ccS) match {
+                  case (Right(cI), Right(cS)) =>
+                    val fieldsI = cI.primaryConstructor.totalParameters.flatten.toList
+                    val fieldsS = cS.primaryConstructor.totalParameters.flatten.toList
+                    val direct = scala.collection.mutable.Set.empty[String]
+                    val nested = scala.collection.mutable.Map.empty[String, Expr[Any]]
+                    val selfRec = scala.collection.mutable.Set.empty[String]
+                    fieldsI
+                      .zip(fieldsS)
+                      .traverse { case ((name, pI), (_, pS)) =>
+                        val tI = pI.tpe.Underlying
+                        val tS = pS.tpe.Underlying
+                        if (tI =:= IntType && tS =:= StringType) {
+                          direct += name
+                          MIO.void
+                        } else if (tI =:= tS) MIO.void
+                        else {
+                          val param = fieldsI.find(_._1 == name).get._2
+                          import param.tpe.Underlying as FT
+                          summonFoldableForFieldType(Type[FT].asInstanceOf[Type[Any]]) match {
+                            case Some(expr) =>
+                              nested += (name -> expr)
+                              MIO.void
+                            case None =>
+                              mkCtor1FromTypeFoldable(Type[FT].asInstanceOf[Type[Any]]) match {
+                                case Some(ut) if ut == parentCtor =>
+                                  selfRec += name
+                                  MIO.void
+                                case _ =>
+                                  failDerivation[Unit](
+                                    CatsDerivationError.MissingInstanceForField("Foldable", name, childName)
+                                  )
+                              }
+                          }
                         }
-                    }
-                  }
+                      }
+                      .map(_ => childName -> ChildFieldInfo(direct.toSet, nested.toMap, selfRec.toSet))
+                  case _ =>
+                    MIO.pure(childName -> ChildFieldInfo(Set.empty, Map.empty, Set.empty))
                 }
-                result += (childName -> ChildFieldInfo(direct.toSet, nested.toMap, selfRec.toSet))
-              case _ =>
-                result += (childName -> ChildFieldInfo(Set.empty, Map.empty, Set.empty))
-            }
+              }
+              .map(_.toMap)
           }
-          MIO.pure(result.toMap)
-        }
 
-        val hasSelfRecursive = childInfo.values.exists(_.selfRecursiveFields.nonEmpty)
+          val hasSelfRecursive = childInfo.values.exists(_.selfRecursiveFields.nonEmpty)
 
-        import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
+          import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
 
-        def mkFoldLeftBody(
-            faExpr: Expr[F[Any]],
-            bExpr: Expr[Any],
-            fExpr: Expr[(Any, Any) => Any],
-            selfOpt: Option[Expr[Any]]
-        ): Expr[Any] = runSafe {
-          enumm
-            .matchOn[MIO, Any](faExpr) { matched =>
-              import matched.{value as caseValue, Underlying as CT}
-              val cn = Type[CT].shortName
-              childInfo.get(cn) match {
-                case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
-                case Some(info) =>
-                  val cc = CaseClass.parse[CT].toEither match {
-                    case Right(c) => c; case Left(e) => throw new RuntimeException(e.toString)
-                  }
-                  val fields = cc.caseFieldValuesAt(caseValue).toList
-                  var result: Expr[Any] = bExpr
-                  fields.foreach { case (fn, fv) =>
-                    import fv.Underlying as Field
-                    val fe = fv.value.asInstanceOf[Expr[Field]]
-                    if (info.directFields.contains(fn))
-                      result = Expr.quote(Expr.splice(fExpr)(Expr.splice(result), Expr.splice(fe.upcast[Any])))
-                    else if (info.selfRecursiveFields.contains(fn) || info.nestedFoldables.contains(fn)) {
-                      val foldableE =
-                        if (info.selfRecursiveFields.contains(fn))
-                          selfOpt.getOrElse(throw new RuntimeException("No self"))
-                        else info.nestedFoldables(fn)
-                      result = Expr.quote {
-                        hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                          .foldLeftNested(
-                            Expr.splice(foldableE),
-                            Expr.splice(fe.upcast[Any]),
-                            Expr.splice(result),
-                            Expr.splice(fExpr)
-                          )
+          def mkFoldLeftBody(
+              faExpr: Expr[F[Any]],
+              bExpr: Expr[Any],
+              fExpr: Expr[(Any, Any) => Any],
+              selfOpt: Option[Expr[Any]]
+          ): Expr[Any] = runSafe {
+            val selfOrFail: MIO[Expr[Any]] = selfOpt match {
+              case Some(self) => MIO.pure(self)
+              case None       => failDerivation(CatsDerivationError.MissingSelfReference("Foldable"))
+            }
+            enumm
+              .matchOn[MIO, Any](faExpr) { matched =>
+                import matched.{value as caseValue, Underlying as CT}
+                val cn = Type[CT].shortName
+                childInfo.get(cn) match {
+                  case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Foldable", cn))
+                  case Some(info) =>
+                    parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
+                      val fields = cc.caseFieldValuesAt(caseValue).toList
+                      var result: Expr[Any] = bExpr
+                      fields
+                        .traverse { case (fn, fv) =>
+                          import fv.Underlying as Field
+                          val fe = fv.value.asInstanceOf[Expr[Field]]
+                          if (info.directFields.contains(fn)) {
+                            result = Expr.quote(Expr.splice(fExpr)(Expr.splice(result), Expr.splice(fe.upcast[Any])))
+                            MIO.void
+                          } else if (info.selfRecursiveFields.contains(fn) || info.nestedFoldables.contains(fn)) {
+                            val foldableEMIO: MIO[Expr[Any]] =
+                              if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                              else MIO.pure(info.nestedFoldables(fn))
+                            foldableEMIO.map { foldableE =>
+                              result = Expr.quote {
+                                hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                  .foldLeftNested(
+                                    Expr.splice(foldableE),
+                                    Expr.splice(fe.upcast[Any]),
+                                    Expr.splice(result),
+                                    Expr.splice(fExpr)
+                                  )
+                              }
+                            }
+                          } else MIO.void
+                        }
+                        .map(_ => result)
+                    }
+                }
+              }
+              .flatMap {
+                case Some(r) => MIO.pure(r)
+                case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any]].prettyPrint))
+              }
+          }
+
+          def mkFoldRightBody(
+              faExpr: Expr[F[Any]],
+              lbExpr: Expr[cats.Eval[Any]],
+              fExpr: Expr[(Any, cats.Eval[Any]) => cats.Eval[Any]],
+              selfOpt: Option[Expr[Any]]
+          ): Expr[cats.Eval[Any]] = runSafe {
+            val selfOrFail: MIO[Expr[Any]] = selfOpt match {
+              case Some(self) => MIO.pure(self)
+              case None       => failDerivation(CatsDerivationError.MissingSelfReference("Foldable"))
+            }
+            enumm
+              .matchOn[MIO, cats.Eval[Any]](faExpr) { matched =>
+                import matched.{value as caseValue, Underlying as CT}
+                val cn = Type[CT].shortName
+                childInfo.get(cn) match {
+                  case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Foldable", cn))
+                  case Some(info) =>
+                    parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
+                      val fields = cc.caseFieldValuesAt(caseValue).toList
+                      val foldableMIO: MIO[List[Option[(String, Expr[Any], Option[Expr[Any]])]]] =
+                        fields.traverse { case (fn, fv) =>
+                          import fv.Underlying as Field
+                          if (info.directFields.contains(fn))
+                            MIO.pure(
+                              Option(
+                                (fn, fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option.empty[Expr[Any]])
+                              )
+                            )
+                          else if (info.selfRecursiveFields.contains(fn) || info.nestedFoldables.contains(fn)) {
+                            val feMIO: MIO[Expr[Any]] =
+                              if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                              else MIO.pure(info.nestedFoldables(fn))
+                            feMIO.map { fe =>
+                              Option((fn, fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option(fe)))
+                            }
+                          } else MIO.pure(Option.empty[(String, Expr[Any], Option[Expr[Any]])])
+                        }
+                      foldableMIO.map { foldableOpts =>
+                        foldableOpts.flatten.foldRight(lbExpr) { case ((_, fieldExpr, foldableOpt), acc) =>
+                          foldableOpt match {
+                            case None =>
+                              Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr), Expr.splice(acc)))
+                            case Some(foldableE) =>
+                              Expr.quote {
+                                hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                  .foldRightNested(
+                                    Expr.splice(foldableE),
+                                    Expr.splice(fieldExpr),
+                                    Expr.splice(acc),
+                                    Expr.splice(fExpr)
+                                  )
+                              }
+                          }
+                        }
                       }
                     }
-                  }
-                  MIO.pure(result)
+                }
               }
-            }
-            .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
-        }
-
-        def mkFoldRightBody(
-            faExpr: Expr[F[Any]],
-            lbExpr: Expr[cats.Eval[Any]],
-            fExpr: Expr[(Any, cats.Eval[Any]) => cats.Eval[Any]],
-            selfOpt: Option[Expr[Any]]
-        ): Expr[cats.Eval[Any]] = runSafe {
-          enumm
-            .matchOn[MIO, cats.Eval[Any]](faExpr) { matched =>
-              import matched.{value as caseValue, Underlying as CT}
-              val cn = Type[CT].shortName
-              childInfo.get(cn) match {
-                case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
-                case Some(info) =>
-                  val cc = CaseClass.parse[CT].toEither match {
-                    case Right(c) => c; case Left(e) => throw new RuntimeException(e.toString)
-                  }
-                  val fields = cc.caseFieldValuesAt(caseValue).toList
-                  val foldable: List[(String, Expr[Any], Option[Expr[Any]])] = fields.collect {
-                    case (fn, fv) if info.directFields.contains(fn) =>
-                      import fv.Underlying as Field
-                      (fn, fv.value.asInstanceOf[Expr[Field]].upcast[Any], None)
-                    case (fn, fv) if info.selfRecursiveFields.contains(fn) || info.nestedFoldables.contains(fn) =>
-                      import fv.Underlying as Field
-                      val fe =
-                        if (info.selfRecursiveFields.contains(fn))
-                          selfOpt.getOrElse(throw new RuntimeException("No self"))
-                        else info.nestedFoldables(fn)
-                      (fn, fv.value.asInstanceOf[Expr[Field]].upcast[Any], Some(fe))
-                  }
-                  val result = foldable.foldRight(lbExpr) { case ((_, fieldExpr, foldableOpt), acc) =>
-                    foldableOpt match {
-                      case None =>
-                        Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr), Expr.splice(acc)))
-                      case Some(foldableE) =>
-                        Expr.quote {
-                          hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                            .foldRightNested(
-                              Expr.splice(foldableE),
-                              Expr.splice(fieldExpr),
-                              Expr.splice(acc),
-                              Expr.splice(fExpr)
-                            )
-                        }
-                    }
-                  }
-                  MIO.pure(result)
+              .flatMap {
+                case Some(r) => MIO.pure(r)
+                case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any]].prettyPrint))
               }
-            }
-            .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
-        }
+          }
 
-        if (hasSelfRecursive) {
-          MIO.pure {
-            Expr.quote {
-              var self$macro: Any = null
-              self$macro = CatsDerivationFactories.foldableInstance[F](
-                foldLeftFn = { (fa: F[CatsDerivationFactories.W1], bAny: Any, fAny: (Any, Any) => Any) =>
-                  val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-                  val _ = anyFa; val _ = bAny; val _ = fAny
-                  Expr.splice(
-                    mkFoldLeftBody(Expr.quote(anyFa), Expr.quote(bAny), Expr.quote(fAny), Some(Expr.quote(self$macro)))
-                  )
-                },
-                foldRightFn = {
-                  (
-                      fa: F[CatsDerivationFactories.W1],
-                      lbAny: cats.Eval[Any],
-                      fAny: (Any, cats.Eval[Any]) => cats.Eval[Any]
-                  ) =>
+          if (hasSelfRecursive) {
+            MIO.pure {
+              Expr.quote {
+                var self$macro: Any = null
+                self$macro = CatsDerivationFactories.foldableInstance[F](
+                  foldLeftFn = { (fa: F[CatsDerivationFactories.W1], bAny: Any, fAny: (Any, Any) => Any) =>
                     val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-                    val _ = anyFa; val _ = lbAny; val _ = fAny
+                    val _ = anyFa; val _ = bAny; val _ = fAny
                     Expr.splice(
-                      mkFoldRightBody(
+                      mkFoldLeftBody(
                         Expr.quote(anyFa),
-                        Expr.quote(lbAny),
+                        Expr.quote(bAny),
                         Expr.quote(fAny),
                         Some(Expr.quote(self$macro))
                       )
                     )
-                }
-              )
-              self$macro.asInstanceOf[cats.Foldable[F]]
+                  },
+                  foldRightFn = {
+                    (
+                        fa: F[CatsDerivationFactories.W1],
+                        lbAny: cats.Eval[Any],
+                        fAny: (Any, cats.Eval[Any]) => cats.Eval[Any]
+                    ) =>
+                      val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
+                      val _ = anyFa; val _ = lbAny; val _ = fAny
+                      Expr.splice(
+                        mkFoldRightBody(
+                          Expr.quote(anyFa),
+                          Expr.quote(lbAny),
+                          Expr.quote(fAny),
+                          Some(Expr.quote(self$macro))
+                        )
+                      )
+                  }
+                )
+                self$macro.asInstanceOf[cats.Foldable[F]]
+              }
             }
-          }
-        } else {
-          MIO.pure {
-            Expr.quote {
-              CatsDerivationFactories.foldableInstance[F](
-                foldLeftFn = { (fa: F[CatsDerivationFactories.W1], bAny: Any, fAny: (Any, Any) => Any) =>
-                  val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-                  val _ = anyFa; val _ = bAny; val _ = fAny
-                  Expr.splice(mkFoldLeftBody(Expr.quote(anyFa), Expr.quote(bAny), Expr.quote(fAny), None))
-                },
-                foldRightFn = {
-                  (
-                      fa: F[CatsDerivationFactories.W1],
-                      lbAny: cats.Eval[Any],
-                      fAny: (Any, cats.Eval[Any]) => cats.Eval[Any]
-                  ) =>
+          } else {
+            MIO.pure {
+              Expr.quote {
+                CatsDerivationFactories.foldableInstance[F](
+                  foldLeftFn = { (fa: F[CatsDerivationFactories.W1], bAny: Any, fAny: (Any, Any) => Any) =>
                     val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-                    val _ = anyFa; val _ = lbAny; val _ = fAny
-                    Expr.splice(mkFoldRightBody(Expr.quote(anyFa), Expr.quote(lbAny), Expr.quote(fAny), None))
-                }
-              )
+                    val _ = anyFa; val _ = bAny; val _ = fAny
+                    Expr.splice(mkFoldLeftBody(Expr.quote(anyFa), Expr.quote(bAny), Expr.quote(fAny), None))
+                  },
+                  foldRightFn = {
+                    (
+                        fa: F[CatsDerivationFactories.W1],
+                        lbAny: cats.Eval[Any],
+                        fAny: (Any, cats.Eval[Any]) => cats.Eval[Any]
+                    ) =>
+                      val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
+                      val _ = anyFa; val _ = lbAny; val _ = fAny
+                      Expr.splice(mkFoldRightBody(Expr.quote(anyFa), Expr.quote(lbAny), Expr.quote(fAny), None))
+                  }
+                )
+              }
             }
           }
         }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -11,7 +13,10 @@ import hearth.kindlings.catsderivation.LogDerivation
   * Uses free type variables A and B directly in the generated code, relying on Hearth 0.2.0-264+ cross-quotes support
   * for method-level type parameters inside Expr.quote/Expr.splice.
   */
-trait FunctorMacrosImpl extends rules.FunctorCaseClassRuleImpl with CatsDerivationTimeout {
+trait FunctorMacrosImpl
+    extends rules.FunctorCaseClassRuleImpl
+    with CatsDerivationTimeout
+    with CatsDerivationErrorSupport {
   this: MacroCommons & StdExtensions =>
 
   protected def summonFunctorForFieldType(fieldType: Type[Any]): Option[Expr[Any]]
@@ -171,83 +176,75 @@ trait FunctorMacrosImpl extends rules.FunctorCaseClassRuleImpl with CatsDerivati
     implicit val FBType: Type[F[B]] = FCtor.apply[B]
     implicit val AnyType: Type[Any] = FunctorTypes.Any
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
+    val selfOrFail: MIO[Expr[Any]] = selfOpt match {
+      case Some(self) => MIO.pure(self)
+      case None       => failDerivation(CatsDerivationError.MissingSelfReference("Functor"))
     }
-    val caseClassB = CaseClass.parse[F[B]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[B]: $e")
-    }
-    val bFieldMap = caseClassB.primaryConstructor.totalParameters.flatten.toMap
 
-    val fields = caseClass.caseFieldValuesAt(faExpr).toList
+    parseCaseClassMIO[F[A]]("F[A]").parTuple(parseCaseClassMIO[F[B]]("F[B]")).flatMap { case (caseClass, caseClassB) =>
+      val bFieldMap = caseClassB.primaryConstructor.totalParameters.flatten.toMap
 
-    val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+      val fields = caseClass.caseFieldValuesAt(faExpr).toList
 
-      if (directFields.contains(fieldName)) {
-        val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
-        (fieldName, mapped.as_??)
-      } else if (selfRecursiveFields.contains(fieldName) && selfRecursiveOuterFunctors.contains(fieldName)) {
-        // Self-recursive nested field: e.g. Option[Search[A]] where Search is the parent.
-        // Use outerFunctor.map(field)(inner => self.map(inner)(f))
-        val outerFunctorExpr = selfRecursiveOuterFunctors(fieldName)
-        val selfExpr = selfOpt.getOrElse(
-          throw new RuntimeException("Self-recursive field but no self Functor reference")
-        )
-        val nestedResult: Expr[Any] = Expr.quote {
-          hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-            .mapNestedSelfRecursive(
-              Expr.splice(outerFunctorExpr),
-              Expr.splice(selfExpr),
-              Expr.splice(fieldExpr.upcast[Any]),
-              Expr.splice(fExpr.asInstanceOf[Expr[Any => Any]])
-            )
+      val mappedFieldsMIO: MIO[List[(String, Expr_??)]] = fields.traverse { case (fieldName, fieldValue) =>
+        import fieldValue.Underlying as Field
+        val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+
+        if (directFields.contains(fieldName)) {
+          val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
+          MIO.pure((fieldName, mapped.as_??))
+        } else if (selfRecursiveFields.contains(fieldName) && selfRecursiveOuterFunctors.contains(fieldName)) {
+          // Self-recursive nested field: e.g. Option[Search[A]] where Search is the parent.
+          // Use outerFunctor.map(field)(inner => self.map(inner)(f))
+          val outerFunctorExpr = selfRecursiveOuterFunctors(fieldName)
+          selfOrFail.map { selfExpr =>
+            val nestedResult: Expr[Any] = Expr.quote {
+              hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                .mapNestedSelfRecursive(
+                  Expr.splice(outerFunctorExpr),
+                  Expr.splice(selfExpr),
+                  Expr.splice(fieldExpr.upcast[Any]),
+                  Expr.splice(fExpr.asInstanceOf[Expr[Any => Any]])
+                )
+            }
+            val bParam = bFieldMap(fieldName)
+            (fieldName, castAnyToTyped(nestedResult, bParam.tpe))
+          }
+        } else if (selfRecursiveFields.contains(fieldName)) {
+          // Direct self-recursive field (no outer wrapper): e.g. F[A] itself
+          selfOrFail.map { selfExpr =>
+            val nestedResult: Expr[Any] = Expr.quote {
+              hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                .mapNested(
+                  Expr.splice(selfExpr),
+                  Expr.splice(fieldExpr.upcast[Any]),
+                  Expr.splice(fExpr.asInstanceOf[Expr[Any => Any]])
+                )
+            }
+            val bParam = bFieldMap(fieldName)
+            (fieldName, castAnyToTyped(nestedResult, bParam.tpe))
+          }
+        } else if (nestedFieldFunctors.contains(fieldName)) {
+          val functorExpr = nestedFieldFunctors(fieldName)
+          val nestedResult: Expr[Any] = Expr.quote {
+            hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+              .mapNested(
+                Expr.splice(functorExpr),
+                Expr.splice(fieldExpr.upcast[Any]),
+                Expr.splice(fExpr.asInstanceOf[Expr[Any => Any]])
+              )
+          }
+          val bParam = bFieldMap(fieldName)
+          MIO.pure((fieldName, castAnyToTyped(nestedResult, bParam.tpe)))
+        } else {
+          MIO.pure((fieldName, fieldExpr.as_??))
         }
-        val bParam = bFieldMap(fieldName)
-        (fieldName, castAnyToTyped(nestedResult, bParam.tpe))
-      } else if (selfRecursiveFields.contains(fieldName)) {
-        // Direct self-recursive field (no outer wrapper): e.g. F[A] itself
-        val selfExpr = selfOpt.getOrElse(
-          throw new RuntimeException("Self-recursive field but no self Functor reference")
-        )
-        val nestedResult: Expr[Any] = Expr.quote {
-          hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-            .mapNested(
-              Expr.splice(selfExpr),
-              Expr.splice(fieldExpr.upcast[Any]),
-              Expr.splice(fExpr.asInstanceOf[Expr[Any => Any]])
-            )
-        }
-        val bParam = bFieldMap(fieldName)
-        (fieldName, castAnyToTyped(nestedResult, bParam.tpe))
-      } else if (nestedFieldFunctors.contains(fieldName)) {
-        val functorExpr = nestedFieldFunctors(fieldName)
-        val nestedResult: Expr[Any] = Expr.quote {
-          hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-            .mapNested(
-              Expr.splice(functorExpr),
-              Expr.splice(fieldExpr.upcast[Any]),
-              Expr.splice(fExpr.asInstanceOf[Expr[Any => Any]])
-            )
-        }
-        val bParam = bFieldMap(fieldName)
-        (fieldName, castAnyToTyped(nestedResult, bParam.tpe))
-      } else {
-        (fieldName, fieldExpr.as_??)
       }
-    }
-    caseClassB.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[B]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct mapped result: $error"))
+
+      mappedFieldsMIO.flatMap { mappedFields =>
+        constructInstanceFree(caseClassB.primaryConstructor, "Constructor", "mapped result")(mappedFields.toMap)
+          .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[B]]])
+      }
     }
   }
 
@@ -269,185 +266,187 @@ trait FunctorMacrosImpl extends rules.FunctorCaseClassRuleImpl with CatsDerivati
 
     val parentCtor = FCtor.asUntyped
 
-    Enum.parse[F[Any]].toEither match {
-      case Left(reason) =>
-        MIO.fail(new RuntimeException(s"Cannot parse as enum: $reason"))
-      case Right(enumm) =>
-        val enumInt = Enum.parse(using FCtor.apply[Int].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e
-          case Left(_)  => return MIO.fail(new RuntimeException("Cannot parse F[Int] as enum"))
-        }
-        val enumString = Enum.parse(using FCtor.apply[String].asInstanceOf[Type[Any]]).toEither match {
-          case Right(e) => e
-          case Left(_)  => return MIO.fail(new RuntimeException("Cannot parse F[String] as enum"))
-        }
+    parseEnumMIO[F[Any]]("F[Any]").flatMap { enumm =>
+      parseEnumMIO[Any]("F[Int]")(using FCtor.apply[Int].asInstanceOf[Type[Any]])
+        .parTuple(parseEnumMIO[Any]("F[String]")(using FCtor.apply[String].asInstanceOf[Type[Any]]))
+        .flatMap { case (enumInt, enumString) =>
+          case class ChildFieldInfo(
+              directFields: Set[String],
+              nestedFieldFunctors: Map[String, Expr[Any]],
+              selfRecursiveFields: Set[String]
+          )
 
-        case class ChildFieldInfo(
-            directFields: Set[String],
-            nestedFieldFunctors: Map[String, Expr[Any]],
-            selfRecursiveFields: Set[String]
-        )
+          val childInfo: Map[String, ChildFieldInfo] = runSafe {
+            val childrenInt = enumInt.directChildren.toList
+            val childrenString = enumString.directChildren.toList
 
-        val childInfo: Map[String, ChildFieldInfo] = runSafe {
-          val result = scala.collection.mutable.Map.empty[String, ChildFieldInfo]
-          val childrenInt = enumInt.directChildren.toList
-          val childrenString = enumString.directChildren.toList
+            childrenInt
+              .zip(childrenString)
+              .traverse { case ((childName, childI), (_, childS)) =>
+                import childI.Underlying as ChildI
+                import childS.Underlying as ChildS
 
-          childrenInt.zip(childrenString).foreach { case ((childName, childI), (_, childS)) =>
-            import childI.Underlying as ChildI
-            import childS.Underlying as ChildS
+                val ccI = CaseClass.parse[ChildI].toEither
+                val ccS = CaseClass.parse[ChildS].toEither
 
-            val ccI = CaseClass.parse[ChildI].toEither
-            val ccS = CaseClass.parse[ChildS].toEither
+                (ccI, ccS) match {
+                  case (Right(cI), Right(cS)) =>
+                    val fieldsI = cI.primaryConstructor.totalParameters.flatten.toList
+                    val fieldsS = cS.primaryConstructor.totalParameters.flatten.toList
+                    val directFields = scala.collection.mutable.Set.empty[String]
+                    val nestedFunctors = scala.collection.mutable.Map.empty[String, Expr[Any]]
+                    val selfRecursive = scala.collection.mutable.Set.empty[String]
 
-            (ccI, ccS) match {
-              case (Right(cI), Right(cS)) =>
-                val fieldsI = cI.primaryConstructor.totalParameters.flatten.toList
-                val fieldsS = cS.primaryConstructor.totalParameters.flatten.toList
-                val directFields = scala.collection.mutable.Set.empty[String]
-                val nestedFunctors = scala.collection.mutable.Map.empty[String, Expr[Any]]
-                val selfRecursive = scala.collection.mutable.Set.empty[String]
-
-                fieldsI.zip(fieldsS).foreach { case ((name, pI), (_, pS)) =>
-                  val tI = pI.tpe.Underlying
-                  val tS = pS.tpe.Underlying
-                  if (tI =:= IntType && tS =:= StringType) {
-                    directFields += name
-                  } else if (tI =:= tS) {
-                    // invariant
-                  } else {
-                    val param = fieldsI.find(_._1 == name).get._2
-                    import param.tpe.Underlying as FieldType
-                    summonFunctorForFieldType(Type[FieldType].asInstanceOf[Type[Any]]) match {
-                      case Some(functorExpr) => nestedFunctors += (name -> functorExpr)
-                      case None              =>
-                        mkCtor1FromType(Type[FieldType].asInstanceOf[Type[Any]]) match {
-                          case Some((_, nestedUntyped)) if nestedUntyped == parentCtor =>
-                            selfRecursive += name
-                          case _ =>
-                            throw new RuntimeException(
-                              s"Cannot find or derive Functor for nested field $name in $childName"
-                            )
-                        }
-                    }
-                  }
-                }
-                result += (childName -> ChildFieldInfo(directFields.toSet, nestedFunctors.toMap, selfRecursive.toSet))
-              case _ =>
-                result += (childName -> ChildFieldInfo(Set.empty, Map.empty, Set.empty))
-            }
-          }
-          MIO.pure(result.toMap)
-        }
-
-        val hasSelfRecursive = childInfo.values.exists(_.selfRecursiveFields.nonEmpty)
-
-        import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
-
-        def mkEnumMapBody(
-            faExpr: Expr[F[Any]],
-            fExpr: Expr[Any => Any],
-            selfOpt: Option[Expr[Any]]
-        ): Expr[F[Any]] =
-          runSafe {
-            enumm
-              .matchOn[MIO, F[Any]](faExpr) { matched =>
-                import matched.{value as caseValue, Underlying as ChildType}
-                val childName = Type[ChildType].shortName
-                childInfo.get(childName) match {
-                  case None =>
-                    MIO.fail(new RuntimeException(s"No derivation info for child $childName"))
-                  case Some(info) =>
-                    val childCC = CaseClass.parse[ChildType].toEither match {
-                      case Right(cc) => cc
-                      case Left(e)   => throw new RuntimeException(s"Cannot parse child $childName: $e")
-                    }
-                    val fields = childCC.caseFieldValuesAt(caseValue).toList
-                    if (fields.isEmpty) {
-                      MIO.pure(caseValue.upcast[F[Any]])
-                    } else {
-                      val mapped: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-                        import fieldValue.Underlying as Field
-                        val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-                        if (info.directFields.contains(fieldName)) {
-                          val m: Expr[Any] =
-                            Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.upcast[Any])))
-                          val typedM: Expr[Field] = Expr.quote(Expr.splice(m).asInstanceOf[Field])
-                          (fieldName, typedM.as_??)
-                        } else if (
-                          info.selfRecursiveFields.contains(fieldName) ||
-                          info.nestedFieldFunctors.contains(fieldName)
-                        ) {
-                          val functorExpr = if (info.selfRecursiveFields.contains(fieldName)) {
-                            selfOpt.getOrElse(
-                              throw new RuntimeException("Self-recursive field but no self Functor")
-                            )
-                          } else info.nestedFieldFunctors(fieldName)
-                          val nested: Expr[Any] = Expr.quote {
-                            hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                              .mapNested(
-                                Expr.splice(functorExpr),
-                                Expr.splice(fieldExpr.upcast[Any]),
-                                Expr.splice(fExpr)
-                              )
-                          }
-                          val typedNested: Expr[Field] =
-                            Expr.quote(Expr.splice(nested).asInstanceOf[Field])
-                          (fieldName, typedNested.as_??)
+                    fieldsI
+                      .zip(fieldsS)
+                      .traverse { case ((name, pI), (_, pS)) =>
+                        val tI = pI.tpe.Underlying
+                        val tS = pS.tpe.Underlying
+                        if (tI =:= IntType && tS =:= StringType) {
+                          directFields += name
+                          MIO.void
+                        } else if (tI =:= tS) {
+                          // invariant
+                          MIO.void
                         } else {
-                          (fieldName, fieldExpr.as_??)
+                          val param = fieldsI.find(_._1 == name).get._2
+                          import param.tpe.Underlying as FieldType
+                          summonFunctorForFieldType(Type[FieldType].asInstanceOf[Type[Any]]) match {
+                            case Some(functorExpr) =>
+                              nestedFunctors += (name -> functorExpr)
+                              MIO.void
+                            case None =>
+                              mkCtor1FromType(Type[FieldType].asInstanceOf[Type[Any]]) match {
+                                case Some((_, nestedUntyped)) if nestedUntyped == parentCtor =>
+                                  selfRecursive += name
+                                  MIO.void
+                                case _ =>
+                                  failDerivation[Unit](
+                                    CatsDerivationError.MissingInstanceForField("Functor", name, childName)
+                                  )
+                              }
+                          }
                         }
                       }
-                      childCC.primaryConstructor.fold(
-                        onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                        onTypes = _ => Map.empty,
-                        onValues = _ => mapped.toMap
-                      ) match {
-                        case Right(expr) => MIO.pure(expr.value.asInstanceOf[Expr[F[Any]]])
-                        case Left(err)   => MIO.fail(new RuntimeException(s"Cannot construct $childName: $err"))
+                      .map { _ =>
+                        childName -> ChildFieldInfo(directFields.toSet, nestedFunctors.toMap, selfRecursive.toSet)
                       }
-                    }
+                  case _ =>
+                    MIO.pure(childName -> ChildFieldInfo(Set.empty, Map.empty, Set.empty))
                 }
               }
-              .flatMap {
-                case Some(r) => MIO.pure(r)
-                case None    => MIO.fail(new RuntimeException("Enum has no children"))
-              }
+              .map(_.toMap)
           }
 
-        if (hasSelfRecursive) {
-          MIO.pure {
-            Expr.quote {
-              var self$macro: Any = null
-              self$macro = CatsDerivationFactories.functorInstance[F] {
-                (fa: F[CatsDerivationFactories.W1], f: CatsDerivationFactories.W1 => CatsDerivationFactories.W2) =>
-                  val _ = fa; val _ = f
-                  val r$0: F[Any] = Expr.splice {
-                    mkEnumMapBody(
-                      Expr.quote(fa.asInstanceOf[F[Any]]),
-                      Expr.quote(f.asInstanceOf[Any => Any]),
-                      Some(Expr.quote(self$macro))
-                    )
+          val hasSelfRecursive = childInfo.values.exists(_.selfRecursiveFields.nonEmpty)
+
+          import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
+
+          def mkEnumMapBody(
+              faExpr: Expr[F[Any]],
+              fExpr: Expr[Any => Any],
+              selfOpt: Option[Expr[Any]]
+          ): Expr[F[Any]] =
+            runSafe {
+              enumm
+                .matchOn[MIO, F[Any]](faExpr) { matched =>
+                  import matched.{value as caseValue, Underlying as ChildType}
+                  val childName = Type[ChildType].shortName
+                  childInfo.get(childName) match {
+                    case None =>
+                      failDerivation(CatsDerivationError.MissingDerivationInfo("Functor", childName))
+                    case Some(info) =>
+                      parseCaseClassMIO[ChildType](s"child $childName").flatMap { childCC =>
+                        val fields = childCC.caseFieldValuesAt(caseValue).toList
+                        if (fields.isEmpty) {
+                          MIO.pure(caseValue.upcast[F[Any]])
+                        } else {
+                          val mappedMIO: MIO[List[(String, Expr_??)]] = fields.traverse {
+                            case (fieldName, fieldValue) =>
+                              import fieldValue.Underlying as Field
+                              val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+                              if (info.directFields.contains(fieldName)) {
+                                val m: Expr[Any] =
+                                  Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.upcast[Any])))
+                                val typedM: Expr[Field] = Expr.quote(Expr.splice(m).asInstanceOf[Field])
+                                MIO.pure((fieldName, typedM.as_??))
+                              } else if (
+                                info.selfRecursiveFields.contains(fieldName) ||
+                                info.nestedFieldFunctors.contains(fieldName)
+                              ) {
+                                val functorExprMIO: MIO[Expr[Any]] =
+                                  if (info.selfRecursiveFields.contains(fieldName)) {
+                                    selfOpt match {
+                                      case Some(self) => MIO.pure(self)
+                                      case None       =>
+                                        failDerivation(CatsDerivationError.MissingSelfReference("Functor"))
+                                    }
+                                  } else MIO.pure(info.nestedFieldFunctors(fieldName))
+                                functorExprMIO.map { functorExpr =>
+                                  val nested: Expr[Any] = Expr.quote {
+                                    hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                      .mapNested(
+                                        Expr.splice(functorExpr),
+                                        Expr.splice(fieldExpr.upcast[Any]),
+                                        Expr.splice(fExpr)
+                                      )
+                                  }
+                                  val typedNested: Expr[Field] =
+                                    Expr.quote(Expr.splice(nested).asInstanceOf[Field])
+                                  (fieldName, typedNested.as_??)
+                                }
+                              } else {
+                                MIO.pure((fieldName, fieldExpr.as_??))
+                              }
+                          }
+                          mappedMIO.flatMap { mapped =>
+                            constructInstanceFree(childCC.primaryConstructor, "Constructor", childName)(mapped.toMap)
+                              .map(expr => expr.value.asInstanceOf[Expr[F[Any]]])
+                          }
+                        }
+                      }
                   }
-                  r$0.asInstanceOf[F[CatsDerivationFactories.W2]]
-              }
-              self$macro.asInstanceOf[cats.Functor[F]]
+                }
+                .flatMap {
+                  case Some(r) => MIO.pure(r)
+                  case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any]].prettyPrint))
+                }
             }
-          }
-        } else {
-          MIO.pure {
-            Expr.quote {
-              CatsDerivationFactories.functorInstance[F] {
-                (fa: F[CatsDerivationFactories.W1], f: CatsDerivationFactories.W1 => CatsDerivationFactories.W2) =>
-                  val _ = fa; val _ = f
-                  val r$0: F[Any] = Expr.splice {
-                    mkEnumMapBody(
-                      Expr.quote(fa.asInstanceOf[F[Any]]),
-                      Expr.quote(f.asInstanceOf[Any => Any]),
-                      None
-                    )
-                  }
-                  r$0.asInstanceOf[F[CatsDerivationFactories.W2]]
+
+          if (hasSelfRecursive) {
+            MIO.pure {
+              Expr.quote {
+                var self$macro: Any = null
+                self$macro = CatsDerivationFactories.functorInstance[F] {
+                  (fa: F[CatsDerivationFactories.W1], f: CatsDerivationFactories.W1 => CatsDerivationFactories.W2) =>
+                    val _ = fa; val _ = f
+                    val r$0: F[Any] = Expr.splice {
+                      mkEnumMapBody(
+                        Expr.quote(fa.asInstanceOf[F[Any]]),
+                        Expr.quote(f.asInstanceOf[Any => Any]),
+                        Some(Expr.quote(self$macro))
+                      )
+                    }
+                    r$0.asInstanceOf[F[CatsDerivationFactories.W2]]
+                }
+                self$macro.asInstanceOf[cats.Functor[F]]
+              }
+            }
+          } else {
+            MIO.pure {
+              Expr.quote {
+                CatsDerivationFactories.functorInstance[F] {
+                  (fa: F[CatsDerivationFactories.W1], f: CatsDerivationFactories.W1 => CatsDerivationFactories.W2) =>
+                    val _ = fa; val _ = f
+                    val r$0: F[Any] = Expr.splice {
+                      mkEnumMapBody(
+                        Expr.quote(fa.asInstanceOf[F[Any]]),
+                        Expr.quote(f.asInstanceOf[Any => Any]),
+                        None
+                      )
+                    }
+                    r$0.asInstanceOf[F[CatsDerivationFactories.W2]]
+                }
               }
             }
           }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
@@ -19,20 +19,50 @@ trait FunctorMacrosImpl
     with CatsDerivationErrorSupport {
   this: MacroCommons & StdExtensions =>
 
-  protected def summonFunctorForFieldType(fieldType: Type[Any]): Option[Expr[Any]]
+  /** Summon `cats.Functor[G]` for the type constructor `G` of the applied type `G[X]`, using Hearth's `Type.decompose1`
+    * to discover `G` and `Type.CtorK1#apply` to build `Type[cats.Functor[G]]` to summon for. Returns None when the
+    * field is not an applied type or no `Functor` instance is in scope.
+    *
+    * Replaces the former platform-specific `summonFunctorForFieldType` (Issue #284: HKT ctor primitives).
+    */
+  final protected def summonFunctorForFieldType(fieldType: Type[Any]): Option[Expr[Any]] =
+    Type.decompose1(using fieldType).flatMap { case (gCtor, _) =>
+      implicit val FunctorOfG: Type[cats.Functor[AnyK]] =
+        CatsFunctorCtor.apply(using gCtor).asInstanceOf[Type[cats.Functor[AnyK]]]
+      Expr.summonImplicit[cats.Functor[AnyK]].toOption.map(_.asInstanceOf[Expr[Any]])
+    }
 
-  protected def mkCtor1FromType(appliedType: Type[Any]): Option[(Type.Ctor1[AnyK], UntypedType)]
+  /** Decompose an applied type `G[X]` into its (live) type constructor `G` and that constructor's untyped form. The
+    * returned `Type.Ctor1` can be re-applied (`ctor[B]`) or compared (`sameTypeConstructorAs`). Returns None for
+    * non-applied types.
+    *
+    * Replaces the former platform-specific `mkCtor1FromType` (Issue #284).
+    */
+  final protected def mkCtor1FromType(appliedType: Type[Any]): Option[(Type.Ctor1[AnyK], UntypedType)] =
+    Type.decompose1(using appliedType).map { case (gCtor, _) =>
+      (gCtor.asInstanceOf[Type.Ctor1[AnyK]], gCtor.asUntyped)
+    }
 
   /** Given an applied type `G[X]`, extract the single type argument `X` as a `Type[Any]`. Returns None if the type is
     * not a single-argument applied type.
+    *
+    * Replaces the former platform-specific `extractSingleTypeArg` (Issue #284).
     */
-  protected def extractSingleTypeArg(appliedType: Type[Any]): Option[Type[Any]]
+  final protected def extractSingleTypeArg(appliedType: Type[Any]): Option[Type[Any]] =
+    Type.decompose1(using appliedType).map { case (_, arg) => arg.Underlying.asInstanceOf[Type[Any]] }
 
   /** Check whether the given applied type `G[X]` has an inner type argument `X` whose type constructor matches the
     * given parent constructor. For example, `Option[Search[Int]]` with parent `Search` would return true because
     * `Search` (from `Search[Int]`) matches the parent.
+    *
+    * Replaces the former platform-specific `isNestedSelfRecursive` (Issue #284).
     */
-  protected def isNestedSelfRecursive(fieldType: Type[Any], parentCtor: UntypedType): Boolean
+  final protected def isNestedSelfRecursive(fieldType: Type[Any], parentCtor: UntypedType): Boolean =
+    Type.decompose1(using fieldType).exists { case (_, innerArg) =>
+      Type.decompose1(using innerArg.Underlying.asInstanceOf[Type[Any]]).exists { case (innerCtor, _) =>
+        innerCtor.sameTypeConstructorAs(parentCtor)
+      }
+    }
 
   final case class FunctorCaseClassResult[F[_]](
       FCtor: Type.Ctor1[F],
@@ -455,6 +485,11 @@ trait FunctorMacrosImpl
   }
 
   protected type AnyK[X] = Any
+
+  /** Higher-kinded constructor for `cats.Functor`, used to build `Type[cats.Functor[G]]` for a discovered `G` via
+    * `CatsFunctorCtor.apply(using gCtor)` (Issue #284).
+    */
+  protected lazy val CatsFunctorCtor: Type.CtorK1[cats.Functor] = Type.CtorK1.of[cats.Functor]
 
   protected object FunctorTypes {
     val Any: Type[Any] = Type.of[Any]

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/InvariantMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/InvariantMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -12,7 +14,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * for method-level type parameters inside Expr.quote/Expr.splice. Supports direct A fields (covariant), Function1[A,
   * R] fields (contravariant), Function1[R, A] fields (covariant), and Function1[A, A] fields (both).
   */
-trait InvariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait InvariantMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveInvariant[F[_]](
@@ -30,14 +33,8 @@ trait InvariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & S
           implicit val IntType: Type[Int] = InvariantTypes.Int
           implicit val StringType: Type[String] = InvariantTypes.String
 
-          val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-          }
-          val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-          }
+          val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+          val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
           val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
           val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -50,42 +47,60 @@ trait InvariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & S
             Type.Ctor2.fromUntyped[Function1](impl.asUntyped)
           }
 
-          fieldsInt.zip(fieldsString).foreach { case ((name, pInt), (_, pString)) =>
-            val tInt = pInt.tpe.Underlying
-            val tString = pString.tpe.Underlying
-            if (tInt =:= tString) {
-              fieldKinds(name) = "invariant"
-            } else if (tInt =:= IntType && tString =:= StringType) {
-              fieldKinds(name) = "direct"
-            } else {
-              (Function1Ctor2.unapply(tInt), Function1Ctor2.unapply(tString)) match {
-                case (Some((arg1Int, arg2Int)), Some((arg1String, arg2String))) =>
-                  import arg1Int.Underlying as A1Int
-                  import arg2Int.Underlying as A2Int
-                  import arg1String.Underlying as A1String
-                  import arg2String.Underlying as A2String
+          runSafe {
+            fieldsInt
+              .zip(fieldsString)
+              .traverse { case ((name, pInt), (_, pString)) =>
+                val tInt = pInt.tpe.Underlying
+                val tString = pString.tpe.Underlying
+                if (tInt =:= tString) {
+                  fieldKinds(name) = "invariant"
+                  MIO.void
+                } else if (tInt =:= IntType && tString =:= StringType) {
+                  fieldKinds(name) = "direct"
+                  MIO.void
+                } else {
+                  (Function1Ctor2.unapply(tInt), Function1Ctor2.unapply(tString)) match {
+                    case (Some((arg1Int, arg2Int)), Some((arg1String, arg2String))) =>
+                      import arg1Int.Underlying as A1Int
+                      import arg2Int.Underlying as A2Int
+                      import arg1String.Underlying as A1String
+                      import arg2String.Underlying as A2String
 
-                  val firstArgChanges = !(A1Int =:= A1String)
-                  val secondArgChanges = !(A2Int =:= A2String)
+                      val firstArgChanges = !(A1Int =:= A1String)
+                      val secondArgChanges = !(A2Int =:= A2String)
 
-                  if (firstArgChanges && !secondArgChanges) {
-                    fieldKinds(name) = "fn1Contra"
-                  } else if (!firstArgChanges && secondArgChanges) {
-                    fieldKinds(name) = "fn1Covar"
-                  } else if (firstArgChanges && secondArgChanges) {
-                    fieldKinds(name) = "fn1Both"
-                  } else {
-                    throw new RuntimeException(
-                      s"Cannot derive Invariant: field '$name' has inconsistent Function1 decomposition."
-                    )
+                      if (firstArgChanges && !secondArgChanges) {
+                        fieldKinds(name) = "fn1Contra"
+                        MIO.void
+                      } else if (!firstArgChanges && secondArgChanges) {
+                        fieldKinds(name) = "fn1Covar"
+                        MIO.void
+                      } else if (firstArgChanges && secondArgChanges) {
+                        fieldKinds(name) = "fn1Both"
+                        MIO.void
+                      } else {
+                        failDerivation[Unit](
+                          CatsDerivationError.UnsupportedFieldShape(
+                            "Invariant",
+                            name,
+                            "the field has inconsistent Function1 decomposition"
+                          )
+                        )
+                      }
+                    case _ =>
+                      failDerivation[Unit](
+                        CatsDerivationError.UnsupportedFieldShape(
+                          "Invariant",
+                          name,
+                          "the field contains a nested type constructor that is not Function1 - " +
+                            "only direct A fields, Function1[A, R] fields, and invariant fields are currently supported"
+                        )
+                      )
                   }
-                case _ =>
-                  throw new RuntimeException(
-                    s"Cannot derive Invariant: field '$name' contains a nested type constructor that is not Function1. " +
-                      "Only direct A fields, Function1[A, R] fields, and invariant fields are currently supported."
-                  )
+                }
               }
-            }
+              .void
           }
 
           val fieldKindsMap: Map[String, String] = fieldKinds.toMap
@@ -150,60 +165,45 @@ trait InvariantMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & S
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
     implicit val FBType: Type[F[B]] = FCtor.apply[B]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val caseClassB = CaseClass.parse[F[B]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[B]: $e")
-    }
+    parseCaseClassMIO[F[A]]("F[A]").parTuple(parseCaseClassMIO[F[B]]("F[B]")).flatMap { case (caseClass, caseClassB) =>
+      val fields = caseClass.caseFieldValuesAt(faExpr).toList
+      val fieldsB = caseClassB.primaryConstructor.totalParameters.flatten.toList
+      val fieldBTypes: Map[String, Type[Any]] =
+        fieldsB.map { case (name, param) => (name, param.tpe.Underlying.asInstanceOf[Type[Any]]) }.toMap
 
-    val fields = caseClass.caseFieldValuesAt(faExpr).toList
-    val fieldsB = caseClassB.primaryConstructor.totalParameters.flatten.toList
-    val fieldBTypes: Map[String, Type[Any]] =
-      fieldsB.map { case (name, param) => (name, param.tpe.Underlying.asInstanceOf[Type[Any]]) }.toMap
+      val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
+        import fieldValue.Underlying as Field
+        val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
 
-    val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-
-      fieldKinds.getOrElse(fieldName, "invariant") match {
-        case "direct" =>
-          val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
-          (fieldName, mapped.as_??)
-        case "fn1Contra" =>
-          val bFieldType = fieldBTypes(fieldName).asInstanceOf[Type[Field]]
-          val composed: Expr[Field] =
-            mkComposeExpr[Field](fieldExpr.asInstanceOf[Expr[Any]], gExpr.asInstanceOf[Expr[Any]])(bFieldType)
-          (fieldName, composed.as_??(bFieldType))
-        case "fn1Covar" =>
-          val bFieldType = fieldBTypes(fieldName).asInstanceOf[Type[Field]]
-          val composed: Expr[Field] =
-            mkAndThenExpr[Field](fieldExpr.asInstanceOf[Expr[Any]], fExpr.asInstanceOf[Expr[Any]])(bFieldType)
-          (fieldName, composed.as_??(bFieldType))
-        case "fn1Both" =>
-          val bFieldType = fieldBTypes(fieldName).asInstanceOf[Type[Field]]
-          val composed: Expr[Field] = mkComposeAndThenExpr[Field](
-            fieldExpr.asInstanceOf[Expr[Any]],
-            fExpr.asInstanceOf[Expr[Any]],
-            gExpr.asInstanceOf[Expr[Any]]
-          )(bFieldType)
-          (fieldName, composed.as_??(bFieldType))
-        case _ =>
-          (fieldName, fieldExpr.as_??)
+        fieldKinds.getOrElse(fieldName, "invariant") match {
+          case "direct" =>
+            val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
+            (fieldName, mapped.as_??)
+          case "fn1Contra" =>
+            val bFieldType = fieldBTypes(fieldName).asInstanceOf[Type[Field]]
+            val composed: Expr[Field] =
+              mkComposeExpr[Field](fieldExpr.asInstanceOf[Expr[Any]], gExpr.asInstanceOf[Expr[Any]])(bFieldType)
+            (fieldName, composed.as_??(bFieldType))
+          case "fn1Covar" =>
+            val bFieldType = fieldBTypes(fieldName).asInstanceOf[Type[Field]]
+            val composed: Expr[Field] =
+              mkAndThenExpr[Field](fieldExpr.asInstanceOf[Expr[Any]], fExpr.asInstanceOf[Expr[Any]])(bFieldType)
+            (fieldName, composed.as_??(bFieldType))
+          case "fn1Both" =>
+            val bFieldType = fieldBTypes(fieldName).asInstanceOf[Type[Field]]
+            val composed: Expr[Field] = mkComposeAndThenExpr[Field](
+              fieldExpr.asInstanceOf[Expr[Any]],
+              fExpr.asInstanceOf[Expr[Any]],
+              gExpr.asInstanceOf[Expr[Any]]
+            )(bFieldType)
+            (fieldName, composed.as_??(bFieldType))
+          case _ =>
+            (fieldName, fieldExpr.as_??)
+        }
       }
-    }
 
-    caseClassB.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[B]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct imapped result: $error"))
+      constructInstanceFree(caseClassB.primaryConstructor, "Constructor", "imapped result")(mappedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[B]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/MonoidKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/MonoidKMacrosImpl.scala
@@ -2,12 +2,15 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
 
 /** MonoidK derivation: combines EmptyK + SemigroupK by summoning Monoid for each field type in F[Any]. */
-trait MonoidKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait MonoidKMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveMonoidK[F[_]](
@@ -60,9 +63,10 @@ trait MonoidKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & Std
               }
             }
           case Left(reason) =>
-            MIO.fail(
-              new RuntimeException(
-                s"$macroName: Cannot derive for type: $reason. Can only be derived for case classes."
+            failDerivation(
+              CatsDerivationError.CannotParseCaseClass(
+                Type[F[Any]].prettyPrint,
+                s"$reason. $macroName can only be derived for case classes."
               )
             )
         }
@@ -88,29 +92,28 @@ trait MonoidKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & Std
   )(implicit FCtor: Type.Ctor1[F], FAnyType: Type[F[Any]], AnyType: Type[Any]): MIO[Expr[F[Any]]] = {
     val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
 
-    val fieldExprs: List[(String, Expr_??)] = fields.map { case (fieldName, param) =>
+    val fieldExprsMIO: MIO[List[(String, Expr_??)]] = fields.traverse { case (fieldName, param) =>
       import param.tpe.Underlying as Field
 
-      val monoidExpr = MonoidKTypes.Monoid[Field].summonExprIgnoring().toEither match {
-        case Right(m)     => m
+      MonoidKTypes.Monoid[Field].summonExprIgnoring().toEither match {
+        case Right(monoidExpr) =>
+          val value: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
+          MIO.pure((fieldName, value.as_??))
         case Left(reason) =>
-          throw new RuntimeException(
-            s"No Monoid instance found for field '$fieldName': ${Field.prettyPrint}: $reason"
+          failDerivation(
+            CatsDerivationError.MissingInstanceForField(
+              "Monoid",
+              fieldName,
+              Type[F[Any]].prettyPrint,
+              Some(s"${Field.prettyPrint}: $reason")
+            )
           )
       }
-      val value: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
-      (fieldName, value.as_??)
     }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => fieldExprs.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct empty result: $error"))
+    fieldExprsMIO.flatMap { fieldExprs =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "empty result")(fieldExprs.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 
@@ -123,32 +126,31 @@ trait MonoidKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & Std
     val fieldsX = caseClass.caseFieldValuesAt(xExpr).toList
     val fieldsY = caseClass.caseFieldValuesAt(yExpr).toList
 
-    val combinedFields: List[(String, Expr_??)] =
-      fieldsX.zip(fieldsY).map { case ((fieldName, fieldValueX), (_, fieldValueY)) =>
+    val combinedFieldsMIO: MIO[List[(String, Expr_??)]] =
+      fieldsX.zip(fieldsY).traverse { case ((fieldName, fieldValueX), (_, fieldValueY)) =>
         import fieldValueX.Underlying as Field
         val fx = fieldValueX.value.asInstanceOf[Expr[Field]]
         val fy = fieldValueY.value.asInstanceOf[Expr[Field]]
 
-        val sgExpr = MonoidKTypes.Semigroup[Field].summonExprIgnoring().toEither match {
-          case Right(sg)    => sg
+        MonoidKTypes.Semigroup[Field].summonExprIgnoring().toEither match {
+          case Right(sgExpr) =>
+            val combined: Expr[Field] = Expr.quote(Expr.splice(sgExpr).combine(Expr.splice(fx), Expr.splice(fy)))
+            MIO.pure((fieldName, combined.as_??))
           case Left(reason) =>
-            throw new RuntimeException(
-              s"No Semigroup instance found for field '$fieldName': ${Field.prettyPrint}: $reason"
+            failDerivation(
+              CatsDerivationError.MissingInstanceForField(
+                "Semigroup",
+                fieldName,
+                Type[F[Any]].prettyPrint,
+                Some(s"${Field.prettyPrint}: $reason")
+              )
             )
         }
-        val combined: Expr[Field] = Expr.quote(Expr.splice(sgExpr).combine(Expr.splice(fx), Expr.splice(fy)))
-        (fieldName, combined.as_??)
       }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => combinedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct combined result: $error"))
+    combinedFieldsMIO.flatMap { combinedFields =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "combined result")(combinedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyAlternativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyAlternativeMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -15,7 +17,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   *   - ap[A, B]: needs F[Any] erasure because ff: F[A => B] and fa: F[A] have different type parameters
   *   - combineK[A]: summons Semigroup for field types at macro time, needs concrete types
   */
-trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveNonEmptyAlternative[F[_]](
@@ -33,14 +36,8 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroC
           implicit val IntType: Type[Int] = NEATypes.Int
           implicit val StringType: Type[String] = NEATypes.String
 
-          val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-          }
-          val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-          }
+          val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+          val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
           val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
           val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -61,10 +58,16 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroC
           }
 
           if (nestedFields.nonEmpty) {
-            throw new RuntimeException(
-              s"Cannot derive NonEmptyAlternative: fields ${nestedFields.mkString(", ")} contain nested type constructors. " +
-                "Only direct type parameter fields (A) and invariant fields are supported."
-            )
+            runSafe {
+              failDerivation[Unit](
+                CatsDerivationError.UnsupportedFieldShape(
+                  "NonEmptyAlternative",
+                  nestedFields.mkString(", "),
+                  "nested type constructors are not supported - " +
+                    "only direct type parameter fields (A) and invariant fields are supported"
+                )
+              )
+            }
           }
 
           val directFieldSet: Set[String] = directFields.toSet
@@ -78,10 +81,7 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroC
           implicit val AnyType: Type[Any] = NEATypes.Any
           implicit val FAnyType: Type[F[Any]] = FCtor.apply[Any]
 
-          val caseClassAny = CaseClass.parse[F[Any]].toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Any]: $e")
-          }
+          val caseClassAny = runSafe(parseCaseClassMIO[F[Any]]("F[Any]"))
 
           val doAp: (Expr[F[Any]], Expr[F[Any]]) => Expr[F[Any]] = (ffExpr, faExpr) =>
             runSafe {
@@ -165,39 +165,36 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroC
   )(implicit AType: Type[A]): MIO[Expr[F[A]]] = {
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
+    parseCaseClassMIO[F[A]]("F[A]").flatMap { caseClass =>
+      val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
 
-    val fieldExprs: List[(String, Expr_??)] = fields.map { case (fieldName, param) =>
-      import param.tpe.Underlying as Field
+      val fieldExprsMIO: MIO[List[(String, Expr_??)]] = fields.traverse { case (fieldName, param) =>
+        import param.tpe.Underlying as Field
 
-      if (directFields.contains(fieldName)) {
-        (fieldName, aExpr.as_??)
-      } else {
-        val monoidExpr = NEATypes.Monoid[Field].summonExprIgnoring().toEither match {
-          case Right(m)     => m
-          case Left(reason) =>
-            throw new RuntimeException(
-              s"No Monoid instance found for invariant field '$fieldName': ${Field.prettyPrint}: $reason"
-            )
+        if (directFields.contains(fieldName)) {
+          MIO.pure((fieldName, aExpr.as_??))
+        } else {
+          NEATypes.Monoid[Field].summonExprIgnoring().toEither match {
+            case Right(monoidExpr) =>
+              val emptyValue: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
+              MIO.pure((fieldName, emptyValue.as_??))
+            case Left(reason) =>
+              failDerivation(
+                CatsDerivationError.MissingInstanceForField(
+                  "Monoid",
+                  fieldName,
+                  Type[F[A]].prettyPrint,
+                  Some(s"${Field.prettyPrint}: $reason")
+                )
+              )
+          }
         }
-        val emptyValue: Expr[Field] = Expr.quote(Expr.splice(monoidExpr).empty)
-        (fieldName, emptyValue.as_??)
       }
-    }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => fieldExprs.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[A]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct pure result: $error"))
+      fieldExprsMIO.flatMap { fieldExprs =>
+        constructInstanceFree(caseClass.primaryConstructor, "Constructor", "pure result")(fieldExprs.toMap)
+          .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[A]]])
+      }
     }
   }
 
@@ -211,37 +208,23 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroC
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
     implicit val FBType: Type[F[B]] = FCtor.apply[B]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val fields = caseClass.caseFieldValuesAt(faExpr).toList
+    parseCaseClassMIO[F[A]]("F[A]").parTuple(parseCaseClassMIO[F[B]]("F[B]")).flatMap { case (caseClass, caseClassB) =>
+      val fields = caseClass.caseFieldValuesAt(faExpr).toList
 
-    val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+      val mappedFields: List[(String, Expr_??)] = fields.map { case (fieldName, fieldValue) =>
+        import fieldValue.Underlying as Field
+        val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
 
-      if (directFields.contains(fieldName)) {
-        val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
-        (fieldName, mapped.as_??)
-      } else {
-        (fieldName, fieldExpr.as_??)
+        if (directFields.contains(fieldName)) {
+          val mapped: Expr[B] = Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.asInstanceOf[Expr[A]])))
+          (fieldName, mapped.as_??)
+        } else {
+          (fieldName, fieldExpr.as_??)
+        }
       }
-    }
 
-    val caseClassB = CaseClass.parse[F[B]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[B]: $e")
-    }
-    caseClassB.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[B]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct mapped result: $error"))
+      constructInstanceFree(caseClassB.primaryConstructor, "Constructor", "mapped result")(mappedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[B]]])
     }
   }
 
@@ -255,8 +238,8 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroC
     val fieldsFF = caseClass.caseFieldValuesAt(ffExpr).toList
     val fieldsFA = caseClass.caseFieldValuesAt(faExpr).toList
 
-    val apFields: List[(String, Expr_??)] =
-      fieldsFF.zip(fieldsFA).map { case ((fieldName, ffFieldValue), (_, faFieldValue)) =>
+    val apFieldsMIO: MIO[List[(String, Expr_??)]] =
+      fieldsFF.zip(fieldsFA).traverse { case ((fieldName, ffFieldValue), (_, faFieldValue)) =>
         import ffFieldValue.Underlying as Field
         val ffField = ffFieldValue.value.asInstanceOf[Expr[Field]]
         val faField = faFieldValue.value.asInstanceOf[Expr[Field]]
@@ -265,31 +248,30 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroC
           val applied: Expr[Any] = Expr.quote(
             Expr.splice(ffField).asInstanceOf[Any => Any].apply(Expr.splice(faField).asInstanceOf[Any])
           )
-          (fieldName, applied.as_??)
+          MIO.pure((fieldName, applied.as_??))
         } else {
-          val sgExpr = NEATypes.Semigroup[Field].summonExprIgnoring().toEither match {
-            case Right(sg)    => sg
+          NEATypes.Semigroup[Field].summonExprIgnoring().toEither match {
+            case Right(sgExpr) =>
+              val combined: Expr[Field] = Expr.quote(
+                Expr.splice(sgExpr).combine(Expr.splice(ffField), Expr.splice(faField))
+              )
+              MIO.pure((fieldName, combined.as_??))
             case Left(reason) =>
-              throw new RuntimeException(
-                s"No Semigroup instance found for invariant field '$fieldName': ${Field.prettyPrint}: $reason"
+              failDerivation(
+                CatsDerivationError.MissingInstanceForField(
+                  "Semigroup",
+                  fieldName,
+                  Type[F[Any]].prettyPrint,
+                  Some(s"${Field.prettyPrint}: $reason")
+                )
               )
           }
-          val combined: Expr[Field] = Expr.quote(
-            Expr.splice(sgExpr).combine(Expr.splice(ffField), Expr.splice(faField))
-          )
-          (fieldName, combined.as_??)
         }
       }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => apFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct ap result: $error"))
+    apFieldsMIO.flatMap { apFields =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "ap result")(apFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 
@@ -302,32 +284,31 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout { this: MacroC
     val fieldsX = caseClass.caseFieldValuesAt(xExpr).toList
     val fieldsY = caseClass.caseFieldValuesAt(yExpr).toList
 
-    val combinedFields: List[(String, Expr_??)] =
-      fieldsX.zip(fieldsY).map { case ((fieldName, fieldValueX), (_, fieldValueY)) =>
+    val combinedFieldsMIO: MIO[List[(String, Expr_??)]] =
+      fieldsX.zip(fieldsY).traverse { case ((fieldName, fieldValueX), (_, fieldValueY)) =>
         import fieldValueX.Underlying as Field
         val fx = fieldValueX.value.asInstanceOf[Expr[Field]]
         val fy = fieldValueY.value.asInstanceOf[Expr[Field]]
 
-        val sgExpr = NEATypes.Semigroup[Field].summonExprIgnoring().toEither match {
-          case Right(sg)    => sg
+        NEATypes.Semigroup[Field].summonExprIgnoring().toEither match {
+          case Right(sgExpr) =>
+            val combined: Expr[Field] = Expr.quote(Expr.splice(sgExpr).combine(Expr.splice(fx), Expr.splice(fy)))
+            MIO.pure((fieldName, combined.as_??))
           case Left(reason) =>
-            throw new RuntimeException(
-              s"No Semigroup instance found for field '$fieldName': ${Field.prettyPrint}: $reason"
+            failDerivation(
+              CatsDerivationError.MissingInstanceForField(
+                "Semigroup",
+                fieldName,
+                Type[F[Any]].prettyPrint,
+                Some(s"${Field.prettyPrint}: $reason")
+              )
             )
         }
-        val combined: Expr[Field] = Expr.quote(Expr.splice(sgExpr).combine(Expr.splice(fx), Expr.splice(fy)))
-        (fieldName, combined.as_??)
       }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => combinedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct combined result: $error"))
+    combinedFieldsMIO.flatMap { combinedFields =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "combined result")(combinedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyTraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyTraverseMacrosImpl.scala
@@ -15,7 +15,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * For nonEmptyTraverse, instead of seeding with G.pure (which requires Applicative), we seed with the first field
   * mapped through f (giving G[B]), then combine remaining fields using G.map2.
   */
-trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveNonEmptyTraverse[F[_]](
@@ -39,14 +40,8 @@ trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout { this: MacroComm
               implicit val IntType: Type[Int] = NETTypes.Int
               implicit val StringType: Type[String] = NETTypes.String
 
-              val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-              }
-              val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-              }
+              val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+              val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
               val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
               val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -67,17 +62,28 @@ trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout { this: MacroComm
               }
 
               if (nestedFields.nonEmpty) {
-                throw new RuntimeException(
-                  s"Cannot derive NonEmptyTraverse: fields ${nestedFields.mkString(", ")} contain nested type constructors. " +
-                    "Only direct type parameter fields (A) and invariant fields are supported."
-                )
+                runSafe {
+                  failDerivation[Unit](
+                    CatsDerivationError.UnsupportedFieldShape(
+                      "NonEmptyTraverse",
+                      nestedFields.mkString(", "),
+                      "the fields contain nested type constructors - " +
+                        "only direct type parameter fields (A) and invariant fields are supported"
+                    )
+                  )
+                }
               }
 
               if (directFields.isEmpty) {
-                throw new RuntimeException(
-                  "Cannot derive NonEmptyTraverse: no direct type parameter fields found. " +
-                    "NonEmptyTraverse requires at least one field of the type parameter."
-                )
+                runSafe {
+                  failDerivation[Unit](
+                    CatsDerivationError.DerivationFailed(
+                      "NonEmptyTraverse",
+                      "no direct type parameter fields found - " +
+                        "NonEmptyTraverse requires at least one field of the type parameter"
+                    )
+                  )
+                }
               }
 
               val directFieldSet: Set[String] = directFields.toSet
@@ -207,9 +213,10 @@ trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout { this: MacroComm
               }
             }
           case Left(reason) =>
-            MIO.fail(
-              new RuntimeException(
-                s"$macroName: Cannot derive for type: $reason. Can only be derived for case classes."
+            failDerivation(
+              CatsDerivationError.CannotParseCaseClass(
+                Type[F[Any]].prettyPrint,
+                s"$reason. $macroName can only be derived for case classes."
               )
             )
         }
@@ -263,8 +270,11 @@ trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout { this: MacroComm
       FAnyType: Type[F[Any]],
       AnyType: Type[Any],
       ListAnyType: Type[List[Any]]
-  ): MIO[Expr[(List[Any], Any) => Any]] = {
-    val lambda =
+  ): MIO[Expr[(List[Any], Any) => Any]] =
+    // LambdaBuilder callbacks are synchronous and cannot return MIO, so failures inside the
+    // callback throw the typed CatsDerivationError; the enclosing MIO(...) converts the
+    // NonFatal throw into a proper MIO error-channel failure.
+    MIO {
       LambdaBuilder.of2[List[Any], Any]("newVals", "original").buildWith { case (newValsExpr, originalExpr) =>
         val faExpr: Expr[F[Any]] = Expr.quote(Expr.splice(originalExpr).asInstanceOf[F[Any]])
         val fields = caseClass.caseFieldValuesAt(faExpr).toList
@@ -280,18 +290,16 @@ trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout { this: MacroComm
             (fieldName, fieldValue.value.asInstanceOf[Expr[Field]].as_??)
           }
         }
-        caseClass.primaryConstructor.fold(
-          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+        foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
           onTypes = _ => Map.empty,
           onValues = _ => fieldExprs.toMap
         ) match {
           case Right(constructExpr) => constructExpr.value.asInstanceOf[Expr[Any]]
           case Left(error)          =>
-            throw new RuntimeException(s"Cannot construct traversed result: $error")
+            throw CatsDerivationError.CannotConstructResult("traversed result", error)
         }
       }
-    MIO.pure(lambda)
-  }
+    }
 
   @scala.annotation.nowarn("msg=is never used|unused implicit parameter")
   private def deriveNETFoldLeftBody[F[_]](

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/PureMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/PureMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -12,7 +14,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * method-level type parameters inside Expr.quote/Expr.splice. All type-parameter-dependent fields are filled with the
   * provided value. Invariant fields cause a derivation error.
   */
-trait PureMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait PureMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def derivePure[F[_]](FCtor0: Type.Ctor1[F], PureFType: Type[alleycats.Pure[F]]): Expr[alleycats.Pure[F]] = {
@@ -27,44 +30,55 @@ trait PureMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExt
           implicit val IntType: Type[Int] = PureTypes.Int
           implicit val StringType: Type[String] = PureTypes.String
 
-          val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-          }
-          val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-          }
+          val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+          val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
           val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
           val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
 
           val directFields = scala.collection.mutable.Set.empty[String]
 
-          fieldsInt.zip(fieldsString).foreach { case ((name, pInt), (_, pString)) =>
-            val tInt = pInt.tpe.Underlying
-            val tString = pString.tpe.Underlying
-            if (tInt =:= tString) {
-              // Invariant field — no value to fill
-            } else if (tInt =:= IntType && tString =:= StringType) {
-              directFields += name
-            } else {
-              throw new RuntimeException(
-                s"Cannot derive Pure: field '$name' contains a nested type constructor. " +
-                  "Only direct type parameter fields (A) and invariant fields are supported, " +
-                  "but invariant fields also require default values which are not yet supported."
-              )
-            }
+          runSafe {
+            fieldsInt
+              .zip(fieldsString)
+              .traverse { case ((name, pInt), (_, pString)) =>
+                val tInt = pInt.tpe.Underlying
+                val tString = pString.tpe.Underlying
+                if (tInt =:= tString) {
+                  // Invariant field — no value to fill
+                  MIO.void
+                } else if (tInt =:= IntType && tString =:= StringType) {
+                  directFields += name
+                  MIO.void
+                } else {
+                  failDerivation[Unit](
+                    CatsDerivationError.UnsupportedFieldShape(
+                      "Pure",
+                      name,
+                      "the field contains a nested type constructor - " +
+                        "only direct type parameter fields (A) and invariant fields are supported, " +
+                        "but invariant fields also require default values which are not yet supported"
+                    )
+                  )
+                }
+              }
+              .void
           }
 
           // Check if there are any non-direct fields (invariant) — these need defaults we can't provide
           val allFieldNames = fieldsInt.map(_._1).toSet
           val invariantFields = allFieldNames -- directFields.toSet
           if (invariantFields.nonEmpty) {
-            throw new RuntimeException(
-              s"Cannot derive Pure: fields ${invariantFields.mkString(", ")} are not of the type parameter type. " +
-                "Pure can only be derived when all fields use the type parameter directly."
-            )
+            runSafe {
+              failDerivation[Unit](
+                CatsDerivationError.UnsupportedFieldShape(
+                  "Pure",
+                  invariantFields.mkString(", "),
+                  "the fields are not of the type parameter type - " +
+                    "Pure can only be derived when all fields use the type parameter directly"
+                )
+              )
+            }
           }
 
           val directFieldSet: Set[String] = directFields.toSet
@@ -114,26 +128,16 @@ trait PureMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExt
   )(implicit AType: Type[A]): MIO[Expr[F[A]]] = {
     implicit val FAType: Type[F[A]] = FCtor.apply[A]
 
-    val caseClass = CaseClass.parse[F[A]].toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse F[A]: $e")
-    }
-    val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
+    parseCaseClassMIO[F[A]]("F[A]").flatMap { caseClass =>
+      val fields = caseClass.primaryConstructor.totalParameters.flatten.toList
 
-    val fieldMap: Map[String, Expr_??] = fields.map { case (fieldName, _) =>
-      // All fields are direct (we verified this above), so all get `a`
-      (fieldName, aExpr.as_??)
-    }.toMap
+      val fieldMap: Map[String, Expr_??] = fields.map { case (fieldName, _) =>
+        // All fields are direct (we verified this above), so all get `a`
+        (fieldName, aExpr.as_??)
+      }.toMap
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => fieldMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[A]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct pure result: $error"))
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "pure result")(fieldMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[A]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ReducibleMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ReducibleMacrosImpl.scala
@@ -14,7 +14,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   *
   * Requires at least one direct field (non-empty guarantee).
   */
-trait ReducibleMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait ReducibleMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveReducible[F[_]](
@@ -32,14 +33,8 @@ trait ReducibleMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & S
           implicit val IntType: Type[Int] = ReducibleTypes.Int
           implicit val StringType: Type[String] = ReducibleTypes.String
 
-          val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-          }
-          val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-          }
+          val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+          val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
           val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
           val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -60,17 +55,28 @@ trait ReducibleMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & S
           }
 
           if (nestedFields.nonEmpty) {
-            throw new RuntimeException(
-              s"Cannot derive Reducible: fields ${nestedFields.mkString(", ")} contain nested type constructors. " +
-                "Only direct type parameter fields (A) and invariant fields are supported."
-            )
+            runSafe {
+              failDerivation[Unit](
+                CatsDerivationError.UnsupportedFieldShape(
+                  "Reducible",
+                  nestedFields.mkString(", "),
+                  "the fields contain nested type constructors - " +
+                    "only direct type parameter fields (A) and invariant fields are supported"
+                )
+              )
+            }
           }
 
           if (directFields.isEmpty) {
-            throw new RuntimeException(
-              "Cannot derive Reducible: no direct type parameter fields found. " +
-                "Reducible requires at least one field of the type parameter."
-            )
+            runSafe {
+              failDerivation[Unit](
+                CatsDerivationError.DerivationFailed(
+                  "Reducible",
+                  "no direct type parameter fields found - " +
+                    "Reducible requires at least one field of the type parameter"
+                )
+              )
+            }
           }
 
           val directFieldSet: Set[String] = directFields.toSet
@@ -84,10 +90,7 @@ trait ReducibleMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & S
           implicit val FAnyType: Type[F[Any]] = FCtor.apply[Any]
           implicit val EvalAnyType: Type[cats.Eval[Any]] = ReducibleTypes.EvalCtor.apply[Any]
 
-          val ccAny = CaseClass.parse[F[Any]].toEither match {
-            case Right(cc) => cc
-            case Left(e)   => throw new RuntimeException(s"Cannot parse F[Any]: $e")
-          }
+          val ccAny = runSafe(parseCaseClassMIO[F[Any]]("F[Any]"))
 
           val doReduceLeftTo: (Expr[F[Any]], Expr[Any => Any], Expr[(Any, Any) => Any]) => Expr[Any] =
             (faExpr, fExpr, gExpr) =>

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupKMacrosImpl.scala
@@ -2,12 +2,15 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
 
 /** SemigroupK derivation: combines F[A] values field-wise by summoning Semigroup for each field type in F[Any]. */
-trait SemigroupKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait SemigroupKMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used|unused explicit parameter")
   def deriveSemigroupK[F[_]](
@@ -49,9 +52,10 @@ trait SemigroupKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
               }
             }
           case Left(reason) =>
-            MIO.fail(
-              new RuntimeException(
-                s"$macroName: Cannot derive for type: $reason. Can only be derived for case classes."
+            failDerivation(
+              CatsDerivationError.CannotParseCaseClass(
+                Type[F[Any]].prettyPrint,
+                s"$reason. $macroName can only be derived for case classes."
               )
             )
         }
@@ -80,32 +84,31 @@ trait SemigroupKMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & 
     val fieldsX = caseClass.caseFieldValuesAt(xExpr).toList
     val fieldsY = caseClass.caseFieldValuesAt(yExpr).toList
 
-    val combinedFields: List[(String, Expr_??)] =
-      fieldsX.zip(fieldsY).map { case ((fieldName, fieldValueX), (_, fieldValueY)) =>
+    val combinedFieldsMIO: MIO[List[(String, Expr_??)]] =
+      fieldsX.zip(fieldsY).traverse { case ((fieldName, fieldValueX), (_, fieldValueY)) =>
         import fieldValueX.Underlying as Field
         val fx = fieldValueX.value.asInstanceOf[Expr[Field]]
         val fy = fieldValueY.value.asInstanceOf[Expr[Field]]
 
-        val sgExpr = SemigroupKTypes.Semigroup[Field].summonExprIgnoring().toEither match {
-          case Right(sg)    => sg
+        SemigroupKTypes.Semigroup[Field].summonExprIgnoring().toEither match {
+          case Right(sgExpr) =>
+            val combined: Expr[Field] = Expr.quote(Expr.splice(sgExpr).combine(Expr.splice(fx), Expr.splice(fy)))
+            MIO.pure((fieldName, combined.as_??))
           case Left(reason) =>
-            throw new RuntimeException(
-              s"No Semigroup instance found for field '$fieldName': ${Field.prettyPrint}: $reason"
+            failDerivation(
+              CatsDerivationError.MissingInstanceForField(
+                "Semigroup",
+                fieldName,
+                Type[F[Any]].prettyPrint,
+                Some(s"${Field.prettyPrint}: $reason")
+              )
             )
         }
-        val combined: Expr[Field] = Expr.quote(Expr.splice(sgExpr).combine(Expr.splice(fx), Expr.splice(fy)))
-        (fieldName, combined.as_??)
       }
 
-    caseClass.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => combinedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        MIO.pure(constructExpr.value.asInstanceOf[Expr[F[Any]]])
-      case Left(error) =>
-        MIO.fail(new RuntimeException(s"Cannot construct combined result: $error"))
+    combinedFieldsMIO.flatMap { combinedFields =>
+      constructInstanceFree(caseClass.primaryConstructor, "Constructor", "combined result")(combinedFields.toMap)
+        .map(constructExpr => constructExpr.value.asInstanceOf[Expr[F[Any]]])
     }
   }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupMacrosImpl.scala
@@ -13,7 +13,8 @@ trait SemigroupMacrosImpl
     with rules.SemigroupUseImplicitRuleImpl
     with rules.SemigroupBuiltInRuleImpl
     with rules.SemigroupCaseClassRuleImpl
-    with CatsDerivationTimeout {
+    with CatsDerivationTimeout
+    with CatsDerivationErrorSupport {
   this: MacroCommons & StdExtensions =>
 
   @scala.annotation.nowarn("msg=is never used")

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/TraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/TraverseMacrosImpl.scala
@@ -2,6 +2,8 @@ package hearth.kindlings.catsderivation.internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.effect.*
+import hearth.fp.instances.*
+import hearth.fp.syntax.*
 import hearth.std.*
 
 import hearth.kindlings.catsderivation.LogDerivation
@@ -14,7 +16,8 @@ import hearth.kindlings.catsderivation.LogDerivation
   * (apply f) and nested fields (delegate to Traverse[G].traverse). A LambdaBuilder-built reconstruction lambda rebuilds
   * the case class from the resulting List[Any] + original invariant field values.
   */
-trait TraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & StdExtensions =>
+trait TraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupport {
+  this: MacroCommons & StdExtensions =>
 
   protected def summonTraverseForFieldType(fieldType: Type[Any]): Option[Expr[Any]]
 
@@ -40,14 +43,8 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
               implicit val IntType: Type[Int] = TraverseTypes.Int
               implicit val StringType: Type[String] = TraverseTypes.String
 
-              val ccInt = CaseClass.parse(using FCtor.apply[Int]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[Int]: $e")
-              }
-              val ccString = CaseClass.parse(using FCtor.apply[String]).toEither match {
-                case Right(cc) => cc
-                case Left(e)   => throw new RuntimeException(s"Cannot parse F[String]: $e")
-              }
+              val ccInt = runSafe(parseCaseClassMIO[F[Int]]("F[Int]")(using FCtor.apply[Int]))
+              val ccString = runSafe(parseCaseClassMIO[F[String]]("F[String]")(using FCtor.apply[String]))
 
               val fieldsInt = ccInt.primaryConstructor.totalParameters.flatten.toList
               val fieldsString = ccString.primaryConstructor.totalParameters.flatten.toList
@@ -79,10 +76,15 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
                   }
                 }
                 if (unsupported.nonEmpty) {
-                  throw new RuntimeException(
-                    s"Cannot derive Traverse: fields ${unsupported.mkString(", ")} contain nested type constructors " +
-                      "without Traverse instances."
-                  )
+                  runSafe {
+                    failDerivation[Unit](
+                      CatsDerivationError.UnsupportedFieldShape(
+                        "Traverse",
+                        unsupported.mkString(", "),
+                        "the fields contain nested type constructors without Traverse instances"
+                      )
+                    )
+                  }
                 }
               }
 
@@ -187,9 +189,10 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
           case Left(_) =>
             Enum.parse[F[Any]].toEither match {
               case Left(reason2) =>
-                MIO.fail(
-                  new RuntimeException(
-                    s"$macroName: Cannot derive for type: not a case class and not a sealed trait ($reason2)."
+                failDerivation(
+                  CatsDerivationError.CannotParseEnum(
+                    Type[F[Any]].prettyPrint,
+                    s"not a case class and not a sealed trait ($reason2). $macroName cannot derive for this type."
                   )
                 )
               case Right(enumm) =>
@@ -224,8 +227,11 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
       FAnyType: Type[F[Any]],
       AnyType: Type[Any],
       ListAnyType: Type[List[Any]]
-  ): MIO[Expr[(List[Any], Any) => Any]] = {
-    val lambda =
+  ): MIO[Expr[(List[Any], Any) => Any]] =
+    // LambdaBuilder callbacks are synchronous and cannot return MIO, so failures inside the
+    // callback throw the typed CatsDerivationError; the enclosing MIO(...) converts the
+    // NonFatal throw into a proper MIO error-channel failure.
+    MIO {
       LambdaBuilder.of2[List[Any], Any]("newVals", "original").buildWith { case (newValsExpr, originalExpr) =>
         val faExpr: Expr[F[Any]] = Expr.quote(Expr.splice(originalExpr).asInstanceOf[F[Any]])
         val fields = caseClass.caseFieldValuesAt(faExpr).toList
@@ -242,18 +248,16 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
             (fieldName, fieldValue.value.asInstanceOf[Expr[Field]].as_??)
           }
         }
-        caseClass.primaryConstructor.fold(
-          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+        foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
           onTypes = _ => Map.empty,
           onValues = _ => fieldExprs.toMap
         ) match {
           case Right(constructExpr) => constructExpr.value.asInstanceOf[Expr[Any]]
           case Left(error)          =>
-            throw new RuntimeException(s"Cannot construct traversed result: $error")
+            throw CatsDerivationError.CannotConstructResult("traversed result", error)
         }
       }
-    MIO.pure(lambda)
-  }
+    }
 
   @scala.annotation.nowarn("msg=is never used|unused implicit parameter")
   private def deriveTraverseBody[F[_]](
@@ -411,326 +415,387 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout { this: MacroCommons & St
 
     val parentCtor = FCtor.asUntyped
 
-    val enumInt = Enum.parse(using FCtor.apply[Int].asInstanceOf[Type[Any]]).toEither match {
-      case Right(e) => e
-      case Left(_)  => return MIO.fail(new RuntimeException("Cannot parse F[Int] as enum"))
-    }
-    val enumString = Enum.parse(using FCtor.apply[String].asInstanceOf[Type[Any]]).toEither match {
-      case Right(e) => e
-      case Left(_)  => return MIO.fail(new RuntimeException("Cannot parse F[String] as enum"))
-    }
+    parseEnumMIO[Any]("F[Int]")(using FCtor.apply[Int].asInstanceOf[Type[Any]])
+      .parTuple(parseEnumMIO[Any]("F[String]")(using FCtor.apply[String].asInstanceOf[Type[Any]]))
+      .flatMap { case (enumInt, enumString) =>
+        case class ChildFieldInfo(
+            directFields: Set[String],
+            nestedInstances: Map[String, Expr[Any]],
+            selfRecursiveFields: Set[String]
+        )
 
-    case class ChildFieldInfo(
-        directFields: Set[String],
-        nestedInstances: Map[String, Expr[Any]],
-        selfRecursiveFields: Set[String]
-    )
-
-    val childInfo: Map[String, ChildFieldInfo] = runSafe {
-      val result = scala.collection.mutable.Map.empty[String, ChildFieldInfo]
-      val childrenInt = enumInt.directChildren.toList
-      val childrenString = enumString.directChildren.toList
-      childrenInt.zip(childrenString).foreach { case ((childName, childI), (_, childS)) =>
-        import childI.Underlying as ChildI
-        import childS.Underlying as ChildS
-        val ccI = CaseClass.parse[ChildI].toEither
-        val ccS = CaseClass.parse[ChildS].toEither
-        (ccI, ccS) match {
-          case (Right(cI), Right(cS)) =>
-            val fieldsI = cI.primaryConstructor.totalParameters.flatten.toList
-            val fieldsS = cS.primaryConstructor.totalParameters.flatten.toList
-            val direct = scala.collection.mutable.Set.empty[String]
-            val nested = scala.collection.mutable.Map.empty[String, Expr[Any]]
-            val selfRec = scala.collection.mutable.Set.empty[String]
-            fieldsI.zip(fieldsS).foreach { case ((name, pI), (_, pS)) =>
-              val tI = pI.tpe.Underlying
-              val tS = pS.tpe.Underlying
-              if (tI =:= IntType && tS =:= StringType) direct += name
-              else if (tI =:= tS) ()
-              else {
-                val param = fieldsI.find(_._1 == name).get._2
-                import param.tpe.Underlying as FT
-                summonTraverseForFieldType(Type[FT].asInstanceOf[Type[Any]]) match {
-                  case Some(expr) => nested += (name -> expr)
-                  case None       =>
-                    mkCtor1FromTypeTraverse(Type[FT].asInstanceOf[Type[Any]]) match {
-                      case Some(ut) if ut == parentCtor => selfRec += name
-                      case _ => throw new RuntimeException(s"No Traverse for nested field $name in $childName")
-                    }
-                }
-              }
-            }
-            result += (childName -> ChildFieldInfo(direct.toSet, nested.toMap, selfRec.toSet))
-          case _ =>
-            result += (childName -> ChildFieldInfo(Set.empty, Map.empty, Set.empty))
-        }
-      }
-      MIO.pure(result.toMap)
-    }
-
-    val hasSelfRecursive = childInfo.values.exists(_.selfRecursiveFields.nonEmpty)
-
-    import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
-
-    def mkTraverseBody(
-        faExpr: Expr[F[Any]],
-        fExpr: Expr[Any],
-        gExpr: Expr[Any],
-        selfOpt: Option[Expr[Any]]
-    ): Expr[Any] = runSafe {
-      enumm
-        .matchOn[MIO, Any](faExpr) { matched =>
-          import matched.{value as caseValue, Underlying as CT}
-          val cn = Type[CT].shortName
-          childInfo.get(cn) match {
-            case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
-            case Some(info) =>
-              val cc = CaseClass.parse[CT].toEither match {
-                case Right(c) => c; case Left(e) => throw new RuntimeException(e.toString)
-              }
-              val fields = cc.caseFieldValuesAt(caseValue).toList
-              if (fields.isEmpty) {
-                val gE = Expr.quote(Expr.splice(gExpr).asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]])
-                MIO.pure(Expr.quote(Expr.splice(gE).pure(Expr.splice(caseValue.upcast[Any]))).upcast[Any])
-              } else {
-                val gFieldExprs: List[Expr[CatsDerivationFactories.AnyF[Any]]] = fields.collect {
-                  case (fn, fv) if info.directFields.contains(fn) =>
-                    import fv.Underlying as Field
-                    val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
-                    Expr.quote(
-                      Expr.splice(fExpr).asInstanceOf[Any => CatsDerivationFactories.AnyF[Any]](Expr.splice(fe))
-                    )
-                  case (fn, fv) if info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn) =>
-                    import fv.Underlying as Field
-                    val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
-                    val travE =
-                      if (info.selfRecursiveFields.contains(fn))
-                        selfOpt.getOrElse(throw new RuntimeException("No self"))
-                      else info.nestedInstances(fn)
-                    Expr.quote(
-                      hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                        .traverseNested(Expr.splice(travE), Expr.splice(fe), Expr.splice(fExpr), Expr.splice(gExpr))
-                        .asInstanceOf[CatsDerivationFactories.AnyF[Any]]
-                    )
-                }
-                val traversableFields = info.directFields ++ info.nestedInstances.keySet ++ info.selfRecursiveFields
-
-                val reconLambda: Expr[List[Any] => Any] = runSafe {
-                  val lambda = LambdaBuilder.of1[List[Any]]("newVals").buildWith { newValsExpr =>
-                    var currentList: Expr[List[Any]] = newValsExpr
-                    val fieldExprs: List[(String, Expr_??)] = fields.map { case (fn2, fv2) =>
-                      import fv2.Underlying as Field2
-                      if (traversableFields.contains(fn2)) {
-                        val headExpr: Expr[Any] = Expr.quote(Expr.splice(currentList).head)
-                        val tailExpr: Expr[List[Any]] = Expr.quote(Expr.splice(currentList).tail)
-                        currentList = tailExpr
-                        val typed: Expr[Field2] = Expr.quote(Expr.splice(headExpr).asInstanceOf[Field2])
-                        (fn2, typed.as_??)
-                      } else {
-                        (fn2, fv2.value.asInstanceOf[Expr[Field2]].as_??)
+        val childInfo: Map[String, ChildFieldInfo] = runSafe {
+          val childrenInt = enumInt.directChildren.toList
+          val childrenString = enumString.directChildren.toList
+          childrenInt
+            .zip(childrenString)
+            .traverse { case ((childName, childI), (_, childS)) =>
+              import childI.Underlying as ChildI
+              import childS.Underlying as ChildS
+              val ccI = CaseClass.parse[ChildI].toEither
+              val ccS = CaseClass.parse[ChildS].toEither
+              (ccI, ccS) match {
+                case (Right(cI), Right(cS)) =>
+                  val fieldsI = cI.primaryConstructor.totalParameters.flatten.toList
+                  val fieldsS = cS.primaryConstructor.totalParameters.flatten.toList
+                  val direct = scala.collection.mutable.Set.empty[String]
+                  val nested = scala.collection.mutable.Map.empty[String, Expr[Any]]
+                  val selfRec = scala.collection.mutable.Set.empty[String]
+                  fieldsI
+                    .zip(fieldsS)
+                    .traverse { case ((name, pI), (_, pS)) =>
+                      val tI = pI.tpe.Underlying
+                      val tS = pS.tpe.Underlying
+                      if (tI =:= IntType && tS =:= StringType) {
+                        direct += name
+                        MIO.void
+                      } else if (tI =:= tS) MIO.void
+                      else {
+                        val param = fieldsI.find(_._1 == name).get._2
+                        import param.tpe.Underlying as FT
+                        summonTraverseForFieldType(Type[FT].asInstanceOf[Type[Any]]) match {
+                          case Some(expr) =>
+                            nested += (name -> expr)
+                            MIO.void
+                          case None =>
+                            mkCtor1FromTypeTraverse(Type[FT].asInstanceOf[Type[Any]]) match {
+                              case Some(ut) if ut == parentCtor =>
+                                selfRec += name
+                                MIO.void
+                              case _ =>
+                                failDerivation[Unit](
+                                  CatsDerivationError.MissingInstanceForField("Traverse", name, childName)
+                                )
+                            }
+                        }
                       }
                     }
-                    cc.primaryConstructor.fold(
-                      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                      onTypes = _ => Map.empty,
-                      onValues = _ => fieldExprs.toMap
-                    ) match {
-                      case Right(expr) => expr.value.asInstanceOf[Expr[Any]]
-                      case Left(err)   => throw new RuntimeException(s"Cannot construct $cn: $err")
+                    .map(_ => childName -> ChildFieldInfo(direct.toSet, nested.toMap, selfRec.toSet))
+                case _ =>
+                  MIO.pure(childName -> ChildFieldInfo(Set.empty, Map.empty, Set.empty))
+              }
+            }
+            .map(_.toMap)
+        }
+
+        val hasSelfRecursive = childInfo.values.exists(_.selfRecursiveFields.nonEmpty)
+
+        import hearth.kindlings.catsderivation.internal.runtime.CatsDerivationFactories
+
+        def mkTraverseBody(
+            faExpr: Expr[F[Any]],
+            fExpr: Expr[Any],
+            gExpr: Expr[Any],
+            selfOpt: Option[Expr[Any]]
+        ): Expr[Any] = runSafe {
+          val selfOrFail: MIO[Expr[Any]] = selfOpt match {
+            case Some(self) => MIO.pure(self)
+            case None       => failDerivation(CatsDerivationError.MissingSelfReference("Traverse"))
+          }
+          enumm
+            .matchOn[MIO, Any](faExpr) { matched =>
+              import matched.{value as caseValue, Underlying as CT}
+              val cn = Type[CT].shortName
+              childInfo.get(cn) match {
+                case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Traverse", cn))
+                case Some(info) =>
+                  parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
+                    val fields = cc.caseFieldValuesAt(caseValue).toList
+                    if (fields.isEmpty) {
+                      val gE =
+                        Expr.quote(Expr.splice(gExpr).asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]])
+                      MIO.pure(Expr.quote(Expr.splice(gE).pure(Expr.splice(caseValue.upcast[Any]))).upcast[Any])
+                    } else {
+                      val gFieldExprsMIO: MIO[List[Option[Expr[CatsDerivationFactories.AnyF[Any]]]]] =
+                        fields.traverse { case (fn, fv) =>
+                          import fv.Underlying as Field
+                          if (info.directFields.contains(fn)) {
+                            val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
+                            MIO.pure(
+                              Option(
+                                Expr.quote(
+                                  Expr
+                                    .splice(fExpr)
+                                    .asInstanceOf[Any => CatsDerivationFactories.AnyF[Any]](Expr.splice(fe))
+                                )
+                              )
+                            )
+                          } else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
+                            val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
+                            val travEMIO: MIO[Expr[Any]] =
+                              if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                              else MIO.pure(info.nestedInstances(fn))
+                            travEMIO.map { travE =>
+                              Option(
+                                Expr.quote(
+                                  hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                    .traverseNested(
+                                      Expr.splice(travE),
+                                      Expr.splice(fe),
+                                      Expr.splice(fExpr),
+                                      Expr.splice(gExpr)
+                                    )
+                                    .asInstanceOf[CatsDerivationFactories.AnyF[Any]]
+                                )
+                              )
+                            }
+                          } else MIO.pure(Option.empty[Expr[CatsDerivationFactories.AnyF[Any]]])
+                        }
+                      gFieldExprsMIO.flatMap { gFieldOpts =>
+                        val gFieldExprs = gFieldOpts.flatten
+                        val traversableFields =
+                          info.directFields ++ info.nestedInstances.keySet ++ info.selfRecursiveFields
+
+                        // LambdaBuilder callbacks are synchronous and cannot return MIO, so failures
+                        // inside the callback throw the typed CatsDerivationError; the enclosing
+                        // MIO(...) converts the NonFatal throw into an MIO error-channel failure.
+                        val reconLambda: Expr[List[Any] => Any] = runSafe {
+                          MIO {
+                            LambdaBuilder.of1[List[Any]]("newVals").buildWith { newValsExpr =>
+                              var currentList: Expr[List[Any]] = newValsExpr
+                              val fieldExprs: List[(String, Expr_??)] = fields.map { case (fn2, fv2) =>
+                                import fv2.Underlying as Field2
+                                if (traversableFields.contains(fn2)) {
+                                  val headExpr: Expr[Any] = Expr.quote(Expr.splice(currentList).head)
+                                  val tailExpr: Expr[List[Any]] = Expr.quote(Expr.splice(currentList).tail)
+                                  currentList = tailExpr
+                                  val typed: Expr[Field2] = Expr.quote(Expr.splice(headExpr).asInstanceOf[Field2])
+                                  (fn2, typed.as_??)
+                                } else {
+                                  (fn2, fv2.value.asInstanceOf[Expr[Field2]].as_??)
+                                }
+                              }
+                              foldInstanceFree(cc.primaryConstructor, "Constructor")(
+                                onTypes = _ => Map.empty,
+                                onValues = _ => fieldExprs.toMap
+                              ) match {
+                                case Right(expr) => expr.value.asInstanceOf[Expr[Any]]
+                                case Left(err)   => throw CatsDerivationError.CannotConstructResult(cn, err)
+                              }
+                            }
+                          }
+                        }
+
+                        val gListExpr = gFieldExprs.foldRight(
+                          Expr.quote(
+                            Expr
+                              .splice(gExpr)
+                              .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
+                              .pure(Nil: List[Any])
+                          )
+                        ) { (gvExpr, accExpr) =>
+                          Expr.quote(
+                            Expr
+                              .splice(gExpr)
+                              .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
+                              .map2[Any, List[Any], List[Any]](Expr.splice(gvExpr), Expr.splice(accExpr))(_ :: _)
+                          )
+                        }
+                        val result = Expr.quote {
+                          val recon: List[Any] => Any = Expr.splice(reconLambda)
+                          val _ = recon
+                          Expr
+                            .splice(gExpr)
+                            .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
+                            .map[List[Any], Any](Expr.splice(gListExpr))(newVals => recon(newVals))
+                        }
+                        MIO.pure(result.upcast[Any])
+                      }
                     }
                   }
-                  MIO.pure(lambda)
-                }
-
-                val gListExpr = gFieldExprs.foldRight(
-                  Expr.quote(
-                    Expr.splice(gExpr).asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]].pure(Nil: List[Any])
-                  )
-                ) { (gvExpr, accExpr) =>
-                  Expr.quote(
-                    Expr
-                      .splice(gExpr)
-                      .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
-                      .map2[Any, List[Any], List[Any]](Expr.splice(gvExpr), Expr.splice(accExpr))(_ :: _)
-                  )
-                }
-                val result = Expr.quote {
-                  val recon: List[Any] => Any = Expr.splice(reconLambda)
-                  val _ = recon
-                  Expr
-                    .splice(gExpr)
-                    .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
-                    .map[List[Any], Any](Expr.splice(gListExpr))(newVals => recon(newVals))
-                }
-                MIO.pure(result.upcast[Any])
               }
+            }
+            .flatMap {
+              case Some(r) => MIO.pure(r)
+              case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any]].prettyPrint))
+            }
+        }
+
+        def mkFoldLeftBody(
+            faExpr: Expr[F[Any]],
+            bExpr: Expr[Any],
+            fExpr: Expr[(Any, Any) => Any],
+            selfOpt: Option[Expr[Any]]
+        ): Expr[Any] = runSafe {
+          val selfOrFail: MIO[Expr[Any]] = selfOpt match {
+            case Some(self) => MIO.pure(self)
+            case None       => failDerivation(CatsDerivationError.MissingSelfReference("Traverse"))
           }
-        }
-        .flatMap {
-          case Some(r) => MIO.pure(r)
-          case None    => MIO.fail(new RuntimeException("No children"))
-        }
-    }
-
-    def mkFoldLeftBody(
-        faExpr: Expr[F[Any]],
-        bExpr: Expr[Any],
-        fExpr: Expr[(Any, Any) => Any],
-        selfOpt: Option[Expr[Any]]
-    ): Expr[Any] = runSafe {
-      enumm
-        .matchOn[MIO, Any](faExpr) { matched =>
-          import matched.{value as caseValue, Underlying as CT}
-          val cn = Type[CT].shortName
-          childInfo.get(cn) match {
-            case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
-            case Some(info) =>
-              val cc = CaseClass.parse[CT].toEither match {
-                case Right(c) => c; case Left(e) => throw new RuntimeException(e.toString)
+          enumm
+            .matchOn[MIO, Any](faExpr) { matched =>
+              import matched.{value as caseValue, Underlying as CT}
+              val cn = Type[CT].shortName
+              childInfo.get(cn) match {
+                case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Traverse", cn))
+                case Some(info) =>
+                  parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
+                    val fields = cc.caseFieldValuesAt(caseValue).toList
+                    var result: Expr[Any] = bExpr
+                    fields
+                      .traverse { case (fn, fv) =>
+                        import fv.Underlying as Field
+                        val fe = fv.value.asInstanceOf[Expr[Field]]
+                        if (info.directFields.contains(fn)) {
+                          result = Expr.quote(Expr.splice(fExpr)(Expr.splice(result), Expr.splice(fe.upcast[Any])))
+                          MIO.void
+                        } else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
+                          val foldEMIO: MIO[Expr[Any]] =
+                            if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                            else MIO.pure(info.nestedInstances(fn))
+                          foldEMIO.map { foldE =>
+                            result = Expr.quote(
+                              hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                .foldLeftNested(
+                                  Expr.splice(foldE),
+                                  Expr.splice(fe.upcast[Any]),
+                                  Expr.splice(result),
+                                  Expr.splice(fExpr)
+                                )
+                            )
+                          }
+                        } else MIO.void
+                      }
+                      .map(_ => result)
+                  }
               }
-              val fields = cc.caseFieldValuesAt(caseValue).toList
-              var result: Expr[Any] = bExpr
-              fields.foreach { case (fn, fv) =>
-                import fv.Underlying as Field
-                val fe = fv.value.asInstanceOf[Expr[Field]]
-                if (info.directFields.contains(fn))
-                  result = Expr.quote(Expr.splice(fExpr)(Expr.splice(result), Expr.splice(fe.upcast[Any])))
-                else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
-                  val foldE =
-                    if (info.selfRecursiveFields.contains(fn))
-                      selfOpt.getOrElse(throw new RuntimeException("No self"))
-                    else info.nestedInstances(fn)
-                  result = Expr.quote(
-                    hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                      .foldLeftNested(
-                        Expr.splice(foldE),
-                        Expr.splice(fe.upcast[Any]),
-                        Expr.splice(result),
-                        Expr.splice(fExpr)
+            }
+            .flatMap {
+              case Some(r) => MIO.pure(r)
+              case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any]].prettyPrint))
+            }
+        }
+
+        def mkFoldRightBody(
+            faExpr: Expr[F[Any]],
+            lbExpr: Expr[cats.Eval[Any]],
+            fExpr: Expr[(Any, cats.Eval[Any]) => cats.Eval[Any]],
+            selfOpt: Option[Expr[Any]]
+        ): Expr[cats.Eval[Any]] = runSafe {
+          val selfOrFail: MIO[Expr[Any]] = selfOpt match {
+            case Some(self) => MIO.pure(self)
+            case None       => failDerivation(CatsDerivationError.MissingSelfReference("Traverse"))
+          }
+          enumm
+            .matchOn[MIO, cats.Eval[Any]](faExpr) { matched =>
+              import matched.{value as caseValue, Underlying as CT}
+              val cn = Type[CT].shortName
+              childInfo.get(cn) match {
+                case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Traverse", cn))
+                case Some(info) =>
+                  parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
+                    val fields = cc.caseFieldValuesAt(caseValue).toList
+                    val foldableMIO: MIO[List[Option[(Expr[Any], Option[Expr[Any]])]]] =
+                      fields.traverse { case (fn, fv) =>
+                        import fv.Underlying as Field
+                        if (info.directFields.contains(fn))
+                          MIO.pure(
+                            Option((fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option.empty[Expr[Any]]))
+                          )
+                        else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
+                          val feMIO: MIO[Expr[Any]] =
+                            if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                            else MIO.pure(info.nestedInstances(fn))
+                          feMIO.map { fe =>
+                            Option((fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option(fe)))
+                          }
+                        } else MIO.pure(Option.empty[(Expr[Any], Option[Expr[Any]])])
+                      }
+                    foldableMIO.map { foldableOpts =>
+                      foldableOpts.flatten.foldRight(lbExpr) { case ((fieldExpr, foldableOpt), acc) =>
+                        foldableOpt match {
+                          case None =>
+                            Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr), Expr.splice(acc)))
+                          case Some(foldableE) =>
+                            Expr.quote(
+                              hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                .foldRightNested(
+                                  Expr.splice(foldableE),
+                                  Expr.splice(fieldExpr),
+                                  Expr.splice(acc),
+                                  Expr.splice(fExpr)
+                                )
+                            )
+                        }
+                      }
+                    }
+                  }
+              }
+            }
+            .flatMap {
+              case Some(r) => MIO.pure(r)
+              case None    => failDerivation(CatsDerivationError.EnumHasNoChildren(Type[F[Any]].prettyPrint))
+            }
+        }
+
+        if (hasSelfRecursive) {
+          MIO.pure {
+            Expr.quote {
+              var self$macro: Any = null
+              self$macro = CatsDerivationFactories.traverseInstance[F](
+                traverseFn = { (fa: F[CatsDerivationFactories.W1], fAny: Any, gAny: Any) =>
+                  val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
+                  val _ = anyFa; val _ = fAny; val _ = gAny
+                  Expr.splice(
+                    mkTraverseBody(Expr.quote(anyFa), Expr.quote(fAny), Expr.quote(gAny), Some(Expr.quote(self$macro)))
+                  )
+                },
+                foldLeftFn = { (fa: F[CatsDerivationFactories.W1], anyB: Any, anyF: (Any, Any) => Any) =>
+                  val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
+                  val _ = anyFa; val _ = anyB; val _ = anyF
+                  Expr.splice(
+                    mkFoldLeftBody(Expr.quote(anyFa), Expr.quote(anyB), Expr.quote(anyF), Some(Expr.quote(self$macro)))
+                  )
+                },
+                foldRightFn = {
+                  (
+                      fa: F[CatsDerivationFactories.W1],
+                      anyLb: cats.Eval[Any],
+                      anyF: (Any, cats.Eval[Any]) => cats.Eval[Any]
+                  ) =>
+                    val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
+                    val _ = anyFa; val _ = anyLb; val _ = anyF
+                    Expr.splice(
+                      mkFoldRightBody(
+                        Expr.quote(anyFa),
+                        Expr.quote(anyLb),
+                        Expr.quote(anyF),
+                        Some(Expr.quote(self$macro))
                       )
-                  )
-                }
-              }
-              MIO.pure(result)
-          }
-        }
-        .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
-    }
-
-    def mkFoldRightBody(
-        faExpr: Expr[F[Any]],
-        lbExpr: Expr[cats.Eval[Any]],
-        fExpr: Expr[(Any, cats.Eval[Any]) => cats.Eval[Any]],
-        selfOpt: Option[Expr[Any]]
-    ): Expr[cats.Eval[Any]] = runSafe {
-      enumm
-        .matchOn[MIO, cats.Eval[Any]](faExpr) { matched =>
-          import matched.{value as caseValue, Underlying as CT}
-          val cn = Type[CT].shortName
-          childInfo.get(cn) match {
-            case None       => MIO.fail(new RuntimeException(s"No info for $cn"))
-            case Some(info) =>
-              val cc = CaseClass.parse[CT].toEither match {
-                case Right(c) => c; case Left(e) => throw new RuntimeException(e.toString)
-              }
-              val fields = cc.caseFieldValuesAt(caseValue).toList
-              val foldable: List[(Expr[Any], Option[Expr[Any]])] = fields.collect {
-                case (fn, fv) if info.directFields.contains(fn) =>
-                  import fv.Underlying as Field
-                  (fv.value.asInstanceOf[Expr[Field]].upcast[Any], None)
-                case (fn, fv) if info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn) =>
-                  import fv.Underlying as Field
-                  val fe =
-                    if (info.selfRecursiveFields.contains(fn))
-                      selfOpt.getOrElse(throw new RuntimeException("No self"))
-                    else info.nestedInstances(fn)
-                  (fv.value.asInstanceOf[Expr[Field]].upcast[Any], Some(fe))
-              }
-              val result = foldable.foldRight(lbExpr) { case ((fieldExpr, foldableOpt), acc) =>
-                foldableOpt match {
-                  case None =>
-                    Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr), Expr.splice(acc)))
-                  case Some(foldableE) =>
-                    Expr.quote(
-                      hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                        .foldRightNested(
-                          Expr.splice(foldableE),
-                          Expr.splice(fieldExpr),
-                          Expr.splice(acc),
-                          Expr.splice(fExpr)
-                        )
                     )
                 }
-              }
-              MIO.pure(result)
+              )
+              self$macro.asInstanceOf[cats.Traverse[F]]
+            }
+          }
+        } else {
+          MIO.pure {
+            Expr.quote {
+              CatsDerivationFactories.traverseInstance[F](
+                traverseFn = { (fa: F[CatsDerivationFactories.W1], fAny: Any, gAny: Any) =>
+                  val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
+                  val _ = anyFa; val _ = fAny; val _ = gAny
+                  Expr.splice(mkTraverseBody(Expr.quote(anyFa), Expr.quote(fAny), Expr.quote(gAny), None))
+                },
+                foldLeftFn = { (fa: F[CatsDerivationFactories.W1], anyB: Any, anyF: (Any, Any) => Any) =>
+                  val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
+                  val _ = anyFa; val _ = anyB; val _ = anyF
+                  Expr.splice(mkFoldLeftBody(Expr.quote(anyFa), Expr.quote(anyB), Expr.quote(anyF), None))
+                },
+                foldRightFn = {
+                  (
+                      fa: F[CatsDerivationFactories.W1],
+                      anyLb: cats.Eval[Any],
+                      anyF: (Any, cats.Eval[Any]) => cats.Eval[Any]
+                  ) =>
+                    val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
+                    val _ = anyFa; val _ = anyLb; val _ = anyF
+                    Expr.splice(mkFoldRightBody(Expr.quote(anyFa), Expr.quote(anyLb), Expr.quote(anyF), None))
+                }
+              )
+            }
           }
         }
-        .flatMap { case Some(r) => MIO.pure(r); case None => MIO.fail(new RuntimeException("No children")) }
-    }
-
-    if (hasSelfRecursive) {
-      MIO.pure {
-        Expr.quote {
-          var self$macro: Any = null
-          self$macro = CatsDerivationFactories.traverseInstance[F](
-            traverseFn = { (fa: F[CatsDerivationFactories.W1], fAny: Any, gAny: Any) =>
-              val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-              val _ = anyFa; val _ = fAny; val _ = gAny
-              Expr.splice(
-                mkTraverseBody(Expr.quote(anyFa), Expr.quote(fAny), Expr.quote(gAny), Some(Expr.quote(self$macro)))
-              )
-            },
-            foldLeftFn = { (fa: F[CatsDerivationFactories.W1], anyB: Any, anyF: (Any, Any) => Any) =>
-              val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-              val _ = anyFa; val _ = anyB; val _ = anyF
-              Expr.splice(
-                mkFoldLeftBody(Expr.quote(anyFa), Expr.quote(anyB), Expr.quote(anyF), Some(Expr.quote(self$macro)))
-              )
-            },
-            foldRightFn = {
-              (
-                  fa: F[CatsDerivationFactories.W1],
-                  anyLb: cats.Eval[Any],
-                  anyF: (Any, cats.Eval[Any]) => cats.Eval[Any]
-              ) =>
-                val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-                val _ = anyFa; val _ = anyLb; val _ = anyF
-                Expr.splice(
-                  mkFoldRightBody(Expr.quote(anyFa), Expr.quote(anyLb), Expr.quote(anyF), Some(Expr.quote(self$macro)))
-                )
-            }
-          )
-          self$macro.asInstanceOf[cats.Traverse[F]]
-        }
       }
-    } else {
-      MIO.pure {
-        Expr.quote {
-          CatsDerivationFactories.traverseInstance[F](
-            traverseFn = { (fa: F[CatsDerivationFactories.W1], fAny: Any, gAny: Any) =>
-              val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-              val _ = anyFa; val _ = fAny; val _ = gAny
-              Expr.splice(mkTraverseBody(Expr.quote(anyFa), Expr.quote(fAny), Expr.quote(gAny), None))
-            },
-            foldLeftFn = { (fa: F[CatsDerivationFactories.W1], anyB: Any, anyF: (Any, Any) => Any) =>
-              val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-              val _ = anyFa; val _ = anyB; val _ = anyF
-              Expr.splice(mkFoldLeftBody(Expr.quote(anyFa), Expr.quote(anyB), Expr.quote(anyF), None))
-            },
-            foldRightFn = {
-              (
-                  fa: F[CatsDerivationFactories.W1],
-                  anyLb: cats.Eval[Any],
-                  anyF: (Any, cats.Eval[Any]) => cats.Eval[Any]
-              ) =>
-                val anyFa: F[Any] = fa.asInstanceOf[F[Any]]
-                val _ = anyFa; val _ = anyLb; val _ = anyF
-                Expr.splice(mkFoldRightBody(Expr.quote(anyFa), Expr.quote(anyLb), Expr.quote(anyF), None))
-            }
-          )
-        }
-      }
-    }
   }
 
   protected object TraverseTypes {

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/EmptyCaseClassRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/EmptyCaseClassRule.scala
@@ -47,28 +47,13 @@ trait EmptyCaseClassRuleImpl {
             }
             .flatMap { emptyFields =>
               val fieldMap: Map[String, Expr_??] = emptyFields.toList.toMap
-              caseClass.primaryConstructor.fold(
-                onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                onTypes = _ => Map.empty,
-                onValues = _ => fieldMap
-              ) match {
-                case Right(constructExpr) =>
-                  MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-                case Left(error) =>
-                  MIO.fail(new RuntimeException(s"Cannot construct empty ${Type[A].prettyPrint}: $error"))
-              }
+              constructInstanceFree(caseClass.primaryConstructor, "Constructor", s"empty ${Type[A].prettyPrint}")(
+                fieldMap
+              ).map(constructExpr => constructExpr.value.asInstanceOf[Expr[A]])
             }
         case None =>
-          caseClass.primaryConstructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-            onTypes = _ => Map.empty,
-            onValues = _ => Map.empty
-          ) match {
-            case Right(constructExpr) =>
-              MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-            case Left(error) =>
-              MIO.fail(new RuntimeException(s"Cannot construct empty ${Type[A].prettyPrint}: $error"))
-          }
+          constructInstanceFree(caseClass.primaryConstructor, "Constructor", s"empty ${Type[A].prettyPrint}")(Map.empty)
+            .map(constructExpr => constructExpr.value.asInstanceOf[Expr[A]])
       }
     }
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/GroupCaseClassRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/GroupCaseClassRule.scala
@@ -38,73 +38,56 @@ trait GroupCaseClassRuleImpl {
                 }
               }
             }
-            .map { emptyFields =>
-              val empty: Expr[A] = {
-                val fieldMap: Map[String, Expr_??] = emptyFields.toList.toMap
-                caseClass.primaryConstructor.fold(
-                  onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                  onTypes = _ => Map.empty,
-                  onValues = _ => fieldMap
-                ) match {
-                  case Right(constructExpr) => constructExpr.value.asInstanceOf[Expr[A]]
-                  case Left(error)          =>
-                    throw new RuntimeException(s"Cannot construct empty ${Type[A].prettyPrint}: $error")
+            .flatMap { emptyFields =>
+              val fieldMap: Map[String, Expr_??] = emptyFields.toList.toMap
+              constructInstanceFree(caseClass.primaryConstructor, "Constructor", s"empty ${Type[A].prettyPrint}")(
+                fieldMap
+              ).map { emptyExpr =>
+                val empty: Expr[A] = emptyExpr.value.asInstanceOf[Expr[A]]
+
+                val combine: (Expr[A], Expr[A]) => MIO[Expr[A]] = (x, y) => {
+                  val sgCtx = SemigroupCtx.from(x, y, gctx.derivedType)
+                  for {
+                    result <- deriveSemigroupRecursively[A](using sgCtx)
+                    cache <- sgCtx.cache.get
+                  } yield cache.toValDefs.use(_ => result)
                 }
-              }
 
-              val combine: (Expr[A], Expr[A]) => MIO[Expr[A]] = (x, y) => {
-                val sgCtx = SemigroupCtx.from(x, y, gctx.derivedType)
-                for {
-                  result <- deriveSemigroupRecursively[A](using sgCtx)
-                  cache <- sgCtx.cache.get
-                } yield cache.toValDefs.use(_ => result)
-              }
-
-              val inverse: Expr[A] => MIO[Expr[A]] = (aExpr) => {
-                val fieldValues = caseClass.caseFieldValuesAt(aExpr).toList
-                NonEmptyList
-                  .fromList(fieldValues)
-                  .get
-                  .traverse { case (fieldName, fieldValue) =>
-                    import fieldValue.Underlying as Field
-                    val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-                    deriveGroupRecursively[Field](using GroupCtx(Type.of[Field], gctx.cache, gctx.derivedType))
-                      .flatMap(_.inverse(fieldExpr).map(_.as_??))
-                      .map(inv => (fieldName, inv))
-                  }
-                  .flatMap { invertedFields =>
-                    val fieldMap: Map[String, Expr_??] = invertedFields.toList.toMap
-                    caseClass.primaryConstructor.fold(
-                      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                      onTypes = _ => Map.empty,
-                      onValues = _ => fieldMap
-                    ) match {
-                      case Right(constructExpr) =>
-                        MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-                      case Left(error) =>
-                        MIO.fail(new RuntimeException(s"Cannot construct inverse ${Type[A].prettyPrint}: $error"))
+                val inverse: Expr[A] => MIO[Expr[A]] = (aExpr) => {
+                  val fieldValues = caseClass.caseFieldValuesAt(aExpr).toList
+                  NonEmptyList
+                    .fromList(fieldValues)
+                    .get
+                    .traverse { case (fieldName, fieldValue) =>
+                      import fieldValue.Underlying as Field
+                      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+                      deriveGroupRecursively[Field](using GroupCtx(Type.of[Field], gctx.cache, gctx.derivedType))
+                        .flatMap(_.inverse(fieldExpr).map(_.as_??))
+                        .map(inv => (fieldName, inv))
                     }
-                  }
-              }
+                    .flatMap { invertedFields =>
+                      val invertedMap: Map[String, Expr_??] = invertedFields.toList.toMap
+                      constructInstanceFree(
+                        caseClass.primaryConstructor,
+                        "Constructor",
+                        s"inverse ${Type[A].prettyPrint}"
+                      )(invertedMap).map(constructExpr => constructExpr.value.asInstanceOf[Expr[A]])
+                    }
+                }
 
-              GroupDerivationResult(empty, combine, inverse)
+                GroupDerivationResult(empty, combine, inverse)
+              }
             }
 
         case None =>
           // No fields — empty case class
-          caseClass.primaryConstructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-            onTypes = _ => Map.empty,
-            onValues = _ => Map.empty
-          ) match {
-            case Right(constructExprE) =>
+          constructInstanceFree(caseClass.primaryConstructor, "Constructor", s"empty ${Type[A].prettyPrint}")(Map.empty)
+            .map { constructExprE =>
               val constructExpr: Expr[A] = constructExprE.value.asInstanceOf[Expr[A]]
               val combine: (Expr[A], Expr[A]) => MIO[Expr[A]] = (_, _) => MIO.pure(constructExpr)
               val inverse: Expr[A] => MIO[Expr[A]] = _ => MIO.pure(constructExpr)
-              MIO.pure(GroupDerivationResult(constructExpr, combine, inverse))
-            case Left(error) =>
-              MIO.fail(new RuntimeException(s"Cannot construct empty ${Type[A].prettyPrint}: $error"))
-          }
+              GroupDerivationResult(constructExpr, combine, inverse)
+            }
       }
     }
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/MonoidCaseClassRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/MonoidCaseClassRule.scala
@@ -50,29 +50,14 @@ trait MonoidCaseClassRuleImpl {
             }
             .flatMap { emptyFields =>
               val fieldMap: Map[String, Expr_??] = emptyFields.toList.toMap
-              caseClass.primaryConstructor.fold(
-                onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                onTypes = _ => Map.empty,
-                onValues = _ => fieldMap
-              ) match {
-                case Right(constructExpr) =>
-                  MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-                case Left(error) =>
-                  MIO.fail(new RuntimeException(s"Cannot construct empty ${Type[A].prettyPrint}: $error"))
-              }
+              constructInstanceFree(caseClass.primaryConstructor, "Constructor", s"empty ${Type[A].prettyPrint}")(
+                fieldMap
+              ).map(constructExpr => constructExpr.value.asInstanceOf[Expr[A]])
             }
         case None =>
           // No fields — construct empty instance
-          caseClass.primaryConstructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-            onTypes = _ => Map.empty,
-            onValues = _ => Map.empty
-          ) match {
-            case Right(constructExpr) =>
-              MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-            case Left(error) =>
-              MIO.fail(new RuntimeException(s"Cannot construct empty ${Type[A].prettyPrint}: $error"))
-          }
+          constructInstanceFree(caseClass.primaryConstructor, "Constructor", s"empty ${Type[A].prettyPrint}")(Map.empty)
+            .map(constructExpr => constructExpr.value.asInstanceOf[Expr[A]])
       }
     }
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/SemigroupCaseClassRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/SemigroupCaseClassRule.scala
@@ -49,29 +49,13 @@ trait SemigroupCaseClassRuleImpl {
             }
             .flatMap { combinedFields =>
               val fieldMap: Map[String, Expr_??] = combinedFields.toList.toMap
-              caseClass.primaryConstructor.fold(
-                onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-                onTypes = _ => Map.empty,
-                onValues = _ => fieldMap
-              ) match {
-                case Right(constructExpr) =>
-                  MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-                case Left(error) =>
-                  MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
-              }
+              constructInstanceFree(caseClass.primaryConstructor, "Constructor", Type[A].prettyPrint)(fieldMap)
+                .map(constructExpr => constructExpr.value.asInstanceOf[Expr[A]])
             }
         case None =>
           // No fields — just construct an empty instance
-          caseClass.primaryConstructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-            onTypes = _ => Map.empty,
-            onValues = _ => Map.empty
-          ) match {
-            case Right(constructExpr) =>
-              MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-            case Left(error) =>
-              MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
-          }
+          constructInstanceFree(caseClass.primaryConstructor, "Constructor", Type[A].prettyPrint)(Map.empty)
+            .map(constructExpr => constructExpr.value.asInstanceOf[Expr[A]])
       }
     }
   }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/ApplyKMacrosImpl.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/ApplyKMacrosImpl.scala
@@ -87,12 +87,8 @@ trait ApplyKMacrosImpl extends FunctorKMacrosImpl with SemigroupalKMacrosImpl { 
     val isTrait = AnonymousInstance.parse(using AlgWCtor1Type).toEither.isRight
 
     if (!isCaseClass && !isTrait) {
-      MIO.fail(
-        new RuntimeException(
-          s"Cannot derive ApplyK for ${ctx.applyKAlgType.prettyPrint}: " +
-            "type is neither a case class nor a trait"
-        )
-      )
+      val err = CatsTaglessDerivationError.NotCaseClassOrTrait("ApplyK", ctx.applyKAlgType.prettyPrint)
+      Log.error(err.message) >> MIO.fail(err)
     } else if (isCaseClass) {
       buildApplyKCaseClassExpr[Alg](runSafe).map(identity)
     } else {
@@ -192,19 +188,5 @@ trait ApplyKMacrosImpl extends FunctorKMacrosImpl with SemigroupalKMacrosImpl { 
         )
       }
     }
-  }
-}
-
-sealed private[compiletime] trait ApplyKDerivationError
-    extends util.control.NoStackTrace
-    with Product
-    with Serializable {
-  def message: String
-  override def getMessage(): String = message
-}
-private[compiletime] object ApplyKDerivationError {
-  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends ApplyKDerivationError {
-    override def message: String =
-      s"The type $tpeName was not handled by any ApplyK derivation rule:\n${reasons.mkString("\n")}"
   }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/CatsTaglessDerivationError.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/CatsTaglessDerivationError.scala
@@ -42,8 +42,7 @@ private[compiletime] object CatsTaglessDerivationError {
   }
 
   /** A method required by the target instance was not found on the source instance. */
-  final case class SourceMethodNotFound(methodName: String, details: String = "")
-      extends CatsTaglessDerivationError {
+  final case class SourceMethodNotFound(methodName: String, details: String = "") extends CatsTaglessDerivationError {
     override def message: String = s"Source method $methodName not found$details"
   }
 

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/CatsTaglessDerivationError.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/CatsTaglessDerivationError.scala
@@ -1,0 +1,59 @@
+package hearth.kindlings.catstaglessderivation.internal.compiletime
+
+sealed private[compiletime] trait CatsTaglessDerivationError
+    extends util.control.NoStackTrace
+    with Product
+    with Serializable {
+  def message: String
+  override def getMessage(): String = message
+}
+private[compiletime] object CatsTaglessDerivationError {
+
+  /** No derivation rule handled the algebra type. */
+  final case class UnsupportedType(typeClass: String, tpeName: String, reasons: List[String])
+      extends CatsTaglessDerivationError {
+    override def message: String =
+      s"The type $tpeName was not handled by any $typeClass derivation rule:\n${reasons.mkString("\n")}"
+  }
+
+  /** The algebra is neither a case class nor a trait, so no derivation strategy applies. */
+  final case class NotCaseClassOrTrait(typeClass: String, tpeName: String) extends CatsTaglessDerivationError {
+    override def message: String =
+      s"Cannot derive $typeClass for $tpeName: type is neither a case class nor a trait"
+  }
+
+  /** A probe/source/target application of the algebra (e.g. Alg[Option]) could not be parsed as a case class or as an
+    * anonymous instance.
+    */
+  final case class CannotParseAlgebra(algebra: String, reason: String) extends CatsTaglessDerivationError {
+    override def message: String = s"Cannot parse $algebra: $reason"
+  }
+
+  /** A case class field has a shape that the type class being derived cannot handle. */
+  final case class UnsupportedField(typeClass: String, fieldName: String, reason: String)
+      extends CatsTaglessDerivationError {
+    override def message: String = s"Cannot derive $typeClass: field '$fieldName' $reason"
+  }
+
+  /** A trait method has a shape that the type class being derived cannot handle. */
+  final case class UnsupportedMethod(typeClass: String, methodName: String, reason: String)
+      extends CatsTaglessDerivationError {
+    override def message: String = s"Cannot derive $typeClass for trait: method '$methodName' $reason"
+  }
+
+  /** A method required by the target instance was not found on the source instance. */
+  final case class SourceMethodNotFound(methodName: String, details: String = "")
+      extends CatsTaglessDerivationError {
+    override def message: String = s"Source method $methodName not found$details"
+  }
+
+  /** Building the forwarding call (Method.fold) for a trait method failed. */
+  final case class MethodForwardingFailed(methodName: String, reason: String) extends CatsTaglessDerivationError {
+    override def message: String = s"Cannot build forwarding call for method '$methodName': $reason"
+  }
+
+  /** Constructing the final type class instance (case class construction or anonymous instance) failed. */
+  final case class CannotConstructResult(typeClass: String, reason: String) extends CatsTaglessDerivationError {
+    override def message: String = s"Cannot construct $typeClass result: $reason"
+  }
+}

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/ContravariantKMacrosImpl.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/ContravariantKMacrosImpl.scala
@@ -49,7 +49,8 @@ trait ContravariantKMacrosImpl
               else s" - ${rule.name}: ${reasons.mkString(", ")}"
             }
             .toList
-          val err = ContravariantKDerivationError.UnsupportedType(
+          val err = CatsTaglessDerivationError.UnsupportedType(
+            "ContravariantK",
             ckctx.contravariantKAlgType.prettyPrint,
             reasonsStrings
           )
@@ -124,127 +125,115 @@ trait ContravariantKMacrosImpl
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val ccOption = CaseClass.parse(using AlgOptionType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val ccList = CaseClass.parse(using AlgListType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+    parsedOrFail(CaseClass.parse(using AlgOptionType).toEither, "Alg[Option]")
+      .parTuple(parsedOrFail(CaseClass.parse(using AlgListType).toEither, "Alg[List]"))
+      .flatMap { case (ccOption, ccList) =>
+        val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
+        val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
 
-    val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
-    val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
+        val nestedFieldExprs = scala.collection.mutable.Map.empty[String, Expr[Any]]
 
-    val nestedFieldExprs = scala.collection.mutable.Map.empty[String, Expr[Any]]
+        val contravariantKAnchor = Type
+          .of[cats.tagless.ContravariantK[CatsTaglessFactories.DummyHKT]]
+          .asInstanceOf[Type[Any]]
+        val invariantKAnchor = Type
+          .of[cats.tagless.InvariantK[CatsTaglessFactories.DummyHKT]]
+          .asInstanceOf[Type[Any]]
 
-    val contravariantKAnchor = Type
-      .of[cats.tagless.ContravariantK[CatsTaglessFactories.DummyHKT]]
-      .asInstanceOf[Type[Any]]
-    val invariantKAnchor = Type
-      .of[cats.tagless.InvariantK[CatsTaglessFactories.DummyHKT]]
-      .asInstanceOf[Type[Any]]
+        val nestedFieldDerivations: MIO[Unit] =
+          fieldsOption.zip(fieldsList).foldLeft(MIO.pure(())) { case (acc, ((name, pOption), (_, pList))) =>
+            val tOption = pOption.tpe.Underlying
+            val tList = pList.tpe.Underlying
+            val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
+            val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
 
-    val nestedFieldDerivations: MIO[Unit] =
-      fieldsOption.zip(fieldsList).foldLeft(MIO.pure(())) { case (acc, ((name, pOption), (_, pList))) =>
-        val tOption = pOption.tpe.Underlying
-        val tList = pList.tpe.Underlying
-        val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
-        val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
-
-        (optionUnapply, listUnapply) match {
-          case (Some(_), Some(_)) =>
-            acc >> MIO.fail(
-              new RuntimeException(
-                s"Cannot derive ContravariantK: field '$name' is covariant in the type constructor parameter " +
-                  s"(has type F[X]). ContravariantK can only handle contravariant or invariant fields. " +
-                  "Consider using InvariantK or FunctorK instead."
-              )
-            )
-          case (None, None) =>
-            if (tOption =:= tList) acc
-            else {
-              acc >> (constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], contravariantKAnchor) match {
-                case Some(info) =>
-                  val nestedCtorK1 = Type.CtorK1.fromUntyped[CatsTaglessFactories.DummyHKT](info.ctorK1Untyped)
-                  val nestedCKType = info.typeClassType
-                    .asInstanceOf[Type[cats.tagless.ContravariantK[CatsTaglessFactories.DummyHKT]]]
-                  val nestedCtx = ContravariantKCtx[CatsTaglessFactories.DummyHKT](
-                    nestedCtorK1,
-                    nestedCKType,
-                    ctx.cache,
-                    ctx.derivedType
-                  )
-                  deriveContravariantKRecursively[CatsTaglessFactories.DummyHKT](using nestedCtx).map { nestedExpr =>
-                    nestedFieldExprs += (name -> nestedExpr.asInstanceOf[Expr[Any]])
-                    ()
-                  }
-                case None =>
-                  val invariantKAvailable = constructTypeClassTypeForField(
-                    tOption.asInstanceOf[Type[Any]],
-                    invariantKAnchor
-                  ).exists(info => info.typeClassType.summonExprIgnoring().toEither.isRight)
-                  val hint =
-                    if (invariantKAvailable)
-                      " An InvariantK instance exists for it — consider using InvariantK.derived instead."
-                    else ""
-                  MIO.fail(
-                    new RuntimeException(
-                      s"Cannot derive ContravariantK: field '$name' depends on the type constructor parameter " +
-                        s"but no ContravariantK instance could be derived for its outer type constructor.$hint"
-                    )
-                  )
-              })
+            (optionUnapply, listUnapply) match {
+              case (Some(_), Some(_)) =>
+                acc >> failUnsupportedField(
+                  "ContravariantK",
+                  name,
+                  "is covariant in the type constructor parameter " +
+                    "(has type F[X]). ContravariantK can only handle contravariant or invariant fields. " +
+                    "Consider using InvariantK or FunctorK instead."
+                )
+              case (None, None) =>
+                if (tOption =:= tList) acc
+                else {
+                  acc >> (constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], contravariantKAnchor) match {
+                    case Some(info) =>
+                      val nestedCtorK1 = Type.CtorK1.fromUntyped[CatsTaglessFactories.DummyHKT](info.ctorK1Untyped)
+                      val nestedCKType = info.typeClassType
+                        .asInstanceOf[Type[cats.tagless.ContravariantK[CatsTaglessFactories.DummyHKT]]]
+                      val nestedCtx = ContravariantKCtx[CatsTaglessFactories.DummyHKT](
+                        nestedCtorK1,
+                        nestedCKType,
+                        ctx.cache,
+                        ctx.derivedType
+                      )
+                      deriveContravariantKRecursively[CatsTaglessFactories.DummyHKT](using nestedCtx).map {
+                        nestedExpr =>
+                          nestedFieldExprs += (name -> nestedExpr.asInstanceOf[Expr[Any]])
+                          ()
+                      }
+                    case None =>
+                      val invariantKAvailable = constructTypeClassTypeForField(
+                        tOption.asInstanceOf[Type[Any]],
+                        invariantKAnchor
+                      ).exists(info => info.typeClassType.summonExprIgnoring().toEither.isRight)
+                      val hint =
+                        if (invariantKAvailable)
+                          " An InvariantK instance exists for it — consider using InvariantK.derived instead."
+                        else ""
+                      failUnsupportedField(
+                        "ContravariantK",
+                        name,
+                        "depends on the type constructor parameter " +
+                          s"but no ContravariantK instance could be derived for its outer type constructor.$hint"
+                      )
+                  })
+                }
+              case _ =>
+                acc >> failUnsupportedField("ContravariantK", name, "has inconsistent probe decomposition.")
             }
-          case _ =>
-            acc >> MIO.fail(
-              new RuntimeException(
-                s"Cannot derive ContravariantK: field '$name' has inconsistent probe decomposition."
-              )
-            )
-        }
-      }
-
-    for {
-      _ <- nestedFieldDerivations
-      result <- {
-        val sourceCC = CaseClass.parse(using AlgWCtor1Type).toEither match {
-          case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse: $e")
-        }
-        val targetCC = CaseClass.parse(using AlgWCtor2Type).toEither match {
-          case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse: $e")
-        }
-        val sourceFields = sourceCC.caseFieldValuesAt(afExpr).toList
-        val targetParamTypes: Map[String, Type[Any]] = targetCC.primaryConstructor.parameters.flatten.toList.map {
-          case (n, p) => import p.tpe.Underlying as PF; (n, Type[PF].asInstanceOf[Type[Any]])
-        }.toMap
-
-        val nestedFieldMap = nestedFieldExprs.toMap
-
-        val mappedFields: List[(String, Expr_??)] = sourceFields.map { case (fieldName, fieldValue) =>
-          import fieldValue.Underlying as Field
-          val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-
-          if (nestedFieldMap.contains(fieldName)) {
-            val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
-            val mapped = mkNestedContramapK[Field](nestedFieldMap(fieldName), fieldExpr.upcast[Any], fkExpr)(tgt)
-            (fieldName, mapped.as_??(tgt))
-          } else {
-            (fieldName, fieldExpr.as_??)
           }
-        }
 
-        targetCC.primaryConstructor.fold(
-          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-          onTypes = _ => Map.empty,
-          onValues = _ => mappedFields.toMap
-        ) match {
-          case Right(constructExpr) =>
-            import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor2Type))
-          case Left(error) => MIO.fail(new RuntimeException(s"Cannot construct ContravariantK result: $error"))
-        }
+        for {
+          _ <- nestedFieldDerivations
+          sourceAndTarget <- parsedOrFail(CaseClass.parse(using AlgWCtor1Type).toEither, "Alg[WCtor1]")
+            .parTuple(parsedOrFail(CaseClass.parse(using AlgWCtor2Type).toEither, "Alg[WCtor2]"))
+          result <- {
+            val (sourceCC, targetCC) = sourceAndTarget
+            val sourceFields = sourceCC.caseFieldValuesAt(afExpr).toList
+            val targetParamTypes: Map[String, Type[Any]] = targetCC.primaryConstructor.parameters.flatten.toList.map {
+              case (n, p) => import p.tpe.Underlying as PF; (n, Type[PF].asInstanceOf[Type[Any]])
+            }.toMap
+
+            val nestedFieldMap = nestedFieldExprs.toMap
+
+            val mappedFields: List[(String, Expr_??)] = sourceFields.map { case (fieldName, fieldValue) =>
+              import fieldValue.Underlying as Field
+              val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+
+              if (nestedFieldMap.contains(fieldName)) {
+                val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
+                val mapped = mkNestedContramapK[Field](nestedFieldMap(fieldName), fieldExpr.upcast[Any], fkExpr)(tgt)
+                (fieldName, mapped.as_??(tgt))
+              } else {
+                (fieldName, fieldExpr.as_??)
+              }
+            }
+
+            foldInstanceFree(targetCC.primaryConstructor, "Constructor")(
+              onTypes = _ => Map.empty,
+              onValues = _ => mappedFields.toMap
+            ) match {
+              case Right(constructExpr) =>
+                import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor2Type))
+              case Left(error) => failCannotConstruct("ContravariantK", error)
+            }
+          }
+        } yield result
       }
-    } yield result
   }
 
   @scala.annotation.nowarn("msg=is never used|unused implicit parameter")
@@ -258,18 +247,4 @@ trait ContravariantKMacrosImpl
         .contramapK(Expr.splice(contravariantKExpr), Expr.splice(fieldExpr), Expr.splice(fkExpr))
         .asInstanceOf[Result]
     }
-}
-
-sealed private[compiletime] trait ContravariantKDerivationError
-    extends util.control.NoStackTrace
-    with Product
-    with Serializable {
-  def message: String
-  override def getMessage(): String = message
-}
-private[compiletime] object ContravariantKDerivationError {
-  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends ContravariantKDerivationError {
-    override def message: String =
-      s"The type $tpeName was not handled by any ContravariantK derivation rule:\n${reasons.mkString("\n")}"
-  }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/FunctorKMacrosImpl.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/FunctorKMacrosImpl.scala
@@ -49,7 +49,8 @@ trait FunctorKMacrosImpl
               else s" - ${rule.name}: ${reasons.mkString(", ")}"
             }
             .toList
-          val err = FunctorKDerivationError.UnsupportedType(
+          val err = CatsTaglessDerivationError.UnsupportedType(
+            "FunctorK",
             fkctx.functorKAlgType.prettyPrint,
             reasonsStrings
           )
@@ -124,131 +125,123 @@ trait FunctorKMacrosImpl
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val ccOption = CaseClass.parse(using AlgOptionType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val ccList = CaseClass.parse(using AlgListType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+    parsedOrFail(CaseClass.parse(using AlgOptionType).toEither, "Alg[Option]")
+      .parTuple(parsedOrFail(CaseClass.parse(using AlgListType).toEither, "Alg[List]"))
+      .flatMap { case (ccOption, ccList) =>
+        val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
+        val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
 
-    val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
-    val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
+        val directFields = scala.collection.mutable.Set.empty[String]
+        val nestedFieldExprs = scala.collection.mutable.Map.empty[String, Expr[Any]]
 
-    val directFields = scala.collection.mutable.Set.empty[String]
-    val nestedFieldExprs = scala.collection.mutable.Map.empty[String, Expr[Any]]
+        val functorKAnchor = Type
+          .of[cats.tagless.FunctorK[CatsTaglessFactories.DummyHKT]]
+          .asInstanceOf[Type[Any]]
+        val invariantKAnchor = Type
+          .of[cats.tagless.InvariantK[CatsTaglessFactories.DummyHKT]]
+          .asInstanceOf[Type[Any]]
 
-    val functorKAnchor = Type
-      .of[cats.tagless.FunctorK[CatsTaglessFactories.DummyHKT]]
-      .asInstanceOf[Type[Any]]
-    val invariantKAnchor = Type
-      .of[cats.tagless.InvariantK[CatsTaglessFactories.DummyHKT]]
-      .asInstanceOf[Type[Any]]
+        val nestedFieldDerivations: MIO[Unit] =
+          fieldsOption.zip(fieldsList).foldLeft(MIO.pure(())) { case (acc, ((name, pOption), (_, pList))) =>
+            val tOption = pOption.tpe.Underlying
+            val tList = pList.tpe.Underlying
+            val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
+            val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
 
-    val nestedFieldDerivations: MIO[Unit] =
-      fieldsOption.zip(fieldsList).foldLeft(MIO.pure(())) { case (acc, ((name, pOption), (_, pList))) =>
-        val tOption = pOption.tpe.Underlying
-        val tList = pList.tpe.Underlying
-        val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
-        val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
-
-        (optionUnapply, listUnapply) match {
-          case (Some(innerOption), Some(innerList)) =>
-            import innerOption.Underlying as InnerO
-            import innerList.Underlying as InnerL
-            if (InnerO =:= InnerL) { directFields += name; acc }
-            else
-              acc >> MIO.fail(
-                new RuntimeException(
-                  s"Cannot derive FunctorK: field '$name' has type constructor parameter " +
-                    "nested within its own type argument (e.g. F[F[X]]). This is not supported."
-                )
-              )
-          case (None, None) =>
-            if (tOption =:= tList) acc
-            else {
-              acc >> (constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], functorKAnchor) match {
-                case Some(info) =>
-                  val nestedCtorK1 = Type.CtorK1.fromUntyped[CatsTaglessFactories.DummyHKT](info.ctorK1Untyped)
-                  val nestedFKType =
-                    info.typeClassType.asInstanceOf[Type[cats.tagless.FunctorK[CatsTaglessFactories.DummyHKT]]]
-                  val nestedCtx =
-                    FunctorKCtx[CatsTaglessFactories.DummyHKT](nestedCtorK1, nestedFKType, ctx.cache, ctx.derivedType)
-                  deriveFunctorKRecursively[CatsTaglessFactories.DummyHKT](using nestedCtx).map { nestedExpr =>
-                    nestedFieldExprs += (name -> nestedExpr.asInstanceOf[Expr[Any]])
-                    ()
-                  }
-                case None =>
-                  val invariantKAvailable =
-                    constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], invariantKAnchor)
-                      .exists(info => info.typeClassType.summonExprIgnoring().toEither.isRight)
-                  val hint =
-                    if (invariantKAvailable)
-                      " An InvariantK instance exists for it — consider using InvariantK.derived instead."
-                    else ""
-                  MIO.fail(
-                    new RuntimeException(
-                      s"Cannot derive FunctorK: field '$name' depends on the type constructor parameter " +
-                        s"but no FunctorK instance could be derived for its outer type constructor.$hint"
-                    )
+            (optionUnapply, listUnapply) match {
+              case (Some(innerOption), Some(innerList)) =>
+                import innerOption.Underlying as InnerO
+                import innerList.Underlying as InnerL
+                if (InnerO =:= InnerL) { directFields += name; acc }
+                else
+                  acc >> failUnsupportedField(
+                    "FunctorK",
+                    name,
+                    "has type constructor parameter " +
+                      "nested within its own type argument (e.g. F[F[X]]). This is not supported."
                   )
-              })
+              case (None, None) =>
+                if (tOption =:= tList) acc
+                else {
+                  acc >> (constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], functorKAnchor) match {
+                    case Some(info) =>
+                      val nestedCtorK1 = Type.CtorK1.fromUntyped[CatsTaglessFactories.DummyHKT](info.ctorK1Untyped)
+                      val nestedFKType =
+                        info.typeClassType.asInstanceOf[Type[cats.tagless.FunctorK[CatsTaglessFactories.DummyHKT]]]
+                      val nestedCtx =
+                        FunctorKCtx[CatsTaglessFactories.DummyHKT](
+                          nestedCtorK1,
+                          nestedFKType,
+                          ctx.cache,
+                          ctx.derivedType
+                        )
+                      deriveFunctorKRecursively[CatsTaglessFactories.DummyHKT](using nestedCtx).map { nestedExpr =>
+                        nestedFieldExprs += (name -> nestedExpr.asInstanceOf[Expr[Any]])
+                        ()
+                      }
+                    case None =>
+                      val invariantKAvailable =
+                        constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], invariantKAnchor)
+                          .exists(info => info.typeClassType.summonExprIgnoring().toEither.isRight)
+                      val hint =
+                        if (invariantKAvailable)
+                          " An InvariantK instance exists for it — consider using InvariantK.derived instead."
+                        else ""
+                      failUnsupportedField(
+                        "FunctorK",
+                        name,
+                        "depends on the type constructor parameter " +
+                          s"but no FunctorK instance could be derived for its outer type constructor.$hint"
+                      )
+                  })
+                }
+              case _ =>
+                acc >> failUnsupportedField("FunctorK", name, "has inconsistent probe decomposition.")
             }
-          case _ =>
-            acc >> MIO.fail(
-              new RuntimeException(
-                s"Cannot derive FunctorK: field '$name' has inconsistent probe decomposition."
-              )
-            )
-        }
-      }
-
-    for {
-      _ <- nestedFieldDerivations
-      result <- {
-        val sourceCC = CaseClass.parse(using AlgWCtor1Type).toEither match {
-          case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse: $e")
-        }
-        val targetCC = CaseClass.parse(using AlgWCtor2Type).toEither match {
-          case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse: $e")
-        }
-        val sourceFields = sourceCC.caseFieldValuesAt(afExpr).toList
-        val targetParamTypes: Map[String, Type[Any]] = targetCC.primaryConstructor.parameters.flatten.toList.map {
-          case (n, p) => import p.tpe.Underlying as PF; (n, Type[PF].asInstanceOf[Type[Any]])
-        }.toMap
-
-        val directFieldSet = directFields.toSet
-        val nestedFieldMap = nestedFieldExprs.toMap
-
-        val mappedFields: List[(String, Expr_??)] = sourceFields.map { case (fieldName, fieldValue) =>
-          import fieldValue.Underlying as Field
-          val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-
-          if (directFieldSet.contains(fieldName)) {
-            val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
-            val mapped = mkApplyFk[Field](fkExpr, fieldExpr.upcast[Any])(tgt)
-            (fieldName, mapped.as_??(tgt))
-          } else if (nestedFieldMap.contains(fieldName)) {
-            val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
-            val mapped = mkNestedMapK[Field](nestedFieldMap(fieldName), fieldExpr.upcast[Any], fkExpr)(tgt)
-            (fieldName, mapped.as_??(tgt))
-          } else {
-            (fieldName, fieldExpr.as_??)
           }
-        }
 
-        targetCC.primaryConstructor.fold(
-          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-          onTypes = _ => Map.empty,
-          onValues = _ => mappedFields.toMap
-        ) match {
-          case Right(constructExpr) =>
-            import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor2Type))
-          case Left(error) => MIO.fail(new RuntimeException(s"Cannot construct FunctorK result: $error"))
-        }
+        for {
+          _ <- nestedFieldDerivations
+          sourceAndTarget <- parsedOrFail(CaseClass.parse(using AlgWCtor1Type).toEither, "Alg[WCtor1]")
+            .parTuple(parsedOrFail(CaseClass.parse(using AlgWCtor2Type).toEither, "Alg[WCtor2]"))
+          result <- {
+            val (sourceCC, targetCC) = sourceAndTarget
+            val sourceFields = sourceCC.caseFieldValuesAt(afExpr).toList
+            val targetParamTypes: Map[String, Type[Any]] = targetCC.primaryConstructor.parameters.flatten.toList.map {
+              case (n, p) => import p.tpe.Underlying as PF; (n, Type[PF].asInstanceOf[Type[Any]])
+            }.toMap
+
+            val directFieldSet = directFields.toSet
+            val nestedFieldMap = nestedFieldExprs.toMap
+
+            val mappedFields: List[(String, Expr_??)] = sourceFields.map { case (fieldName, fieldValue) =>
+              import fieldValue.Underlying as Field
+              val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+
+              if (directFieldSet.contains(fieldName)) {
+                val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
+                val mapped = mkApplyFk[Field](fkExpr, fieldExpr.upcast[Any])(tgt)
+                (fieldName, mapped.as_??(tgt))
+              } else if (nestedFieldMap.contains(fieldName)) {
+                val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
+                val mapped = mkNestedMapK[Field](nestedFieldMap(fieldName), fieldExpr.upcast[Any], fkExpr)(tgt)
+                (fieldName, mapped.as_??(tgt))
+              } else {
+                (fieldName, fieldExpr.as_??)
+              }
+            }
+
+            foldInstanceFree(targetCC.primaryConstructor, "Constructor")(
+              onTypes = _ => Map.empty,
+              onValues = _ => mappedFields.toMap
+            ) match {
+              case Right(constructExpr) =>
+                import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor2Type))
+              case Left(error) => failCannotConstruct("FunctorK", error)
+            }
+          }
+        } yield result
       }
-    } yield result
   }
 
   @scala.annotation.nowarn("msg=is never used|unused implicit parameter")
@@ -262,18 +255,4 @@ trait FunctorKMacrosImpl
         .mapK(Expr.splice(functorKExpr), Expr.splice(fieldExpr), Expr.splice(fkExpr))
         .asInstanceOf[Result]
     }
-}
-
-sealed private[compiletime] trait FunctorKDerivationError
-    extends util.control.NoStackTrace
-    with Product
-    with Serializable {
-  def message: String
-  override def getMessage(): String = message
-}
-private[compiletime] object FunctorKDerivationError {
-  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends FunctorKDerivationError {
-    override def message: String =
-      s"The type $tpeName was not handled by any FunctorK derivation rule:\n${reasons.mkString("\n")}"
-  }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/InstrumentMacrosImpl.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/InstrumentMacrosImpl.scala
@@ -86,12 +86,8 @@ trait InstrumentMacrosImpl extends FunctorKMacrosImpl { this: MacroCommons & Std
     val isTrait = AnonymousInstance.parse(using AlgWCtor1Type).toEither.isRight
 
     if (!isCaseClass && !isTrait) {
-      MIO.fail(
-        new RuntimeException(
-          s"Cannot derive Instrument for ${ctx.instrumentAlgType.prettyPrint}: " +
-            "type is neither a case class nor a trait"
-        )
-      )
+      val err = CatsTaglessDerivationError.NotCaseClassOrTrait("Instrument", ctx.instrumentAlgType.prettyPrint)
+      Log.error(err.message) >> MIO.fail(err)
     } else if (isCaseClass) {
       buildInstrumentCaseClassExpr[Alg](runSafe)
     } else {
@@ -163,71 +159,63 @@ trait InstrumentMacrosImpl extends FunctorKMacrosImpl { this: MacroCommons & Std
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val ccOption = CaseClass.parse(using AlgOptionType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val ccList = CaseClass.parse(using AlgListType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+    parsedOrFail(CaseClass.parse(using AlgOptionType).toEither, "Alg[Option]")
+      .parTuple(parsedOrFail(CaseClass.parse(using AlgListType).toEither, "Alg[List]"))
+      .flatMap { case (ccOption, ccList) =>
+        val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
+        val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
 
-    val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
-    val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
+        // Classify fields: direct F[X] fields get wrapped in Instrumentation
+        val directFields = scala.collection.mutable.Set.empty[String]
 
-    // Classify fields: direct F[X] fields get wrapped in Instrumentation
-    val directFields = scala.collection.mutable.Set.empty[String]
+        fieldsOption.zip(fieldsList).foreach { case ((name, pOption), (_, pList)) =>
+          val tOption = pOption.tpe.Underlying
+          val tList = pList.tpe.Underlying
+          val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
+          val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
 
-    fieldsOption.zip(fieldsList).foreach { case ((name, pOption), (_, pList)) =>
-      val tOption = pOption.tpe.Underlying
-      val tList = pList.tpe.Underlying
-      val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
-      val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
+          (optionUnapply, listUnapply) match {
+            case (Some(innerOption), Some(innerList)) =>
+              import innerOption.Underlying as InnerO
+              import innerList.Underlying as InnerL
+              if (InnerO =:= InnerL) directFields += name
+            case _ => // invariant or nested — pass through
+          }
+        }
 
-      (optionUnapply, listUnapply) match {
-        case (Some(innerOption), Some(innerList)) =>
-          import innerOption.Underlying as InnerO
-          import innerList.Underlying as InnerL
-          if (InnerO =:= InnerL) directFields += name
-        case _ => // invariant or nested — pass through
+        parsedOrFail(CaseClass.parse(using AlgWCtor1Type).toEither, "Alg[WCtor1]")
+          .parTuple(parsedOrFail(CaseClass.parse(using AlgWCtor2Type).toEither, "Alg[WCtor2]"))
+          .flatMap { case (sourceCC, targetCC) =>
+            val sourceFields = sourceCC.caseFieldValuesAt(afExpr).toList
+            val targetParamTypes: Map[String, Type[Any]] = targetCC.primaryConstructor.parameters.flatten.toList.map {
+              case (n, p) => import p.tpe.Underlying as PF; (n, Type[PF].asInstanceOf[Type[Any]])
+            }.toMap
+
+            val directFieldSet = directFields.toSet
+
+            val mappedFields: List[(String, Expr_??)] = sourceFields.map { case (fieldName, fieldValue) =>
+              import fieldValue.Underlying as Field
+              val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+
+              if (directFieldSet.contains(fieldName)) {
+                val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
+                val mapped = mkInstrumentation[Field](fieldExpr.upcast[Any], algebraName, fieldName)(tgt)
+                (fieldName, mapped.as_??(tgt))
+              } else {
+                (fieldName, fieldExpr.as_??)
+              }
+            }
+
+            foldInstanceFree(targetCC.primaryConstructor, "Constructor")(
+              onTypes = _ => Map.empty,
+              onValues = _ => mappedFields.toMap
+            ) match {
+              case Right(constructExpr) =>
+                import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor2Type))
+              case Left(error) => failCannotConstruct("Instrument", error)
+            }
+          }
       }
-    }
-
-    val sourceCC = CaseClass.parse(using AlgWCtor1Type).toEither match {
-      case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse: $e")
-    }
-    val targetCC = CaseClass.parse(using AlgWCtor2Type).toEither match {
-      case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse: $e")
-    }
-    val sourceFields = sourceCC.caseFieldValuesAt(afExpr).toList
-    val targetParamTypes: Map[String, Type[Any]] = targetCC.primaryConstructor.parameters.flatten.toList.map {
-      case (n, p) => import p.tpe.Underlying as PF; (n, Type[PF].asInstanceOf[Type[Any]])
-    }.toMap
-
-    val directFieldSet = directFields.toSet
-
-    val mappedFields: List[(String, Expr_??)] = sourceFields.map { case (fieldName, fieldValue) =>
-      import fieldValue.Underlying as Field
-      val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-
-      if (directFieldSet.contains(fieldName)) {
-        val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
-        val mapped = mkInstrumentation[Field](fieldExpr.upcast[Any], algebraName, fieldName)(tgt)
-        (fieldName, mapped.as_??(tgt))
-      } else {
-        (fieldName, fieldExpr.as_??)
-      }
-    }
-
-    targetCC.primaryConstructor.fold(
-      onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-      onTypes = _ => Map.empty,
-      onValues = _ => mappedFields.toMap
-    ) match {
-      case Right(constructExpr) =>
-        import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor2Type))
-      case Left(error) => MIO.fail(new RuntimeException(s"Cannot construct Instrument result: $error"))
-    }
   }
 
   // --- Trait: wrap each F[X] method return in Instrumentation(methodName, af.method(args)) ---
@@ -296,104 +284,124 @@ trait InstrumentMacrosImpl extends FunctorKMacrosImpl { this: MacroCommons & Std
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val anonInstance = AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor2] as anonymous instance: $e")
-    }
+    parsedOrFail(
+      AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither,
+      "Alg[WCtor2] as anonymous instance"
+    )
+      .parTuple(
+        parsedOrFail(
+          AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither,
+          "Alg[WCtor1] as anonymous instance"
+        )
+      )
+      .parTuple(
+        parsedOrFail(AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither, "Alg[Option]")
+      )
+      .parTuple(parsedOrFail(AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither, "Alg[List]"))
+      .flatMap { case (((anonInstance, anonInstanceSource), aiOption), aiList) =>
+        val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
+        val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
 
-    val anonInstanceSource = AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor1] as anonymous instance: $e")
-    }
+        // Pre-validate that every method we must override exists on the source instance, so that the
+        // OverrideBody callbacks below can never hit a missing source method.
+        val missingSourceMethods: List[CatsTaglessDerivationError] = anonInstance.mustOverride
+          .map(_.method.name)
+          .filterNot(n => anonInstanceSource.mustOverride.exists(_.method.name == n))
+          .map(n => CatsTaglessDerivationError.SourceMethodNotFound(n))
 
-    val aiOption = AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val aiList = AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+        missingSourceMethods match {
+          case head :: tail =>
+            Log.error((head :: tail).map(_.message).mkString("\n")) >> MIO.fail(head, tail*)
+          case Nil =>
 
-    val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
-    val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
+            val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
+              val methodName = cm.method.name
+              val sourceMethodOpt = anonInstanceSource.mustOverride.find(_.method.name == methodName)
 
-    val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
-      val methodName = cm.method.name
-      val sourceMethodOpt = anonInstanceSource.mustOverride.find(_.method.name == methodName)
-
-      val isDirectF: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
-        case (Some(om), Some(lm)) =>
-          (om.method.knownReturning, lm.method.knownReturning) match {
-            case (Some(or), Some(lr)) =>
-              (
-                OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
-                ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
-              ) match {
-                case (Some(io), Some(il)) =>
-                  import io.Underlying as IO; import il.Underlying as IL
-                  IO =:= IL
+              val isDirectF: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
+                case (Some(om), Some(lm)) =>
+                  (om.method.knownReturning, lm.method.knownReturning) match {
+                    case (Some(or), Some(lr)) =>
+                      (
+                        OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
+                        ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
+                      ) match {
+                        case (Some(io), Some(il)) =>
+                          import io.Underlying as IO; import il.Underlying as IL
+                          IO =:= IL
+                        case _ => false
+                      }
+                    case _ => false
+                  }
                 case _ => false
               }
-            case _ => false
-          }
-        case _ => false
-      }
 
-      val body: OverrideBody = new OverrideBody {
-        def apply(octx: OverrideContext): Expr_?? = {
-          val returnT = octx.returnType
+              val body: OverrideBody = new OverrideBody {
+                def apply(octx: OverrideContext): Expr_?? = {
+                  val returnT = octx.returnType
 
-          // Call the same method on the source (af) instance
-          val sourceCall: Expr[Any] = sourceMethodOpt match {
-            case Some(sourceCM) =>
-              val sm = sourceCM.method
-              try
-                sm.fold(
-                  onInstance = oi => afExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
-                  onTypes = _ => Map.empty,
-                  onValues = av => {
-                    val paramNames = av.totalParameters.flatten.toList.map(_._1)
-                    paramNames.zip(octx.parameters).toMap
+                  // Call the same method on the source (af) instance
+                  // OverrideBody is a synchronous callback invoked inside `anonInstance.construct`; it cannot
+                  // return MIO. Typed errors thrown here are caught by the MIO block wrapping `construct`
+                  // below and routed into the MIO error channel.
+                  val sourceCall: Expr[Any] = sourceMethodOpt match {
+                    case Some(sourceCM) =>
+                      val sm = sourceCM.method
+                      try
+                        sm.fold(
+                          onInstance = oi => afExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
+                          onTypes = _ => Map.empty,
+                          onValues = av => {
+                            val paramNames = av.totalParameters.flatten.toList.map(_._1)
+                            paramNames.zip(octx.parameters).toMap
+                          }
+                        ) match {
+                          case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
+                          case Left(e)      =>
+                            throw CatsTaglessDerivationError.MethodForwardingFailed(
+                              methodName,
+                              s"fold returned Left: $e"
+                            )
+                        }
+                      catch {
+                        case e: CatsTaglessDerivationError  => throw e
+                        case scala.util.control.NonFatal(e) =>
+                          throw CatsTaglessDerivationError.MethodForwardingFailed(
+                            methodName,
+                            s"fold crashed (${sm.getClass.getSimpleName}, " +
+                              s"expectations=${sm.expectations}, isNullary=${sm.isNullary}): ${e.getMessage}"
+                          )
+                      }
+                    case None =>
+                      // Unreachable: validated via missingSourceMethods before building overrides.
+                      throw CatsTaglessDerivationError.SourceMethodNotFound(methodName)
                   }
-                ) match {
-                  case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
-                  case Left(e)      => throw new RuntimeException(s"fold returned Left for $methodName: $e")
-                }
-              catch {
-                case e: RuntimeException => throw e
-                case e: Throwable        =>
-                  throw new RuntimeException(
-                    s"fold crashed for method $methodName (${sm.getClass.getSimpleName}, " +
-                      s"expectations=${sm.expectations}, isNullary=${sm.isNullary}): ${e.getMessage}",
-                    e
-                  )
-              }
-            case None =>
-              throw new RuntimeException(s"Source method $methodName not found")
-          }
 
-          if (isDirectF) {
-            import returnT.Underlying as RT
-            mkInstrumentation[RT](sourceCall, algebraName, methodName)(returnT.Underlying).as_??(returnT.Underlying)
-          } else {
-            import returnT.Underlying as RT
-            Expr.quote(Expr.splice(sourceCall).asInstanceOf[RT]).as_??(returnT.Underlying)
-          }
+                  if (isDirectF) {
+                    import returnT.Underlying as RT
+                    mkInstrumentation[RT](sourceCall, algebraName, methodName)(returnT.Underlying).as_??(
+                      returnT.Underlying
+                    )
+                  } else {
+                    import returnT.Underlying as RT
+                    Expr.quote(Expr.splice(sourceCall).asInstanceOf[RT]).as_??(returnT.Underlying)
+                  }
+                }
+              }
+
+              cm.method.asUntyped -> body
+            }.toMap
+
+            // The MIO wrapper captures typed errors thrown from the OverrideBody callbacks invoked
+            // synchronously inside `construct` and routes them into the error channel.
+            MIO(anonInstance.construct(None, Map.empty, overrides)).flatMap {
+              case Right(expr) =>
+                MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor2]]])
+              case Left(errors) =>
+                failCannotConstruct("Instrument", s"trait instance: ${errors.toVector.mkString(", ")}")
+            }
         }
       }
-
-      cm.method.asUntyped -> body
-    }.toMap
-
-    anonInstance.construct(None, Map.empty, overrides) match {
-      case Right(expr) =>
-        MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor2]]])
-      case Left(errors) =>
-        MIO.fail(
-          new RuntimeException(
-            s"Cannot construct Instrument trait instance: ${errors.toVector.mkString(", ")}"
-          )
-        )
-    }
   }
 
   // --- Helpers ---
@@ -411,19 +419,5 @@ trait InstrumentMacrosImpl extends FunctorKMacrosImpl { this: MacroCommons & Std
         .mkInstrumentation(Expr.splice(valueExpr), Expr.splice(algNameExpr), Expr.splice(methodNameExpr))
         .asInstanceOf[Result]
     }
-  }
-}
-
-sealed private[compiletime] trait InstrumentDerivationError
-    extends util.control.NoStackTrace
-    with Product
-    with Serializable {
-  def message: String
-  override def getMessage(): String = message
-}
-private[compiletime] object InstrumentDerivationError {
-  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends InstrumentDerivationError {
-    override def message: String =
-      s"The type $tpeName was not handled by any Instrument derivation rule:\n${reasons.mkString("\n")}"
   }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/InvariantKMacrosImpl.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/InvariantKMacrosImpl.scala
@@ -11,7 +11,8 @@ trait InvariantKMacrosImpl
     with rules.InvariantKUseImplicitRuleImpl
     with rules.InvariantKCaseClassRuleImpl
     with rules.InvariantKTraitRuleImpl
-    with CatsTaglessDerivationTimeout { this: MacroCommons & StdExtensions =>
+    with CatsTaglessDerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds { this: MacroCommons & StdExtensions =>
 
   import hearth.kindlings.catstaglessderivation.internal.runtime.CatsTaglessFactories
 
@@ -31,6 +32,27 @@ trait InvariantKMacrosImpl
       typeClassType: Type[Any],
       ctorK1Untyped: UntypedType
   )
+
+  /** Routes a `CaseClass.parse`/`AnonymousInstance.parse` result into the MIO error channel instead of throwing. */
+  private[compiletime] def parsedOrFail[E, A](parsed: Either[E, A], algebra: String): MIO[A] =
+    parsed match {
+      case Right(a) => MIO.pure(a)
+      case Left(e)  =>
+        val err = CatsTaglessDerivationError.CannotParseAlgebra(algebra, e.toString)
+        Log.error(err.message) >> MIO.fail(err)
+    }
+
+  /** Routes field-classification failures into the MIO error channel. */
+  private[compiletime] def failUnsupportedField[A](typeClass: String, fieldName: String, reason: String): MIO[A] = {
+    val err = CatsTaglessDerivationError.UnsupportedField(typeClass, fieldName, reason)
+    Log.error(err.message) >> MIO.fail(err)
+  }
+
+  /** Routes instance-construction failures into the MIO error channel. */
+  private[compiletime] def failCannotConstruct[A](typeClass: String, reason: String): MIO[A] = {
+    val err = CatsTaglessDerivationError.CannotConstructResult(typeClass, reason)
+    Log.error(err.message) >> MIO.fail(err)
+  }
 
   // --- Context ---
 
@@ -68,7 +90,8 @@ trait InvariantKMacrosImpl
               else s" - ${rule.name}: ${reasons.mkString(", ")}"
             }
             .toList
-          val err = InvariantKDerivationError.UnsupportedType(
+          val err = CatsTaglessDerivationError.UnsupportedType(
+            "InvariantK",
             ikctx.invariantKAlgType.prettyPrint,
             reasonsStrings
           )
@@ -152,142 +175,127 @@ trait InvariantKMacrosImpl
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val ccOption = CaseClass.parse(using AlgOptionType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val ccList = CaseClass.parse(using AlgListType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+    parsedOrFail(CaseClass.parse(using AlgOptionType).toEither, "Alg[Option]")
+      .parTuple(parsedOrFail(CaseClass.parse(using AlgListType).toEither, "Alg[List]"))
+      .flatMap { case (ccOption, ccList) =>
+        val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
+        val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
 
-    val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
-    val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
+        // --- Field classification ---
 
-    // --- Field classification ---
+        val directFields = scala.collection.mutable.Set.empty[String]
+        val nestedFieldExprs = scala.collection.mutable.Map.empty[String, Expr[Any]]
 
-    val directFields = scala.collection.mutable.Set.empty[String]
-    val nestedFieldExprs = scala.collection.mutable.Map.empty[String, Expr[Any]]
+        val nestedFieldDerivations: MIO[Unit] =
+          fieldsOption.zip(fieldsList).foldLeft(MIO.pure(())) { case (acc, ((name, pOption), (_, pList))) =>
+            val tOption = pOption.tpe.Underlying
+            val tList = pList.tpe.Underlying
 
-    val nestedFieldDerivations: MIO[Unit] =
-      fieldsOption.zip(fieldsList).foldLeft(MIO.pure(())) { case (acc, ((name, pOption), (_, pList))) =>
-        val tOption = pOption.tpe.Underlying
-        val tList = pList.tpe.Underlying
+            val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
+            val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
 
-        val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
-        val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
-
-        (optionUnapply, listUnapply) match {
-          case (Some(innerOption), Some(innerList)) =>
-            import innerOption.Underlying as InnerO
-            import innerList.Underlying as InnerL
-            if (InnerO =:= InnerL) {
-              directFields += name
-              acc
-            } else {
-              acc >> MIO.fail(
-                new RuntimeException(
-                  s"Cannot derive InvariantK: field '$name' has type constructor parameter " +
-                    "nested within its own type argument (e.g. F[F[X]]). This is not supported."
-                )
-              )
-            }
-          case (None, None) =>
-            if (tOption =:= tList) {
-              acc // invariant
-            } else {
-              val invariantKAnchor = Type
-                .of[cats.tagless.InvariantK[CatsTaglessFactories.DummyHKT]]
-                .asInstanceOf[Type[Any]]
-              acc >> (constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], invariantKAnchor) match {
-                case Some(info) =>
-                  val nestedCtorK1 =
-                    Type.CtorK1.fromUntyped[CatsTaglessFactories.DummyHKT](info.ctorK1Untyped)
-                  val nestedIKType = info.typeClassType.asInstanceOf[Type[cats.tagless.InvariantK[
-                    CatsTaglessFactories.DummyHKT
-                  ]]]
-                  val nestedCtx = InvariantKCtx[CatsTaglessFactories.DummyHKT](
-                    nestedCtorK1,
-                    nestedIKType,
-                    ctx.cache,
-                    ctx.derivedType
+            (optionUnapply, listUnapply) match {
+              case (Some(innerOption), Some(innerList)) =>
+                import innerOption.Underlying as InnerO
+                import innerList.Underlying as InnerL
+                if (InnerO =:= InnerL) {
+                  directFields += name
+                  acc
+                } else {
+                  acc >> failUnsupportedField(
+                    "InvariantK",
+                    name,
+                    "has type constructor parameter " +
+                      "nested within its own type argument (e.g. F[F[X]]). This is not supported."
                   )
-                  deriveInvariantKRecursively[CatsTaglessFactories.DummyHKT](using nestedCtx).map { nestedExpr =>
-                    nestedFieldExprs += (name -> nestedExpr.asInstanceOf[Expr[Any]])
-                    ()
-                  }
-                case None =>
-                  MIO.fail(
-                    new RuntimeException(
-                      s"Cannot derive InvariantK: field '$name' depends on the type constructor parameter " +
-                        "but is not a direct application of it (e.g. F[X]), and its outer type constructor " +
-                        "could not be extracted for recursive derivation. " +
-                        "Only direct F[X] fields, nested Alg[F] fields, and invariant fields are supported."
-                    )
-                  )
-              })
+                }
+              case (None, None) =>
+                if (tOption =:= tList) {
+                  acc // invariant
+                } else {
+                  val invariantKAnchor = Type
+                    .of[cats.tagless.InvariantK[CatsTaglessFactories.DummyHKT]]
+                    .asInstanceOf[Type[Any]]
+                  acc >> (constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], invariantKAnchor) match {
+                    case Some(info) =>
+                      val nestedCtorK1 =
+                        Type.CtorK1.fromUntyped[CatsTaglessFactories.DummyHKT](info.ctorK1Untyped)
+                      val nestedIKType = info.typeClassType.asInstanceOf[Type[cats.tagless.InvariantK[
+                        CatsTaglessFactories.DummyHKT
+                      ]]]
+                      val nestedCtx = InvariantKCtx[CatsTaglessFactories.DummyHKT](
+                        nestedCtorK1,
+                        nestedIKType,
+                        ctx.cache,
+                        ctx.derivedType
+                      )
+                      deriveInvariantKRecursively[CatsTaglessFactories.DummyHKT](using nestedCtx).map { nestedExpr =>
+                        nestedFieldExprs += (name -> nestedExpr.asInstanceOf[Expr[Any]])
+                        ()
+                      }
+                    case None =>
+                      failUnsupportedField(
+                        "InvariantK",
+                        name,
+                        "depends on the type constructor parameter " +
+                          "but is not a direct application of it (e.g. F[X]), and its outer type constructor " +
+                          "could not be extracted for recursive derivation. " +
+                          "Only direct F[X] fields, nested Alg[F] fields, and invariant fields are supported."
+                      )
+                  })
+                }
+              case _ =>
+                acc >> failUnsupportedField("InvariantK", name, "has inconsistent probe decomposition.")
             }
-          case _ =>
-            acc >> MIO.fail(
-              new RuntimeException(
-                s"Cannot derive InvariantK: field '$name' has inconsistent probe decomposition."
-              )
-            )
-        }
-      }
-
-    for {
-      _ <- nestedFieldDerivations
-      result <- {
-        val sourceCC = CaseClass.parse(using AlgWCtor1Type).toEither match {
-          case Right(cc) => cc
-          case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor1]: $e")
-        }
-        val targetCC = CaseClass.parse(using AlgWCtor2Type).toEither match {
-          case Right(cc) => cc
-          case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor2]: $e")
-        }
-
-        val sourceFields = sourceCC.caseFieldValuesAt(afExpr).toList
-        val targetFieldParams = targetCC.primaryConstructor.parameters.flatten.toList
-        val targetParamTypes: Map[String, Type[Any]] = targetFieldParams.map { case (name, param) =>
-          import param.tpe.Underlying as PField
-          (name, Type[PField].asInstanceOf[Type[Any]])
-        }.toMap
-
-        val directFieldSet = directFields.toSet
-        val nestedFieldMap = nestedFieldExprs.toMap
-
-        val mappedFields: List[(String, Expr_??)] = sourceFields.map { case (fieldName, fieldValue) =>
-          import fieldValue.Underlying as Field
-          val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-
-          if (directFieldSet.contains(fieldName)) {
-            val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
-            val mapped = mkApplyFk[Field](fkExpr, fieldExpr.upcast[Any])(tgt)
-            (fieldName, mapped.as_??(tgt))
-          } else if (nestedFieldMap.contains(fieldName)) {
-            val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
-            val nestedIK = nestedFieldMap(fieldName)
-            val mapped = mkNestedImapK[Field](nestedIK, fieldExpr.upcast[Any], fkExpr, gkExpr)(tgt)
-            (fieldName, mapped.as_??(tgt))
-          } else {
-            (fieldName, fieldExpr.as_??)
           }
-        }
 
-        targetCC.primaryConstructor.fold(
-          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-          onTypes = _ => Map.empty,
-          onValues = _ => mappedFields.toMap
-        ) match {
-          case Right(constructExpr) =>
-            import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor2Type))
-          case Left(error) =>
-            MIO.fail(new RuntimeException(s"Cannot construct InvariantK result: $error"))
-        }
+        for {
+          _ <- nestedFieldDerivations
+          sourceAndTarget <- parsedOrFail(CaseClass.parse(using AlgWCtor1Type).toEither, "Alg[WCtor1]")
+            .parTuple(parsedOrFail(CaseClass.parse(using AlgWCtor2Type).toEither, "Alg[WCtor2]"))
+          result <- {
+            val (sourceCC, targetCC) = sourceAndTarget
+
+            val sourceFields = sourceCC.caseFieldValuesAt(afExpr).toList
+            val targetFieldParams = targetCC.primaryConstructor.parameters.flatten.toList
+            val targetParamTypes: Map[String, Type[Any]] = targetFieldParams.map { case (name, param) =>
+              import param.tpe.Underlying as PField
+              (name, Type[PField].asInstanceOf[Type[Any]])
+            }.toMap
+
+            val directFieldSet = directFields.toSet
+            val nestedFieldMap = nestedFieldExprs.toMap
+
+            val mappedFields: List[(String, Expr_??)] = sourceFields.map { case (fieldName, fieldValue) =>
+              import fieldValue.Underlying as Field
+              val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+
+              if (directFieldSet.contains(fieldName)) {
+                val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
+                val mapped = mkApplyFk[Field](fkExpr, fieldExpr.upcast[Any])(tgt)
+                (fieldName, mapped.as_??(tgt))
+              } else if (nestedFieldMap.contains(fieldName)) {
+                val tgt: Type[Field] = targetParamTypes(fieldName).asInstanceOf[Type[Field]]
+                val nestedIK = nestedFieldMap(fieldName)
+                val mapped = mkNestedImapK[Field](nestedIK, fieldExpr.upcast[Any], fkExpr, gkExpr)(tgt)
+                (fieldName, mapped.as_??(tgt))
+              } else {
+                (fieldName, fieldExpr.as_??)
+              }
+            }
+
+            foldInstanceFree(targetCC.primaryConstructor, "Constructor")(
+              onTypes = _ => Map.empty,
+              onValues = _ => mappedFields.toMap
+            ) match {
+              case Right(constructExpr) =>
+                import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor2Type))
+              case Left(error) =>
+                failCannotConstruct("InvariantK", error)
+            }
+          }
+        } yield result
       }
-    } yield result
   }
 
   // --- Helpers ---
@@ -331,19 +339,5 @@ trait InvariantKMacrosImpl
       cd <- data.get("catsTaglessDerivation")
       shouldLog <- cd.get("logDerivation").flatMap(_.asBoolean)
     } yield shouldLog).getOrElse(false)
-  }
-}
-
-sealed private[compiletime] trait InvariantKDerivationError
-    extends util.control.NoStackTrace
-    with Product
-    with Serializable {
-  def message: String
-  override def getMessage(): String = message
-}
-private[compiletime] object InvariantKDerivationError {
-  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends InvariantKDerivationError {
-    override def message: String =
-      s"The type $tpeName was not handled by any InvariantK derivation rule:\n${reasons.mkString("\n")}"
   }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/SemigroupalKMacrosImpl.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/SemigroupalKMacrosImpl.scala
@@ -51,7 +51,8 @@ trait SemigroupalKMacrosImpl
               else s" - ${rule.name}: ${reasons.mkString(", ")}"
             }
             .toList
-          val err = SemigroupalKDerivationError.UnsupportedType(
+          val err = CatsTaglessDerivationError.UnsupportedType(
+            "SemigroupalK",
             skctx.semigroupalKAlgType.prettyPrint,
             reasonsStrings
           )
@@ -128,150 +129,137 @@ trait SemigroupalKMacrosImpl
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val ccOption = CaseClass.parse(using AlgOptionType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val ccList = CaseClass.parse(using AlgListType).toEither match {
-      case Right(cc) => cc
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+    parsedOrFail(CaseClass.parse(using AlgOptionType).toEither, "Alg[Option]")
+      .parTuple(parsedOrFail(CaseClass.parse(using AlgListType).toEither, "Alg[List]"))
+      .flatMap { case (ccOption, ccList) =>
+        val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
+        val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
 
-    val fieldsOption = ccOption.primaryConstructor.parameters.flatten.toList
-    val fieldsList = ccList.primaryConstructor.parameters.flatten.toList
+        // --- Field classification ---
 
-    // --- Field classification ---
+        val directFields = scala.collection.mutable.Set.empty[String]
+        val nestedFieldExprs = scala.collection.mutable.Map.empty[String, Expr[Any]]
 
-    val directFields = scala.collection.mutable.Set.empty[String]
-    val nestedFieldExprs = scala.collection.mutable.Map.empty[String, Expr[Any]]
+        val semigroupalKAnchor = Type
+          .of[cats.tagless.SemigroupalK[CatsTaglessFactories.DummyHKT]]
+          .asInstanceOf[Type[Any]]
 
-    val semigroupalKAnchor = Type
-      .of[cats.tagless.SemigroupalK[CatsTaglessFactories.DummyHKT]]
-      .asInstanceOf[Type[Any]]
+        val nestedFieldDerivations: MIO[Unit] =
+          fieldsOption.zip(fieldsList).foldLeft(MIO.pure(())) { case (acc, ((name, pOption), (_, pList))) =>
+            val tOption = pOption.tpe.Underlying
+            val tList = pList.tpe.Underlying
 
-    val nestedFieldDerivations: MIO[Unit] =
-      fieldsOption.zip(fieldsList).foldLeft(MIO.pure(())) { case (acc, ((name, pOption), (_, pList))) =>
-        val tOption = pOption.tpe.Underlying
-        val tList = pList.tpe.Underlying
+            val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
+            val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
 
-        val optionUnapply = OptionCtor.unapply(tOption.asInstanceOf[Type[Any]])
-        val listUnapply = ListCtor.unapply(tList.asInstanceOf[Type[Any]])
-
-        (optionUnapply, listUnapply) match {
-          case (Some(innerOption), Some(innerList)) =>
-            import innerOption.Underlying as InnerO
-            import innerList.Underlying as InnerL
-            if (InnerO =:= InnerL) {
-              directFields += name
-              acc
-            } else {
-              acc >> MIO.fail(
-                new RuntimeException(
-                  s"Cannot derive SemigroupalK: field '$name' has type constructor parameter " +
-                    "nested within its own type argument (e.g. F[F[X]]). This is not supported."
-                )
-              )
-            }
-          case (None, None) =>
-            if (tOption =:= tList) {
-              acc // invariant
-            } else {
-              acc >> (constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], semigroupalKAnchor) match {
-                case Some(info) =>
-                  val nestedCtorK1 =
-                    Type.CtorK1.fromUntyped[CatsTaglessFactories.DummyHKT](info.ctorK1Untyped)
-                  val nestedSKType = info.typeClassType.asInstanceOf[Type[cats.tagless.SemigroupalK[
-                    CatsTaglessFactories.DummyHKT
-                  ]]]
-                  val nestedCtx = SemigroupalKCtx[CatsTaglessFactories.DummyHKT](
-                    nestedCtorK1,
-                    nestedSKType,
-                    ctx.cache,
-                    ctx.derivedType
+            (optionUnapply, listUnapply) match {
+              case (Some(innerOption), Some(innerList)) =>
+                import innerOption.Underlying as InnerO
+                import innerList.Underlying as InnerL
+                if (InnerO =:= InnerL) {
+                  directFields += name
+                  acc
+                } else {
+                  acc >> failUnsupportedField(
+                    "SemigroupalK",
+                    name,
+                    "has type constructor parameter " +
+                      "nested within its own type argument (e.g. F[F[X]]). This is not supported."
                   )
-                  deriveSemigroupalKRecursively[CatsTaglessFactories.DummyHKT](using nestedCtx).map { nestedExpr =>
-                    nestedFieldExprs += (name -> nestedExpr.asInstanceOf[Expr[Any]])
-                    ()
-                  }
-                case None =>
-                  MIO.fail(
-                    new RuntimeException(
-                      s"Cannot derive SemigroupalK: field '$name' depends on the type constructor parameter " +
-                        "but is not a direct application of it (e.g. F[X]), and its outer type constructor " +
-                        "could not be extracted for recursive derivation."
-                    )
-                  )
-              })
+                }
+              case (None, None) =>
+                if (tOption =:= tList) {
+                  acc // invariant
+                } else {
+                  acc >> (constructTypeClassTypeForField(tOption.asInstanceOf[Type[Any]], semigroupalKAnchor) match {
+                    case Some(info) =>
+                      val nestedCtorK1 =
+                        Type.CtorK1.fromUntyped[CatsTaglessFactories.DummyHKT](info.ctorK1Untyped)
+                      val nestedSKType = info.typeClassType.asInstanceOf[Type[cats.tagless.SemigroupalK[
+                        CatsTaglessFactories.DummyHKT
+                      ]]]
+                      val nestedCtx = SemigroupalKCtx[CatsTaglessFactories.DummyHKT](
+                        nestedCtorK1,
+                        nestedSKType,
+                        ctx.cache,
+                        ctx.derivedType
+                      )
+                      deriveSemigroupalKRecursively[CatsTaglessFactories.DummyHKT](using nestedCtx).map { nestedExpr =>
+                        nestedFieldExprs += (name -> nestedExpr.asInstanceOf[Expr[Any]])
+                        ()
+                      }
+                    case None =>
+                      failUnsupportedField(
+                        "SemigroupalK",
+                        name,
+                        "depends on the type constructor parameter " +
+                          "but is not a direct application of it (e.g. F[X]), and its outer type constructor " +
+                          "could not be extracted for recursive derivation."
+                      )
+                  })
+                }
+              case _ =>
+                acc >> failUnsupportedField("SemigroupalK", name, "has inconsistent probe decomposition.")
             }
-          case _ =>
-            acc >> MIO.fail(
-              new RuntimeException(
-                s"Cannot derive SemigroupalK: field '$name' has inconsistent probe decomposition."
-              )
-            )
-        }
-      }
-
-    for {
-      _ <- nestedFieldDerivations
-      result <- {
-        val sourceCC_F = CaseClass.parse(using AlgWCtor1Type).toEither match {
-          case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[WCtor1]: $e")
-        }
-        val sourceCC_G = CaseClass.parse(using AlgWCtor2Type).toEither match {
-          case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[WCtor2]: $e")
-        }
-        val targetCC = CaseClass.parse(using AlgWCtor3Type).toEither match {
-          case Right(cc) => cc; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[WCtor3]: $e")
-        }
-
-        val sourceFieldsF = sourceCC_F.caseFieldValuesAt(afExpr).toList
-        val sourceFieldsG = sourceCC_G.caseFieldValuesAt(agExpr).toList
-        val sourceFieldsGMap = sourceFieldsG.toMap
-
-        val targetParamTypes: Map[String, Type[Any]] = targetCC.primaryConstructor.parameters.flatten.toList.map {
-          case (n, p) => import p.tpe.Underlying as PF; (n, Type[PF].asInstanceOf[Type[Any]])
-        }.toMap
-
-        val directFieldSet = directFields.toSet
-        val nestedFieldMap = nestedFieldExprs.toMap
-
-        val mappedFields: List[(String, Expr_??)] = sourceFieldsF.map { case (fieldName, fieldValueF) =>
-          import fieldValueF.Underlying as FieldF
-          val fieldExprF = fieldValueF.value.asInstanceOf[Expr[FieldF]]
-
-          if (directFieldSet.contains(fieldName)) {
-            val tgt: Type[FieldF] = targetParamTypes(fieldName).asInstanceOf[Type[FieldF]]
-            val fieldValueG = sourceFieldsGMap(fieldName)
-            import fieldValueG.Underlying as FieldG
-            val fieldExprG = fieldValueG.value.asInstanceOf[Expr[FieldG]]
-            val mapped = mkTuple2K[FieldF](fieldExprF.upcast[Any], fieldExprG.upcast[Any])(tgt)
-            (fieldName, mapped.as_??(tgt))
-          } else if (nestedFieldMap.contains(fieldName)) {
-            val tgt: Type[FieldF] = targetParamTypes(fieldName).asInstanceOf[Type[FieldF]]
-            val fieldValueG = sourceFieldsGMap(fieldName)
-            import fieldValueG.Underlying as FieldG
-            val fieldExprG = fieldValueG.value.asInstanceOf[Expr[FieldG]]
-            val mapped =
-              mkNestedProductK[FieldF](nestedFieldMap(fieldName), fieldExprF.upcast[Any], fieldExprG.upcast[Any])(tgt)
-            (fieldName, mapped.as_??(tgt))
-          } else {
-            (fieldName, fieldExprF.as_??)
           }
-        }
 
-        targetCC.primaryConstructor.fold(
-          onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
-          onTypes = _ => Map.empty,
-          onValues = _ => mappedFields.toMap
-        ) match {
-          case Right(constructExpr) =>
-            import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor3Type))
-          case Left(error) =>
-            MIO.fail(new RuntimeException(s"Cannot construct SemigroupalK result: $error"))
-        }
+        for {
+          _ <- nestedFieldDerivations
+          parsedCCs <- parsedOrFail(CaseClass.parse(using AlgWCtor1Type).toEither, "Alg[WCtor1]")
+            .parTuple(parsedOrFail(CaseClass.parse(using AlgWCtor2Type).toEither, "Alg[WCtor2]"))
+            .parTuple(parsedOrFail(CaseClass.parse(using AlgWCtor3Type).toEither, "Alg[WCtor3]"))
+          result <- {
+            val ((sourceCC_F, sourceCC_G), targetCC) = parsedCCs
+
+            val sourceFieldsF = sourceCC_F.caseFieldValuesAt(afExpr).toList
+            val sourceFieldsG = sourceCC_G.caseFieldValuesAt(agExpr).toList
+            val sourceFieldsGMap = sourceFieldsG.toMap
+
+            val targetParamTypes: Map[String, Type[Any]] = targetCC.primaryConstructor.parameters.flatten.toList.map {
+              case (n, p) => import p.tpe.Underlying as PF; (n, Type[PF].asInstanceOf[Type[Any]])
+            }.toMap
+
+            val directFieldSet = directFields.toSet
+            val nestedFieldMap = nestedFieldExprs.toMap
+
+            val mappedFields: List[(String, Expr_??)] = sourceFieldsF.map { case (fieldName, fieldValueF) =>
+              import fieldValueF.Underlying as FieldF
+              val fieldExprF = fieldValueF.value.asInstanceOf[Expr[FieldF]]
+
+              if (directFieldSet.contains(fieldName)) {
+                val tgt: Type[FieldF] = targetParamTypes(fieldName).asInstanceOf[Type[FieldF]]
+                val fieldValueG = sourceFieldsGMap(fieldName)
+                import fieldValueG.Underlying as FieldG
+                val fieldExprG = fieldValueG.value.asInstanceOf[Expr[FieldG]]
+                val mapped = mkTuple2K[FieldF](fieldExprF.upcast[Any], fieldExprG.upcast[Any])(tgt)
+                (fieldName, mapped.as_??(tgt))
+              } else if (nestedFieldMap.contains(fieldName)) {
+                val tgt: Type[FieldF] = targetParamTypes(fieldName).asInstanceOf[Type[FieldF]]
+                val fieldValueG = sourceFieldsGMap(fieldName)
+                import fieldValueG.Underlying as FieldG
+                val fieldExprG = fieldValueG.value.asInstanceOf[Expr[FieldG]]
+                val mapped =
+                  mkNestedProductK[FieldF](nestedFieldMap(fieldName), fieldExprF.upcast[Any], fieldExprG.upcast[Any])(
+                    tgt
+                  )
+                (fieldName, mapped.as_??(tgt))
+              } else {
+                (fieldName, fieldExprF.as_??)
+              }
+            }
+
+            foldInstanceFree(targetCC.primaryConstructor, "Constructor")(
+              onTypes = _ => Map.empty,
+              onValues = _ => mappedFields.toMap
+            ) match {
+              case Right(constructExpr) =>
+                import constructExpr.Underlying; MIO.pure(constructExpr.value.upcast(using implicitly, AlgWCtor3Type))
+              case Left(error) =>
+                failCannotConstruct("SemigroupalK", error)
+            }
+          }
+        } yield result
       }
-    } yield result
   }
 
   // --- Helpers ---
@@ -298,18 +286,4 @@ trait SemigroupalKMacrosImpl
         .productK(Expr.splice(semigroupalKExpr), Expr.splice(afFieldExpr), Expr.splice(agFieldExpr))
         .asInstanceOf[Result]
     }
-}
-
-sealed private[compiletime] trait SemigroupalKDerivationError
-    extends util.control.NoStackTrace
-    with Product
-    with Serializable {
-  def message: String
-  override def getMessage(): String = message
-}
-private[compiletime] object SemigroupalKDerivationError {
-  final case class UnsupportedType(tpeName: String, reasons: List[String]) extends SemigroupalKDerivationError {
-    override def message: String =
-      s"The type $tpeName was not handled by any SemigroupalK derivation rule:\n${reasons.mkString("\n")}"
-  }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/rules/ContravariantKTraitRule.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/rules/ContravariantKTraitRule.scala
@@ -100,137 +100,165 @@ trait ContravariantKTraitRuleImpl {
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val anonInstance = AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor2] as anonymous instance: $e")
-    }
+    parsedOrFail(
+      AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither,
+      "Alg[WCtor2] as anonymous instance"
+    )
+      .parTuple(
+        parsedOrFail(
+          AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither,
+          "Alg[WCtor1] as anonymous instance"
+        )
+      )
+      .parTuple(
+        parsedOrFail(AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither, "Alg[Option]")
+      )
+      .parTuple(parsedOrFail(AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither, "Alg[List]"))
+      .flatMap { case (((anonInstance, anonInstanceSource), aiOption), aiList) =>
+        val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
+        val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
 
-    val anonInstanceSource = AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor1] as anonymous instance: $e")
-    }
+        // Pre-validate method shapes and source-method presence so the OverrideBody callbacks below
+        // cannot run into unsupported methods.
+        val validationErrors: List[CatsTaglessDerivationError] = anonInstance.mustOverride.flatMap { cm =>
+          val methodName = cm.method.name
 
-    val aiOption = AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val aiList = AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+          val missingSource =
+            if (anonInstanceSource.mustOverride.exists(_.method.name == methodName)) Nil
+            else List(CatsTaglessDerivationError.SourceMethodNotFound(methodName))
 
-    val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
-    val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
-
-    val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
-      val methodName = cm.method.name
-      val sourceMethodOpt = anonInstanceSource.mustOverride.find(_.method.name == methodName)
-
-      // Check if this method returns F[X] — covariant returns are NOT allowed for ContravariantK
-      val isCovariantReturn: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
-        case (Some(om), Some(lm)) =>
-          (om.method.knownReturning, lm.method.knownReturning) match {
-            case (Some(or), Some(lr)) =>
-              (
-                OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
-                ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
-              ) match {
-                case (Some(io), Some(il)) =>
-                  import io.Underlying as IO; import il.Underlying as IL
-                  IO =:= IL
+          // Check if this method returns F[X] — covariant returns are NOT allowed for ContravariantK
+          val isCovariantReturn: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
+            case (Some(om), Some(lm)) =>
+              (om.method.knownReturning, lm.method.knownReturning) match {
+                case (Some(or), Some(lr)) =>
+                  (
+                    OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
+                    ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
+                  ) match {
+                    case (Some(io), Some(il)) =>
+                      import io.Underlying as IO; import il.Underlying as IL
+                      IO =:= IL
+                    case _ => false
+                  }
                 case _ => false
               }
             case _ => false
           }
-        case _ => false
-      }
+          val unsupportedMethod =
+            if (isCovariantReturn)
+              List(
+                CatsTaglessDerivationError.UnsupportedMethod(
+                  "ContravariantK",
+                  methodName,
+                  "returns F[X] " +
+                    "(covariant in the type constructor parameter). ContravariantK can only handle " +
+                    "methods with F[_] in parameter position or invariant methods. " +
+                    "Consider using InvariantK or FunctorK instead."
+                )
+              )
+            else Nil
 
-      if (isCovariantReturn) {
-        throw new RuntimeException(
-          s"Cannot derive ContravariantK for trait: method '$methodName' returns F[X] " +
-            "(covariant in the type constructor parameter). ContravariantK can only handle " +
-            "methods with F[_] in parameter position or invariant methods. " +
-            "Consider using InvariantK or FunctorK instead."
-        )
-      }
+          missingSource ++ unsupportedMethod
+        }
 
-      // Classify parameters: which params contain F[X] (contravariant position)
-      val contravariantParamIndices: Set[Int] = (optionMethods.get(methodName), listMethods.get(methodName)) match {
-        case (Some(om), Some(lm)) =>
-          val optParams = om.method.totalParameters.flatten.toList
-          val listParams = lm.method.totalParameters.flatten.toList
-          optParams
-            .zip(listParams)
-            .zipWithIndex
-            .collect {
-              case (((_, optP), (_, listP)), idx) if !(optP.tpe.Underlying =:= listP.tpe.Underlying) =>
-                idx
-            }
-            .toSet
-        case _ => Set.empty
-      }
+        validationErrors match {
+          case head :: tail =>
+            Log.error((head :: tail).map(_.message).mkString("\n")) >> MIO.fail(head, tail*)
+          case Nil =>
 
-      val body: OverrideBody = new OverrideBody {
-        def apply(octx: OverrideContext): Expr_?? = {
-          val returnT = octx.returnType
+            val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
+              val methodName = cm.method.name
+              val sourceMethodOpt = anonInstanceSource.mustOverride.find(_.method.name == methodName)
 
-          // Build params for the source call, transforming contravariant params with fk (G ~> F)
-          val transformedParams: List[Expr_??] = octx.parameters.zipWithIndex.map { case (paramExpr, idx) =>
-            if (contravariantParamIndices.contains(idx)) {
-              import paramExpr.Underlying as P
-              val transformed = mkApplyFk[P](fkExpr, paramExpr.value.upcast[Any])(paramExpr.Underlying)
-              transformed.as_??(paramExpr.Underlying)
-            } else {
-              paramExpr
-            }
-          }
-
-          // Call the same method on the source (af) instance with transformed params
-          val sourceCall: Expr[Any] = sourceMethodOpt match {
-            case Some(sourceCM) =>
-              val sm = sourceCM.method
-              try
-                sm.fold(
-                  onInstance = oi => afExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
-                  onTypes = _ => Map.empty,
-                  onValues = av => {
-                    val paramNames = av.totalParameters.flatten.toList.map(_._1)
-                    paramNames.zip(transformedParams).toMap
-                  }
-                ) match {
-                  case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
-                  case Left(e)      => throw new RuntimeException(s"fold returned Left for $methodName: $e")
+              // Classify parameters: which params contain F[X] (contravariant position)
+              val contravariantParamIndices: Set[Int] =
+                (optionMethods.get(methodName), listMethods.get(methodName)) match {
+                  case (Some(om), Some(lm)) =>
+                    val optParams = om.method.totalParameters.flatten.toList
+                    val listParams = lm.method.totalParameters.flatten.toList
+                    optParams
+                      .zip(listParams)
+                      .zipWithIndex
+                      .collect {
+                        case (((_, optP), (_, listP)), idx) if !(optP.tpe.Underlying =:= listP.tpe.Underlying) =>
+                          idx
+                      }
+                      .toSet
+                  case _ => Set.empty
                 }
-              catch {
-                case e: RuntimeException => throw e
-                case e: Throwable        =>
-                  throw new RuntimeException(
-                    s"fold crashed for method $methodName (${sm.getClass.getSimpleName}, " +
-                      s"expectations=${sm.expectations}, isNullary=${sm.isNullary}): ${e.getMessage}",
-                    e
-                  )
-              }
-            case None =>
-              throw new RuntimeException(s"Source method $methodName not found")
-          }
 
-          {
-            import returnT.Underlying as RT
-            Expr.quote(Expr.splice(sourceCall).asInstanceOf[RT]).as_??(returnT.Underlying)
-          }
+              val body: OverrideBody = new OverrideBody {
+                def apply(octx: OverrideContext): Expr_?? = {
+                  val returnT = octx.returnType
+
+                  // Build params for the source call, transforming contravariant params with fk (G ~> F)
+                  val transformedParams: List[Expr_??] = octx.parameters.zipWithIndex.map { case (paramExpr, idx) =>
+                    if (contravariantParamIndices.contains(idx)) {
+                      import paramExpr.Underlying as P
+                      val transformed = mkApplyFk[P](fkExpr, paramExpr.value.upcast[Any])(paramExpr.Underlying)
+                      transformed.as_??(paramExpr.Underlying)
+                    } else {
+                      paramExpr
+                    }
+                  }
+
+                  // Call the same method on the source (af) instance with transformed params.
+                  // OverrideBody is a synchronous callback invoked inside `anonInstance.construct`; it cannot
+                  // return MIO. Typed errors thrown here are caught by the MIO block wrapping `construct`
+                  // below and routed into the MIO error channel.
+                  val sourceCall: Expr[Any] = sourceMethodOpt match {
+                    case Some(sourceCM) =>
+                      val sm = sourceCM.method
+                      try
+                        sm.fold(
+                          onInstance = oi => afExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
+                          onTypes = _ => Map.empty,
+                          onValues = av => {
+                            val paramNames = av.totalParameters.flatten.toList.map(_._1)
+                            paramNames.zip(transformedParams).toMap
+                          }
+                        ) match {
+                          case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
+                          case Left(e)      =>
+                            throw CatsTaglessDerivationError.MethodForwardingFailed(
+                              methodName,
+                              s"fold returned Left: $e"
+                            )
+                        }
+                      catch {
+                        case e: CatsTaglessDerivationError  => throw e
+                        case scala.util.control.NonFatal(e) =>
+                          throw CatsTaglessDerivationError.MethodForwardingFailed(
+                            methodName,
+                            s"fold crashed (${sm.getClass.getSimpleName}, " +
+                              s"expectations=${sm.expectations}, isNullary=${sm.isNullary}): ${e.getMessage}"
+                          )
+                      }
+                    case None =>
+                      // Unreachable: validated via validationErrors before building overrides.
+                      throw CatsTaglessDerivationError.SourceMethodNotFound(methodName)
+                  }
+
+                  {
+                    import returnT.Underlying as RT
+                    Expr.quote(Expr.splice(sourceCall).asInstanceOf[RT]).as_??(returnT.Underlying)
+                  }
+                }
+              }
+
+              cm.method.asUntyped -> body
+            }.toMap
+
+            // The MIO wrapper captures typed errors thrown from the OverrideBody callbacks invoked
+            // synchronously inside `construct` and routes them into the error channel.
+            MIO(anonInstance.construct(None, Map.empty, overrides)).flatMap {
+              case Right(expr) =>
+                MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor2]]])
+              case Left(errors) =>
+                failCannotConstruct("ContravariantK", s"trait instance: ${errors.toVector.mkString(", ")}")
+            }
         }
       }
-
-      cm.method.asUntyped -> body
-    }.toMap
-
-    anonInstance.construct(None, Map.empty, overrides) match {
-      case Right(expr) =>
-        MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor2]]])
-      case Left(errors) =>
-        MIO.fail(
-          new RuntimeException(
-            s"Cannot construct ContravariantK trait instance: ${errors.toVector.mkString(", ")}"
-          )
-        )
-    }
   }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/rules/FunctorKTraitRule.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/rules/FunctorKTraitRule.scala
@@ -100,125 +100,152 @@ trait FunctorKTraitRuleImpl {
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val anonInstance = AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor2] as anonymous instance: $e")
-    }
+    parsedOrFail(
+      AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither,
+      "Alg[WCtor2] as anonymous instance"
+    )
+      .parTuple(
+        parsedOrFail(
+          AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither,
+          "Alg[WCtor1] as anonymous instance"
+        )
+      )
+      .parTuple(
+        parsedOrFail(AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither, "Alg[Option]")
+      )
+      .parTuple(parsedOrFail(AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither, "Alg[List]"))
+      .flatMap { case (((anonInstance, anonInstanceSource), aiOption), aiList) =>
+        val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
+        val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
 
-    val anonInstanceSource = AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor1] as anonymous instance: $e")
-    }
+        // Pre-validate method shapes and source-method presence so the OverrideBody callbacks below
+        // cannot run into unsupported methods.
+        val validationErrors: List[CatsTaglessDerivationError] = anonInstance.mustOverride.flatMap { cm =>
+          val methodName = cm.method.name
 
-    val aiOption = AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val aiList = AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+          val missingSource =
+            if (anonInstanceSource.mustOverride.exists(_.method.name == methodName)) Nil
+            else List(CatsTaglessDerivationError.SourceMethodNotFound(methodName))
 
-    val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
-    val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
-
-    val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
-      val methodName = cm.method.name
-      val sourceMethodOpt = anonInstanceSource.mustOverride.find(_.method.name == methodName)
-
-      val isDirectF: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
-        case (Some(om), Some(lm)) =>
-          (om.method.knownReturning, lm.method.knownReturning) match {
-            case (Some(or), Some(lr)) =>
-              (
-                OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
-                ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
-              ) match {
-                case (Some(io), Some(il)) =>
-                  import io.Underlying as IO; import il.Underlying as IL
-                  IO =:= IL
-                case _ => false
+          // Check if any parameter contains F[X] — FunctorK can't handle contravariant positions
+          val hasContravariantParams: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
+            case (Some(om), Some(lm)) =>
+              val optParams = om.method.totalParameters.flatten.toList
+              val listParams = lm.method.totalParameters.flatten.toList
+              optParams.zip(listParams).exists { case ((_, optP), (_, listP)) =>
+                val tOpt = optP.tpe.Underlying
+                val tList = listP.tpe.Underlying
+                !(tOpt =:= tList)
               }
             case _ => false
           }
-        case _ => false
-      }
+          val unsupportedMethod =
+            if (hasContravariantParams)
+              List(
+                CatsTaglessDerivationError.UnsupportedMethod(
+                  "FunctorK",
+                  methodName,
+                  "has F[_] in parameter position. " +
+                    "FunctorK can only handle F[_] in return position (covariant). Use InvariantK instead."
+                )
+              )
+            else Nil
 
-      // Check if any parameter contains F[X] — FunctorK can't handle contravariant positions
-      val hasContravariantParams: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
-        case (Some(om), Some(lm)) =>
-          val optParams = om.method.totalParameters.flatten.toList
-          val listParams = lm.method.totalParameters.flatten.toList
-          optParams.zip(listParams).exists { case ((_, optP), (_, listP)) =>
-            val tOpt = optP.tpe.Underlying
-            val tList = listP.tpe.Underlying
-            !(tOpt =:= tList)
-          }
-        case _ => false
-      }
+          missingSource ++ unsupportedMethod
+        }
 
-      if (hasContravariantParams) {
-        throw new RuntimeException(
-          s"Cannot derive FunctorK for trait: method '$methodName' has F[_] in parameter position. " +
-            "FunctorK can only handle F[_] in return position (covariant). Use InvariantK instead."
-        )
-      }
+        validationErrors match {
+          case head :: tail =>
+            Log.error((head :: tail).map(_.message).mkString("\n")) >> MIO.fail(head, tail*)
+          case Nil =>
 
-      val body: OverrideBody = new OverrideBody {
-        def apply(octx: OverrideContext): Expr_?? = {
-          val returnT = octx.returnType
+            val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
+              val methodName = cm.method.name
+              val sourceMethodOpt = anonInstanceSource.mustOverride.find(_.method.name == methodName)
 
-          // Call the same method on the source (af) instance
-          val sourceCall: Expr[Any] = sourceMethodOpt match {
-            case Some(sourceCM) =>
-              val sm = sourceCM.method
-              try
-                sm.fold(
-                  onInstance = oi => afExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
-                  onTypes = _ => Map.empty,
-                  onValues = av => {
-                    val paramNames = av.totalParameters.flatten.toList.map(_._1)
-                    paramNames.zip(octx.parameters).toMap
+              val isDirectF: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
+                case (Some(om), Some(lm)) =>
+                  (om.method.knownReturning, lm.method.knownReturning) match {
+                    case (Some(or), Some(lr)) =>
+                      (
+                        OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
+                        ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
+                      ) match {
+                        case (Some(io), Some(il)) =>
+                          import io.Underlying as IO; import il.Underlying as IL
+                          IO =:= IL
+                        case _ => false
+                      }
+                    case _ => false
                   }
-                ) match {
-                  case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
-                  case Left(e)      => throw new RuntimeException(s"fold returned Left for $methodName: $e")
-                }
-              catch {
-                case e: RuntimeException => throw e
-                case e: Throwable        =>
-                  throw new RuntimeException(
-                    s"fold crashed for method $methodName (${sm.getClass.getSimpleName}, " +
-                      s"expectations=${sm.expectations}, isNullary=${sm.isNullary}): ${e.getMessage}",
-                    e
-                  )
+                case _ => false
               }
-            case None =>
-              throw new RuntimeException(s"Source method $methodName not found")
-          }
 
-          if (isDirectF) {
-            import returnT.Underlying as RT
-            mkApplyFk[RT](fkExpr, sourceCall)(returnT.Underlying).as_??(returnT.Underlying)
-          } else {
-            // Invariant method — return type is the same in source and target.
-            // Use Expr.quote with asInstanceOf to produce properly typed tree on Scala 2.
-            import returnT.Underlying as RT
-            Expr.quote(Expr.splice(sourceCall).asInstanceOf[RT]).as_??(returnT.Underlying)
-          }
+              val body: OverrideBody = new OverrideBody {
+                def apply(octx: OverrideContext): Expr_?? = {
+                  val returnT = octx.returnType
+
+                  // Call the same method on the source (af) instance.
+                  // OverrideBody is a synchronous callback invoked inside `anonInstance.construct`; it cannot
+                  // return MIO. Typed errors thrown here are caught by the MIO block wrapping `construct`
+                  // below and routed into the MIO error channel.
+                  val sourceCall: Expr[Any] = sourceMethodOpt match {
+                    case Some(sourceCM) =>
+                      val sm = sourceCM.method
+                      try
+                        sm.fold(
+                          onInstance = oi => afExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
+                          onTypes = _ => Map.empty,
+                          onValues = av => {
+                            val paramNames = av.totalParameters.flatten.toList.map(_._1)
+                            paramNames.zip(octx.parameters).toMap
+                          }
+                        ) match {
+                          case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
+                          case Left(e)      =>
+                            throw CatsTaglessDerivationError.MethodForwardingFailed(
+                              methodName,
+                              s"fold returned Left: $e"
+                            )
+                        }
+                      catch {
+                        case e: CatsTaglessDerivationError  => throw e
+                        case scala.util.control.NonFatal(e) =>
+                          throw CatsTaglessDerivationError.MethodForwardingFailed(
+                            methodName,
+                            s"fold crashed (${sm.getClass.getSimpleName}, " +
+                              s"expectations=${sm.expectations}, isNullary=${sm.isNullary}): ${e.getMessage}"
+                          )
+                      }
+                    case None =>
+                      // Unreachable: validated via validationErrors before building overrides.
+                      throw CatsTaglessDerivationError.SourceMethodNotFound(methodName)
+                  }
+
+                  if (isDirectF) {
+                    import returnT.Underlying as RT
+                    mkApplyFk[RT](fkExpr, sourceCall)(returnT.Underlying).as_??(returnT.Underlying)
+                  } else {
+                    // Invariant method — return type is the same in source and target.
+                    // Use Expr.quote with asInstanceOf to produce properly typed tree on Scala 2.
+                    import returnT.Underlying as RT
+                    Expr.quote(Expr.splice(sourceCall).asInstanceOf[RT]).as_??(returnT.Underlying)
+                  }
+                }
+              }
+
+              cm.method.asUntyped -> body
+            }.toMap
+
+            // The MIO wrapper captures typed errors thrown from the OverrideBody callbacks invoked
+            // synchronously inside `construct` and routes them into the error channel.
+            MIO(anonInstance.construct(None, Map.empty, overrides)).flatMap {
+              case Right(expr) =>
+                MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor2]]])
+              case Left(errors) =>
+                failCannotConstruct("FunctorK", s"trait instance: ${errors.toVector.mkString(", ")}")
+            }
         }
       }
-
-      cm.method.asUntyped -> body
-    }.toMap
-
-    anonInstance.construct(None, Map.empty, overrides) match {
-      case Right(expr) =>
-        MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor2]]])
-      case Left(errors) =>
-        MIO.fail(
-          new RuntimeException(
-            s"Cannot construct FunctorK trait instance: ${errors.toVector.mkString(", ")}"
-          )
-        )
-    }
   }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/rules/InvariantKTraitRule.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/rules/InvariantKTraitRule.scala
@@ -106,130 +106,149 @@ trait InvariantKTraitRuleImpl {
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val anonInstance = AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor2] as anonymous instance: $e")
-    }
+    parsedOrFail(
+      AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither,
+      "Alg[WCtor2] as anonymous instance"
+    )
+      .parTuple(
+        parsedOrFail(
+          AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither,
+          "Alg[WCtor1] as anonymous instance"
+        )
+      )
+      .parTuple(
+        parsedOrFail(AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither, "Alg[Option]")
+      )
+      .parTuple(parsedOrFail(AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither, "Alg[List]"))
+      .flatMap { case (((anonInstance, anonInstanceSource), aiOption), aiList) =>
+        val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
+        val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
 
-    val anonInstanceSource = AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor1] as anonymous instance: $e")
-    }
+        // Pre-validate that every method we must override exists on the source instance, so that the
+        // OverrideBody callbacks below can never hit a missing source method.
+        val missingSourceMethods: List[CatsTaglessDerivationError] = anonInstance.mustOverride
+          .map(_.method.name)
+          .filterNot(n => anonInstanceSource.mustOverride.exists(_.method.name == n))
+          .map(n => CatsTaglessDerivationError.SourceMethodNotFound(n))
 
-    val aiOption = AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val aiList = AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+        missingSourceMethods match {
+          case head :: tail =>
+            Log.error((head :: tail).map(_.message).mkString("\n")) >> MIO.fail(head, tail*)
+          case Nil =>
 
-    val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
-    val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
+            val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
+              val methodName = cm.method.name
+              val sourceMethodOpt = anonInstanceSource.mustOverride.find(_.method.name == methodName)
 
-    val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
-      val methodName = cm.method.name
-      val sourceMethodOpt = anonInstanceSource.mustOverride.find(_.method.name == methodName)
-
-      val isCovariantReturn: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
-        case (Some(om), Some(lm)) =>
-          (om.method.knownReturning, lm.method.knownReturning) match {
-            case (Some(or), Some(lr)) =>
-              (
-                OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
-                ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
-              ) match {
-                case (Some(io), Some(il)) =>
-                  import io.Underlying as IO; import il.Underlying as IL
-                  IO =:= IL
+              val isCovariantReturn: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
+                case (Some(om), Some(lm)) =>
+                  (om.method.knownReturning, lm.method.knownReturning) match {
+                    case (Some(or), Some(lr)) =>
+                      (
+                        OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
+                        ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
+                      ) match {
+                        case (Some(io), Some(il)) =>
+                          import io.Underlying as IO; import il.Underlying as IL
+                          IO =:= IL
+                        case _ => false
+                      }
+                    case _ => false
+                  }
                 case _ => false
               }
-            case _ => false
-          }
-        case _ => false
-      }
 
-      // Classify parameters: which params contain F[X] (contravariant position)
-      val contravariantParamIndices: Set[Int] = (optionMethods.get(methodName), listMethods.get(methodName)) match {
-        case (Some(om), Some(lm)) =>
-          val optParams = om.method.totalParameters.flatten.toList
-          val listParams = lm.method.totalParameters.flatten.toList
-          optParams
-            .zip(listParams)
-            .zipWithIndex
-            .collect {
-              case (((_, optP), (_, listP)), idx) if !(optP.tpe.Underlying =:= listP.tpe.Underlying) =>
-                idx
-            }
-            .toSet
-        case _ => Set.empty
-      }
-
-      val body: OverrideBody = new OverrideBody {
-        def apply(octx: OverrideContext): Expr_?? = {
-          val returnT = octx.returnType
-
-          // Build params for the source call, transforming contravariant params with gk (G ~> F)
-          val transformedParams: List[Expr_??] = octx.parameters.zipWithIndex.map { case (paramExpr, idx) =>
-            if (contravariantParamIndices.contains(idx)) {
-              import paramExpr.Underlying as P
-              val transformed = mkApplyFk[P](gkExpr, paramExpr.value.upcast[Any])(paramExpr.Underlying)
-              transformed.as_??(paramExpr.Underlying)
-            } else {
-              paramExpr
-            }
-          }
-
-          // Call the same method on the source (af) instance with transformed params
-          val sourceCall: Expr[Any] = sourceMethodOpt match {
-            case Some(sourceCM) =>
-              val sm = sourceCM.method
-              try
-                sm.fold(
-                  onInstance = oi => afExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
-                  onTypes = _ => Map.empty,
-                  onValues = av => {
-                    val paramNames = av.totalParameters.flatten.toList.map(_._1)
-                    paramNames.zip(transformedParams).toMap
-                  }
-                ) match {
-                  case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
-                  case Left(e)      => throw new RuntimeException(s"fold returned Left for $methodName: $e")
+              // Classify parameters: which params contain F[X] (contravariant position)
+              val contravariantParamIndices: Set[Int] =
+                (optionMethods.get(methodName), listMethods.get(methodName)) match {
+                  case (Some(om), Some(lm)) =>
+                    val optParams = om.method.totalParameters.flatten.toList
+                    val listParams = lm.method.totalParameters.flatten.toList
+                    optParams
+                      .zip(listParams)
+                      .zipWithIndex
+                      .collect {
+                        case (((_, optP), (_, listP)), idx) if !(optP.tpe.Underlying =:= listP.tpe.Underlying) =>
+                          idx
+                      }
+                      .toSet
+                  case _ => Set.empty
                 }
-              catch {
-                case e: RuntimeException => throw e
-                case e: Throwable        =>
-                  throw new RuntimeException(
-                    s"fold crashed for method $methodName (${sm.getClass.getSimpleName}, " +
-                      s"expectations=${sm.expectations}, isNullary=${sm.isNullary}): ${e.getMessage}",
-                    e
-                  )
-              }
-            case None =>
-              throw new RuntimeException(s"Source method $methodName not found")
-          }
 
-          if (isCovariantReturn) {
-            import returnT.Underlying as RT
-            mkApplyFk[RT](fkExpr, sourceCall)(returnT.Underlying).as_??(returnT.Underlying)
-          } else {
-            import returnT.Underlying as RT
-            Expr.quote(Expr.splice(sourceCall).asInstanceOf[RT]).as_??(returnT.Underlying)
-          }
+              val body: OverrideBody = new OverrideBody {
+                def apply(octx: OverrideContext): Expr_?? = {
+                  val returnT = octx.returnType
+
+                  // Build params for the source call, transforming contravariant params with gk (G ~> F)
+                  val transformedParams: List[Expr_??] = octx.parameters.zipWithIndex.map { case (paramExpr, idx) =>
+                    if (contravariantParamIndices.contains(idx)) {
+                      import paramExpr.Underlying as P
+                      val transformed = mkApplyFk[P](gkExpr, paramExpr.value.upcast[Any])(paramExpr.Underlying)
+                      transformed.as_??(paramExpr.Underlying)
+                    } else {
+                      paramExpr
+                    }
+                  }
+
+                  // Call the same method on the source (af) instance with transformed params.
+                  // OverrideBody is a synchronous callback invoked inside `anonInstance.construct`; it cannot
+                  // return MIO. Typed errors thrown here are caught by the MIO block wrapping `construct`
+                  // below and routed into the MIO error channel.
+                  val sourceCall: Expr[Any] = sourceMethodOpt match {
+                    case Some(sourceCM) =>
+                      val sm = sourceCM.method
+                      try
+                        sm.fold(
+                          onInstance = oi => afExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
+                          onTypes = _ => Map.empty,
+                          onValues = av => {
+                            val paramNames = av.totalParameters.flatten.toList.map(_._1)
+                            paramNames.zip(transformedParams).toMap
+                          }
+                        ) match {
+                          case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
+                          case Left(e)      =>
+                            throw CatsTaglessDerivationError.MethodForwardingFailed(
+                              methodName,
+                              s"fold returned Left: $e"
+                            )
+                        }
+                      catch {
+                        case e: CatsTaglessDerivationError  => throw e
+                        case scala.util.control.NonFatal(e) =>
+                          throw CatsTaglessDerivationError.MethodForwardingFailed(
+                            methodName,
+                            s"fold crashed (${sm.getClass.getSimpleName}, " +
+                              s"expectations=${sm.expectations}, isNullary=${sm.isNullary}): ${e.getMessage}"
+                          )
+                      }
+                    case None =>
+                      // Unreachable: validated via missingSourceMethods before building overrides.
+                      throw CatsTaglessDerivationError.SourceMethodNotFound(methodName)
+                  }
+
+                  if (isCovariantReturn) {
+                    import returnT.Underlying as RT
+                    mkApplyFk[RT](fkExpr, sourceCall)(returnT.Underlying).as_??(returnT.Underlying)
+                  } else {
+                    import returnT.Underlying as RT
+                    Expr.quote(Expr.splice(sourceCall).asInstanceOf[RT]).as_??(returnT.Underlying)
+                  }
+                }
+              }
+
+              cm.method.asUntyped -> body
+            }.toMap
+
+            // The MIO wrapper captures typed errors thrown from the OverrideBody callbacks invoked
+            // synchronously inside `construct` and routes them into the error channel.
+            MIO(anonInstance.construct(None, Map.empty, overrides)).flatMap {
+              case Right(expr) =>
+                MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor2]]])
+              case Left(errors) =>
+                failCannotConstruct("InvariantK", s"trait instance: ${errors.toVector.mkString(", ")}")
+            }
         }
       }
-
-      cm.method.asUntyped -> body
-    }.toMap
-
-    anonInstance.construct(None, Map.empty, overrides) match {
-      case Right(expr) =>
-        MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor2]]])
-      case Left(errors) =>
-        MIO.fail(
-          new RuntimeException(
-            s"Cannot construct InvariantK trait instance: ${errors.toVector.mkString(", ")}"
-          )
-        )
-    }
   }
 }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/rules/SemigroupalKTraitRule.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/rules/SemigroupalKTraitRule.scala
@@ -104,109 +104,142 @@ trait SemigroupalKTraitRuleImpl {
     val AlgOptionType = AlgCtorK1.apply[Option](using OptionCtor)
     val AlgListType = AlgCtorK1.apply[List](using ListCtor)
 
-    val anonInstance = AnonymousInstance.parse(using AlgWCtor3Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor3] as anonymous instance: $e")
-    }
+    parsedOrFail(
+      AnonymousInstance.parse(using AlgWCtor3Type.asInstanceOf[Type[Any]]).toEither,
+      "Alg[WCtor3] as anonymous instance"
+    )
+      .parTuple(
+        parsedOrFail(
+          AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither,
+          "Alg[WCtor1] as anonymous instance"
+        )
+      )
+      .parTuple(
+        parsedOrFail(
+          AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither,
+          "Alg[WCtor2] as anonymous instance"
+        )
+      )
+      .parTuple(
+        parsedOrFail(AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither, "Alg[Option]")
+      )
+      .parTuple(parsedOrFail(AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither, "Alg[List]"))
+      .flatMap { case ((((anonInstance, anonInstanceSourceF), anonInstanceSourceG), aiOption), aiList) =>
+        val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
+        val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
 
-    val anonInstanceSourceF = AnonymousInstance.parse(using AlgWCtor1Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor1] as anonymous instance: $e")
-    }
+        // Pre-validate that every method we must override exists on both source instances, so that the
+        // OverrideBody callbacks below can never hit a missing source method.
+        val missingSourceMethods: List[CatsTaglessDerivationError] = anonInstance.mustOverride
+          .map(_.method.name)
+          .flatMap { n =>
+            val missingF =
+              if (anonInstanceSourceF.mustOverride.exists(_.method.name == n)) Nil
+              else List(CatsTaglessDerivationError.SourceMethodNotFound(n, " (F)"))
+            val missingG =
+              if (anonInstanceSourceG.mustOverride.exists(_.method.name == n)) Nil
+              else List(CatsTaglessDerivationError.SourceMethodNotFound(n, " (G)"))
+            missingF ++ missingG
+          }
 
-    val anonInstanceSourceG = AnonymousInstance.parse(using AlgWCtor2Type.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai
-      case Left(e)   => throw new RuntimeException(s"Cannot parse Alg[WCtor2] as anonymous instance: $e")
-    }
+        missingSourceMethods match {
+          case head :: tail =>
+            Log.error((head :: tail).map(_.message).mkString("\n")) >> MIO.fail(head, tail*)
+          case Nil =>
 
-    val aiOption = AnonymousInstance.parse(using AlgOptionType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[Option]: $e")
-    }
-    val aiList = AnonymousInstance.parse(using AlgListType.asInstanceOf[Type[Any]]).toEither match {
-      case Right(ai) => ai; case Left(e) => throw new RuntimeException(s"Cannot parse Alg[List]: $e")
-    }
+            val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
+              val methodName = cm.method.name
+              val sourceMethodOptF = anonInstanceSourceF.mustOverride.find(_.method.name == methodName)
+              val sourceMethodOptG = anonInstanceSourceG.mustOverride.find(_.method.name == methodName)
 
-    val optionMethods = aiOption.mustOverride.map(cm => cm.method.name -> cm).toMap
-    val listMethods = aiList.mustOverride.map(cm => cm.method.name -> cm).toMap
-
-    val overrides: Map[UntypedMethod, OverrideBody] = anonInstance.mustOverride.map { cm =>
-      val methodName = cm.method.name
-      val sourceMethodOptF = anonInstanceSourceF.mustOverride.find(_.method.name == methodName)
-      val sourceMethodOptG = anonInstanceSourceG.mustOverride.find(_.method.name == methodName)
-
-      val isDirectF: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
-        case (Some(om), Some(lm)) =>
-          (om.method.knownReturning, lm.method.knownReturning) match {
-            case (Some(or), Some(lr)) =>
-              (
-                OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
-                ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
-              ) match {
-                case (Some(io), Some(il)) =>
-                  import io.Underlying as IO; import il.Underlying as IL
-                  IO =:= IL
+              val isDirectF: Boolean = (optionMethods.get(methodName), listMethods.get(methodName)) match {
+                case (Some(om), Some(lm)) =>
+                  (om.method.knownReturning, lm.method.knownReturning) match {
+                    case (Some(or), Some(lr)) =>
+                      (
+                        OptionCtor.unapply(or.Underlying.asInstanceOf[Type[Any]]),
+                        ListCtor.unapply(lr.Underlying.asInstanceOf[Type[Any]])
+                      ) match {
+                        case (Some(io), Some(il)) =>
+                          import io.Underlying as IO; import il.Underlying as IL
+                          IO =:= IL
+                        case _ => false
+                      }
+                    case _ => false
+                  }
                 case _ => false
               }
-            case _ => false
-          }
-        case _ => false
-      }
 
-      val body: OverrideBody = new OverrideBody {
-        def apply(octx: OverrideContext): Expr_?? = {
-          val returnT = octx.returnType
+              val body: OverrideBody = new OverrideBody {
+                def apply(octx: OverrideContext): Expr_?? = {
+                  val returnT = octx.returnType
 
-          def foldSourceMethod(sm: Method, srcExpr: Expr[Any]): Expr[Any] =
-            try
-              sm.fold(
-                onInstance = oi => srcExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
-                onTypes = _ => Map.empty,
-                onValues = av => {
-                  val paramNames = av.totalParameters.flatten.toList.map(_._1)
-                  paramNames.zip(octx.parameters).toMap
+                  // OverrideBody is a synchronous callback invoked inside `anonInstance.construct`; it cannot
+                  // return MIO. Typed errors thrown here are caught by the MIO block wrapping `construct`
+                  // below and routed into the MIO error channel.
+                  def foldSourceMethod(sm: Method, srcExpr: Expr[Any]): Expr[Any] =
+                    try
+                      sm.fold(
+                        onInstance = oi => srcExpr.as_??(oi.Instance.asInstanceOf[Type[Any]]),
+                        onTypes = _ => Map.empty,
+                        onValues = av => {
+                          val paramNames = av.totalParameters.flatten.toList.map(_._1)
+                          paramNames.zip(octx.parameters).toMap
+                        }
+                      ) match {
+                        case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
+                        case Left(e)      =>
+                          throw CatsTaglessDerivationError.MethodForwardingFailed(methodName, s"fold returned Left: $e")
+                      }
+                    catch {
+                      case e: CatsTaglessDerivationError  => throw e
+                      case scala.util.control.NonFatal(e) =>
+                        throw CatsTaglessDerivationError.MethodForwardingFailed(
+                          methodName,
+                          s"fold crashed: ${e.getMessage}"
+                        )
+                    }
+
+                  // The getOrElse branches are unreachable: validated via missingSourceMethods before
+                  // building overrides.
+                  if (isDirectF) {
+                    val smF =
+                      sourceMethodOptF.getOrElse(
+                        throw CatsTaglessDerivationError.SourceMethodNotFound(methodName, " (F)")
+                      )
+                    val smG =
+                      sourceMethodOptG.getOrElse(
+                        throw CatsTaglessDerivationError.SourceMethodNotFound(methodName, " (G)")
+                      )
+                    val sourceCallF = foldSourceMethod(smF.method, afExpr)
+                    val sourceCallG = foldSourceMethod(smG.method, agExpr)
+                    import returnT.Underlying as RT
+                    mkTuple2K[RT](sourceCallF, sourceCallG)(returnT.Underlying).as_??(returnT.Underlying)
+                  } else {
+                    // Invariant — take from af
+                    val smF =
+                      sourceMethodOptF.getOrElse(
+                        throw CatsTaglessDerivationError.SourceMethodNotFound(methodName, " (F)")
+                      )
+                    val sourceCallF = foldSourceMethod(smF.method, afExpr)
+                    import returnT.Underlying as RT
+                    sourceCallF.asInstanceOf[Expr[RT]].as_??(returnT.Underlying)
+                  }
                 }
-              ) match {
-                case Right(exprE) => import exprE.Underlying; exprE.value.upcast[Any]
-                case Left(e)      => throw new RuntimeException(s"fold returned Left for $methodName: $e")
               }
-            catch {
-              case e: RuntimeException => throw e
-              case e: Throwable        =>
-                throw new RuntimeException(
-                  s"fold crashed for method $methodName: ${e.getMessage}",
-                  e
-                )
-            }
 
-          if (isDirectF) {
-            val smF = sourceMethodOptF.getOrElse(throw new RuntimeException(s"Source method $methodName not found (F)"))
-            val smG = sourceMethodOptG.getOrElse(throw new RuntimeException(s"Source method $methodName not found (G)"))
-            val sourceCallF = foldSourceMethod(smF.method, afExpr)
-            val sourceCallG = foldSourceMethod(smG.method, agExpr)
-            import returnT.Underlying as RT
-            mkTuple2K[RT](sourceCallF, sourceCallG)(returnT.Underlying).as_??(returnT.Underlying)
-          } else {
-            // Invariant — take from af
-            val smF = sourceMethodOptF.getOrElse(throw new RuntimeException(s"Source method $methodName not found (F)"))
-            val sourceCallF = foldSourceMethod(smF.method, afExpr)
-            import returnT.Underlying as RT
-            sourceCallF.asInstanceOf[Expr[RT]].as_??(returnT.Underlying)
-          }
+              cm.method.asUntyped -> body
+            }.toMap
+
+            // The MIO wrapper captures typed errors thrown from the OverrideBody callbacks invoked
+            // synchronously inside `construct` and routes them into the error channel.
+            MIO(anonInstance.construct(None, Map.empty, overrides)).flatMap {
+              case Right(expr) =>
+                MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor3]]])
+              case Left(errors) =>
+                failCannotConstruct("SemigroupalK", s"trait instance: ${errors.toVector.mkString(", ")}")
+            }
         }
       }
-
-      cm.method.asUntyped -> body
-    }.toMap
-
-    anonInstance.construct(None, Map.empty, overrides) match {
-      case Right(expr) =>
-        MIO.pure(expr.asInstanceOf[Expr[Alg[CatsTaglessFactories.WCtor3]]])
-      case Left(errors) =>
-        MIO.fail(
-          new RuntimeException(
-            s"Cannot construct SemigroupalK trait instance: ${errors.toVector.mkString(", ")}"
-          )
-        )
-    }
   }
 }

--- a/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,23 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  // Access annotations directly from the symbol to preserve type information.
-  // Hearth's param.asUntyped.annotations strips types via c.untypecheck,
-  // making typed comparison impossible. We bypass that by reading the raw
-  // symbol annotations where .tree.tpe is still intact.
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -1,9 +1,0 @@
-package hearth.kindlings.circederivation
-package internal.compiletime
-
-import hearth.MacroCommonsScala2
-
-/** Thin delegate re-exporting the shared implementation from derivation-commons. */
-trait AnnotationSupportScala2
-    extends AnnotationSupport
-    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/CirceJsonFieldConfigExtension.scala
+++ b/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/CirceJsonFieldConfigExtension.scala
@@ -23,14 +23,9 @@ final class CirceJsonFieldConfigExtension extends JsonSchemaConfigExtension {
     // Pre-resolve ExprCodec before introducing cross-quotes implicits
     // to avoid diverging implicit expansion caused by import ctx.* in Scala 2.
 
-    // Bootstrap Type[Configuration] from raw Scala 2 compiler type, bypassing
-    // cross-quotes Type.of which causes SOE: on Scala 2, the Type.of[A] macro
-    // expansion generates an implicit conversion (Type[T] → WeakTypeTag[T]) that
-    // resolves Type[A] at runtime — creating an inescapable self-referential cycle
-    // when the very Type[A] being defined IS the implicit in scope.
-    // Using sc2.c.universe.typeOf[X] + UntypedType.toTyped avoids this entirely.
-    implicit val ConfigT: Type[Configuration] =
-      UntypedType.toTyped[Configuration](sc2.c.universe.typeOf[Configuration].asInstanceOf[UntypedType])
+    // Self-referential implicit val Type.of definitions now work in cross-quotes (Hearth issue #285):
+    // the Scala 2 generated block shadows the in-definition implicit.
+    implicit val ConfigT: Type[Configuration] = Type.of[Configuration]
 
     // Annotation types only need UntypedType for comparison — get directly from
     // Scala 2 universe to avoid additional cross-quotes Type.of forward references.

--- a/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/CodecMacros.scala
+++ b/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/CodecMacros.scala
@@ -7,7 +7,7 @@ import scala.reflect.macros.blackbox
 
 final private[circederivation] class CodecMacros(val c: blackbox.Context)
     extends MacroCommonsScala2
-    with AnnotationSupportScala2
+    with AnnotationSupport
     with LoadStandardExtensionsOnce
     with EncoderMacrosImpl
     with DecoderMacrosImpl

--- a/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/DecoderMacros.scala
+++ b/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/DecoderMacros.scala
@@ -7,7 +7,7 @@ import scala.reflect.macros.blackbox
 
 final private[circederivation] class DecoderMacros(val c: blackbox.Context)
     extends MacroCommonsScala2
-    with AnnotationSupportScala2
+    with AnnotationSupport
     with LoadStandardExtensionsOnce
     with DecoderMacrosImpl {
 

--- a/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/EncoderMacros.scala
+++ b/circe-derivation/src/main/scala-2/hearth/kindlings/circederivation/internal/compiletime/EncoderMacros.scala
@@ -7,7 +7,7 @@ import scala.reflect.macros.blackbox
 
 final private[circederivation] class EncoderMacros(val c: blackbox.Context)
     extends MacroCommonsScala2
-    with AnnotationSupportScala2
+    with AnnotationSupport
     with LoadStandardExtensionsOnce
     with EncoderMacrosImpl {
 

--- a/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -1,9 +1,0 @@
-package hearth.kindlings.circederivation
-package internal.compiletime
-
-import hearth.MacroCommonsScala3
-
-/** Thin delegate re-exporting the shared implementation from derivation-commons. */
-trait AnnotationSupportScala3
-    extends AnnotationSupport
-    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/CirceJsonFieldConfigExtension.scala
+++ b/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/CirceJsonFieldConfigExtension.scala
@@ -14,17 +14,11 @@ final class CirceJsonFieldConfigExtension extends JsonSchemaConfigExtension {
     val sc3 = ctx.asInstanceOf[MacroCommonsScala3]
     import sc3.quotes.reflect.{Apply as QApply, Literal as QLiteral, StringConstant as QStringConstant, Term as QTerm}
 
-    // Bootstrap Type values by bypassing cross-quotes Type.of, which on both Scala 2
-    // and 3 generates code that resolves implicit/given Type[A] — causing an
-    // inescapable self-referential cycle when the Type[A] being defined IS the
-    // implicit in scope. Use scala.quoted.Type.of directly (only needs Quotes).
-    given scala.quoted.Quotes = sc3.quotes
-    implicit val ConfigT: Type[Configuration] =
-      scala.quoted.Type.of[Configuration].asInstanceOf[Type[Configuration]]
-    implicit val FieldNameT: Type[annotations.fieldName] =
-      scala.quoted.Type.of[annotations.fieldName].asInstanceOf[Type[annotations.fieldName]]
-    implicit val TransientFieldT: Type[annotations.transientField] =
-      scala.quoted.Type.of[annotations.transientField].asInstanceOf[Type[annotations.transientField]]
+    // Self-referential implicit val Type.of definitions now work in cross-quotes (Hearth issue #285):
+    // the Scala 3 plugin excludes the self-definition from injected casted givens.
+    implicit val ConfigT: Type[Configuration] = Type.of[Configuration]
+    implicit val FieldNameT: Type[annotations.fieldName] = Type.of[annotations.fieldName]
+    implicit val TransientFieldT: Type[annotations.transientField] = Type.of[annotations.transientField]
 
     Expr.summonImplicit[Configuration].toOption match {
       case Some(configExpr) =>

--- a/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/DecoderMacros.scala
+++ b/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/DecoderMacros.scala
@@ -7,7 +7,7 @@ import scala.quoted.*
 
 final private[circederivation] class DecoderMacros(q: Quotes)
     extends MacroCommonsScala3(using q),
-      AnnotationSupportScala3,
+      AnnotationSupport,
       LoadStandardExtensionsOnce,
       DecoderMacrosImpl
 private[circederivation] object DecoderMacros {

--- a/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/EncoderMacros.scala
+++ b/circe-derivation/src/main/scala-3/hearth/kindlings/circederivation/internal/compiletime/EncoderMacros.scala
@@ -7,7 +7,7 @@ import scala.quoted.*
 
 final private[circederivation] class EncoderMacros(q: Quotes)
     extends MacroCommonsScala3(using q),
-      AnnotationSupportScala3,
+      AnnotationSupport,
       LoadStandardExtensionsOnce,
       EncoderMacrosImpl
 private[circederivation] object EncoderMacros {

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupport.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/AnnotationSupport.scala
@@ -3,15 +3,7 @@ package hearth.kindlings.circederivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderDerivationError.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderDerivationError.scala
@@ -24,4 +24,7 @@ private[compiletime] object DecoderDerivationError {
       constructorError.fold(prefix)(err => s"$prefix: $err")
     }
   }
+  final case class UnexpectedParameterInSingleton(tpeName: String, context: String) extends DecoderDerivationError {
+    override def message: String = s"$context: $tpeName"
+  }
 }

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -13,6 +13,7 @@ import io.circe.{Decoder, DecodingFailure, HCursor, Json, KeyDecoder}
 
 trait DecoderMacrosImpl
     extends CirceDerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.DecoderUseCachedDefWhenAvailableRuleImpl
     with rules.DecoderUseImplicitWhenAvailableRuleImpl
     with rules.DecoderHandleAsLiteralTypeRuleImpl

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
@@ -181,13 +181,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
                   val defaultAsAnyOpt: Option[Expr[Any]] =
                     if (param.hasDefault)
                       param.defaultValue.flatMap { method =>
-                        method
-                          .fold(
-                            onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-                            onTypes = _ => Map.empty,
-                            onValues = _ => Map.empty
-                          )
-                          .toOption
+                        foldInstanceFree(method, "Default value")(
+                          onTypes = _ => Map.empty,
+                          onValues = _ => Map.empty
+                        ).toOption
                           .map { ee => import ee.Underlying; ee.value.upcast[Any] }
                       }
                     else None
@@ -440,8 +437,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
                 .traverse { decodedValuesExpr =>
                   val fieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
@@ -307,14 +307,24 @@ trait DecoderHandleAsMapRuleImpl {
                                       case Some(cc) =>
                                         cc.construct[MIO](new CaseClass.ConstructField[MIO] {
                                           def apply(field: Parameter): MIO[Expr[field.tpe.Underlying]] =
-                                            MIO.fail(new RuntimeException("Unexpected parameter in enum singleton"))
+                                            MIO.fail(
+                                              DecoderDerivationError
+                                                .UnexpectedParameterInSingleton(
+                                                  childName,
+                                                  "Unexpected parameter in enum singleton"
+                                                )
+                                            )
                                         }).flatMap {
                                           case Some(expr) => MIO.pure((childName, expr.asInstanceOf[Expr[K]]))
                                           case None       =>
-                                            MIO.fail(new RuntimeException(s"Cannot construct enum case $childName"))
+                                            val err =
+                                              DecoderDerivationError.CannotConstructType(childName, isSingleton = true)
+                                            Log.error(err.message) >> MIO.fail(err)
                                         }
                                       case None =>
-                                        MIO.fail(new RuntimeException(s"Cannot construct enum case $childName"))
+                                        val err =
+                                          DecoderDerivationError.CannotConstructType(childName, isSingleton = true)
+                                        Log.error(err.message) >> MIO.fail(err)
                                     }
                                 }
                               }

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsNamedTupleRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsNamedTupleRule.scala
@@ -72,8 +72,7 @@ trait DecoderHandleAsNamedTupleRuleImpl {
       NonEmptyList.fromList(fieldsList) match {
         case None =>
           // Empty named tuple: return Right(empty tuple)
-          constructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+          foldInstanceFree(constructor, "Constructor")(
             onTypes = _ => Map.empty,
             onValues = _ => Map.empty
           ) match {
@@ -137,8 +136,7 @@ trait DecoderHandleAsNamedTupleRuleImpl {
                 .traverse { decodedValuesExpr =>
                   val fieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
-                  constructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(constructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/derivation-commons/src/main/scala-2/hearth/kindlings/derivation/compiletime/AnnotationSupportScala2.scala
+++ b/derivation-commons/src/main/scala-2/hearth/kindlings/derivation/compiletime/AnnotationSupportScala2.scala
@@ -1,0 +1,73 @@
+package hearth.kindlings.derivation.compiletime
+
+import hearth.MacroCommonsScala2
+
+trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
+  import c.universe.*
+
+  // Access annotations directly from the symbol to preserve type information.
+  // Hearth's param.asUntyped.annotations strips types via c.untypecheck,
+  // making typed comparison impossible. We bypass that by reading the raw
+  // symbol annotations where .tree.tpe is still intact.
+  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    param.asUntyped.symbol.annotations.collectFirst {
+      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+    }
+  }
+
+  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.collectFirst {
+      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+    }
+  }
+
+  override protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    param.asUntyped.symbol.annotations.collect {
+      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+    }
+  }
+
+  override protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.collect {
+      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+    }
+  }
+
+  override protected def allParamAnnotations(param: Parameter): List[UntypedExpr] =
+    param.asUntyped.symbol.annotations.map(ann => c.untypecheck(ann.tree))
+
+  override protected def allTypeAnnotations[A: Type]: List[UntypedExpr] = {
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.map(ann => c.untypecheck(ann.tree))
+  }
+
+  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
+    annotation match {
+      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
+      case _                                                => None
+    }
+
+  override protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int] =
+    annotation match {
+      case Apply(_, List(Literal(Constant(value: Int)))) => Some(value)
+      case _                                             => None
+    }
+
+  override protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)] =
+    annotation match {
+      case Apply(_, List(Literal(Constant(v1: String)), Literal(Constant(v2: String)))) => Some((v1, v2))
+      case _                                                                            => None
+    }
+
+  override protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)] =
+    annotation match {
+      case Apply(_, List(Literal(Constant(v1: Int)), Literal(Constant(v2: Int)))) => Some((v1, v2))
+      case _                                                                      => None
+    }
+}

--- a/derivation-commons/src/main/scala-2/hearth/kindlings/derivation/compiletime/AnnotationSupportScala2.scala
+++ b/derivation-commons/src/main/scala-2/hearth/kindlings/derivation/compiletime/AnnotationSupportScala2.scala
@@ -2,72 +2,10 @@ package hearth.kindlings.derivation.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  // Access annotations directly from the symbol to preserve type information.
-  // Hearth's param.asUntyped.annotations strips types via c.untypecheck,
-  // making typed comparison impossible. We bypass that by reading the raw
-  // symbol annotations where .tree.tpe is still intact.
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collect {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.collect {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def allParamAnnotations(param: Parameter): List[UntypedExpr] =
-    param.asUntyped.symbol.annotations.map(ann => c.untypecheck(ann.tree))
-
-  override protected def allTypeAnnotations[A: Type]: List[UntypedExpr] = {
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.map(ann => c.untypecheck(ann.tree))
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-
-  override protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: Int)))) => Some(value)
-      case _                                             => None
-    }
-
-  override protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(v1: String)), Literal(Constant(v2: String)))) => Some((v1, v2))
-      case _                                                                            => None
-    }
-
-  override protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(v1: Int)), Literal(Constant(v2: Int)))) => Some((v1, v2))
-      case _                                                                      => None
-    }
-}
+/** Obsolete since Hearth issue #283: [[AnnotationSupport]] is now fully cross-platform (implemented on Hearth's typed
+  * annotation API), so no Scala 2-specific overrides are required. Retained only as an empty alias so derivation
+  * modules that still mix in `AnnotationSupportScala2` keep compiling; new code should mix in [[AnnotationSupport]]
+  * directly and this trait (and its module re-exports) can then be deleted. See `circe-derivation` for the fully
+  * migrated form.
+  */
+trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 => }

--- a/derivation-commons/src/main/scala-3/hearth/kindlings/derivation/compiletime/AnnotationSupportScala3.scala
+++ b/derivation-commons/src/main/scala-3/hearth/kindlings/derivation/compiletime/AnnotationSupportScala3.scala
@@ -1,0 +1,65 @@
+package hearth.kindlings.derivation.compiletime
+
+import hearth.MacroCommonsScala3
+
+trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
+  import quotes.reflect.*
+
+  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    param.asUntyped.annotations.find { term =>
+      term.tpe =:= annTpe
+    }
+  }
+
+  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.find { term =>
+      term.tpe =:= annTpe
+    }
+  }
+
+  override protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    param.asUntyped.annotations.filter(_.tpe =:= annTpe).toList
+  }
+
+  override protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr] = {
+    val annTpe = UntypedType.fromTyped[Ann]
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.filter(_.tpe =:= annTpe).toList
+  }
+
+  override protected def allParamAnnotations(param: Parameter): List[UntypedExpr] =
+    param.asUntyped.annotations.toList
+
+  override protected def allTypeAnnotations[A: Type]: List[UntypedExpr] = {
+    val aTpe = UntypedType.fromTyped[A]
+    aTpe.typeSymbol.annotations.toList
+  }
+
+  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
+    annotation match {
+      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
+      case _                                              => None
+    }
+
+  override protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int] =
+    annotation match {
+      case Apply(_, List(Literal(IntConstant(value)))) => Some(value)
+      case _                                           => None
+    }
+
+  override protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)] =
+    annotation match {
+      case Apply(_, List(Literal(StringConstant(v1)), Literal(StringConstant(v2)))) => Some((v1, v2))
+      case _                                                                        => None
+    }
+
+  override protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)] =
+    annotation match {
+      case Apply(_, List(Literal(IntConstant(v1)), Literal(IntConstant(v2)))) => Some((v1, v2))
+      case _                                                                  => None
+    }
+}

--- a/derivation-commons/src/main/scala-3/hearth/kindlings/derivation/compiletime/AnnotationSupportScala3.scala
+++ b/derivation-commons/src/main/scala-3/hearth/kindlings/derivation/compiletime/AnnotationSupportScala3.scala
@@ -2,64 +2,10 @@ package hearth.kindlings.derivation.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.filter(_.tpe =:= annTpe).toList
-  }
-
-  override protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.filter(_.tpe =:= annTpe).toList
-  }
-
-  override protected def allParamAnnotations(param: Parameter): List[UntypedExpr] =
-    param.asUntyped.annotations.toList
-
-  override protected def allTypeAnnotations[A: Type]: List[UntypedExpr] = {
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.toList
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-
-  override protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int] =
-    annotation match {
-      case Apply(_, List(Literal(IntConstant(value)))) => Some(value)
-      case _                                           => None
-    }
-
-  override protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(v1)), Literal(StringConstant(v2)))) => Some((v1, v2))
-      case _                                                                        => None
-    }
-
-  override protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)] =
-    annotation match {
-      case Apply(_, List(Literal(IntConstant(v1)), Literal(IntConstant(v2)))) => Some((v1, v2))
-      case _                                                                  => None
-    }
-}
+/** Obsolete since Hearth issue #283: [[AnnotationSupport]] is now fully cross-platform (implemented on Hearth's typed
+  * annotation API), so no Scala 3-specific overrides are required. Retained only as an empty alias so derivation
+  * modules that still mix in `AnnotationSupportScala3` keep compiling; new code should mix in [[AnnotationSupport]]
+  * directly and this trait (and its module re-exports) can then be deleted. See `circe-derivation` for the fully
+  * migrated form.
+  */
+trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 => }

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/AnnotationSupport.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/AnnotationSupport.scala
@@ -6,37 +6,57 @@ import hearth.std.*
 /** Cross-platform access to annotations on constructor parameters and types, plus literal extraction from annotation
   * trees.
   *
-  * Platform implementations live in [[AnnotationSupportScala2]] / [[AnnotationSupportScala3]]; each derivation module
-  * re-exports all three traits via thin delegates in its own `internal.compiletime` package (same approach as
-  * [[LoadStandardExtensionsOnce]]).
-  *
-  * This trait exists only because Hearth currently has no typed cross-platform annotation API — see
-  * `docs/research/hearth-gap-annotation-extraction.md`. Once Hearth provides one, this whole hierarchy should be
-  * deleted.
+  * As of Hearth issue #283, this is implemented entirely on top of Hearth's typed cross-platform annotation API
+  * (`Parameter#annotationsOfType` / `Type#annotationsOfType` for `<:<` lookup, and
+  * `Annotations.decodedConstructorArguments` for literal extraction). No platform-specific code is required — the
+  * former `AnnotationSupportScala2` / `AnnotationSupportScala3` halves are obsolete.
   */
 trait AnnotationSupport { this: MacroCommons & StdExtensions =>
 
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
+  // ----- Lookup (was abstract / platform-specific; now shared via Hearth's typed annotation API) -----
 
-  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr]
+  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[Expr[Ann]] =
+    param.annotationsOfType[Ann].headOption
 
-  protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr]
+  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[Expr[Ann]] =
+    Type[A].annotationsOfType[Ann].headOption
 
-  protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr]
+  protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[Expr[Ann]] =
+    param.annotationsOfType[Ann]
 
-  /** Collect ALL annotations on a parameter (regardless of type). */
-  protected def allParamAnnotations(param: Parameter): List[UntypedExpr]
+  protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[Expr[Ann]] =
+    Type[A].annotationsOfType[Ann]
 
-  /** Collect ALL annotations on a type (regardless of type). */
-  protected def allTypeAnnotations[A: Type]: List[UntypedExpr]
+  // ----- Literal extraction from annotation constructor arguments (shared) -----
 
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
+  private def decodedArgs[Ann](annotation: Expr[Ann]): List[Either[String, Any]] =
+    Annotations.decodedConstructorArguments(annotation).getOrElse(Nil)
 
-  protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int]
+  protected def extractStringLiteralFromAnnotation[Ann](annotation: Expr[Ann]): Option[String] =
+    decodedArgs(annotation) match {
+      case List(Right(value: String)) => Some(value)
+      case _                          => None
+    }
 
-  protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)]
+  protected def extractIntLiteralFromAnnotation[Ann](annotation: Expr[Ann]): Option[Int] =
+    decodedArgs(annotation) match {
+      case List(Right(value: Int)) => Some(value)
+      case _                       => None
+    }
 
-  protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)]
+  protected def extractTwoStringLiteralsFromAnnotation[Ann](annotation: Expr[Ann]): Option[(String, String)] =
+    decodedArgs(annotation) match {
+      case List(Right(v1: String), Right(v2: String)) => Some((v1, v2))
+      case _                                          => None
+    }
+
+  protected def extractTwoIntLiteralsFromAnnotation[Ann](annotation: Expr[Ann]): Option[(Int, Int)] =
+    decodedArgs(annotation) match {
+      case List(Right(v1: Int), Right(v2: Int)) => Some((v1, v2))
+      case _                                    => None
+    }
+
+  // ----- Public API (signatures unchanged; call sites unaffected) -----
 
   final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
     findAnnotationOfType[Ann](param).isDefined

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/AnnotationSupport.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/AnnotationSupport.scala
@@ -27,6 +27,22 @@ trait AnnotationSupport { this: MacroCommons & StdExtensions =>
   protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[Expr[Ann]] =
     Type[A].annotationsOfType[Ann]
 
+  /** Collect ALL annotations on a parameter (regardless of type), as untyped spliceable expressions.
+    *
+    * Backed by Hearth's typed cross-platform `Parameter#annotations` (`List[Expr_??]`); each existential expression is
+    * lowered to an [[UntypedExpr]] so callers can re-type it (e.g. `asTyped[Any]`) and splice it into generated code.
+    */
+  protected def allParamAnnotations(param: Parameter): List[UntypedExpr] =
+    param.annotations.map(_.asUntyped)
+
+  /** Collect ALL annotations on a type (regardless of type), as untyped spliceable expressions.
+    *
+    * Backed by Hearth's typed cross-platform `Type#annotations` (`List[Expr_??]`); each existential expression is
+    * lowered to an [[UntypedExpr]] so callers can re-type it (e.g. `asTyped[Any]`) and splice it into generated code.
+    */
+  protected def allTypeAnnotations[A: Type]: List[UntypedExpr] =
+    Type[A].annotations.map(_.asUntyped)
+
   // ----- Literal extraction from annotation constructor arguments (shared) -----
 
   private def decodedArgs[Ann](annotation: Expr[Ann]): List[Either[String, Any]] =

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/AnnotationSupport.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/AnnotationSupport.scala
@@ -1,0 +1,73 @@
+package hearth.kindlings.derivation.compiletime
+
+import hearth.MacroCommons
+import hearth.std.*
+
+/** Cross-platform access to annotations on constructor parameters and types, plus literal extraction from annotation
+  * trees.
+  *
+  * Platform implementations live in [[AnnotationSupportScala2]] / [[AnnotationSupportScala3]]; each derivation module
+  * re-exports all three traits via thin delegates in its own `internal.compiletime` package (same approach as
+  * [[LoadStandardExtensionsOnce]]).
+  *
+  * This trait exists only because Hearth currently has no typed cross-platform annotation API — see
+  * `docs/research/hearth-gap-annotation-extraction.md`. Once Hearth provides one, this whole hierarchy should be
+  * deleted.
+  */
+trait AnnotationSupport { this: MacroCommons & StdExtensions =>
+
+  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
+
+  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr]
+
+  protected def findAllAnnotationsOfType[Ann: Type](param: Parameter): List[UntypedExpr]
+
+  protected def findAllTypeAnnotationsOfType[Ann: Type, A: Type]: List[UntypedExpr]
+
+  /** Collect ALL annotations on a parameter (regardless of type). */
+  protected def allParamAnnotations(param: Parameter): List[UntypedExpr]
+
+  /** Collect ALL annotations on a type (regardless of type). */
+  protected def allTypeAnnotations[A: Type]: List[UntypedExpr]
+
+  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
+
+  protected def extractIntLiteralFromAnnotation(annotation: UntypedExpr): Option[Int]
+
+  protected def extractTwoStringLiteralsFromAnnotation(annotation: UntypedExpr): Option[(String, String)]
+
+  protected def extractTwoIntLiteralsFromAnnotation(annotation: UntypedExpr): Option[(Int, Int)]
+
+  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
+    findAnnotationOfType[Ann](param).isDefined
+
+  final def hasTypeAnnotation[Ann: Type, A: Type]: Boolean =
+    findTypeAnnotationOfType[Ann, A].isDefined
+
+  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
+    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+
+  final def getAnnotationIntArg[Ann: Type](param: Parameter): Option[Int] =
+    findAnnotationOfType[Ann](param).flatMap(extractIntLiteralFromAnnotation)
+
+  final def getTypeAnnotationStringArg[Ann: Type, A: Type]: Option[String] =
+    findTypeAnnotationOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
+
+  final def getTypeAnnotationIntArg[Ann: Type, A: Type]: Option[Int] =
+    findTypeAnnotationOfType[Ann, A].flatMap(extractIntLiteralFromAnnotation)
+
+  final def getAllAnnotationStringArgs[Ann: Type](param: Parameter): List[String] =
+    findAllAnnotationsOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+
+  final def getAllTypeAnnotationStringArgs[Ann: Type, A: Type]: List[String] =
+    findAllTypeAnnotationsOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
+
+  final def getAnnotationTwoIntArgs[Ann: Type](param: Parameter): Option[(Int, Int)] =
+    findAnnotationOfType[Ann](param).flatMap(extractTwoIntLiteralsFromAnnotation)
+
+  final def getAllAnnotationTwoStringArgs[Ann: Type](param: Parameter): List[(String, String)] =
+    findAllAnnotationsOfType[Ann](param).flatMap(extractTwoStringLiteralsFromAnnotation)
+
+  final def getAllTypeAnnotationTwoStringArgs[Ann: Type, A: Type]: List[(String, String)] =
+    findAllTypeAnnotationsOfType[Ann, A].flatMap(extractTwoStringLiteralsFromAnnotation)
+}

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/MethodFolds.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/MethodFolds.scala
@@ -4,8 +4,7 @@ import hearth.MacroCommons
 
 trait MethodFolds { this: MacroCommons =>
 
-  /** Folds a method that should never require an instance (constructors, default-value accessors, companion
-    * `apply`s).
+  /** Folds a method that should never require an instance (constructors, default-value accessors, companion `apply`s).
     *
     * `Method.fold` forces an `onInstance` branch that can only return an `Expr_??` — for instance-free methods the
     * branch is unreachable, and modules used to put `throw new RuntimeException(...)` there, which would crash the

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/MethodFolds.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/MethodFolds.scala
@@ -1,0 +1,28 @@
+package hearth.kindlings.derivation.compiletime
+
+import hearth.MacroCommons
+
+trait MethodFolds { this: MacroCommons =>
+
+  /** Folds a method that should never require an instance (constructors, default-value accessors, companion
+    * `apply`s).
+    *
+    * `Method.fold` forces an `onInstance` branch that can only return an `Expr_??` — for instance-free methods the
+    * branch is unreachable, and modules used to put `throw new RuntimeException(...)` there, which would crash the
+    * compiler instead of reporting a derivation error. This helper goes through `foldF` with an `Either` so the
+    * impossible case becomes a `Left` that callers route into the MIO error channel like any other failure.
+    */
+  final def foldInstanceFree(method: Method, what: => String)(
+      onTypes: Method.ApplyTypes => UntypedTypeArguments,
+      onValues: Method.ApplyValues => Arguments
+  ): Either[String, Expr_??] = {
+    type EitherString[A] = Either[String, A]
+    method
+      .foldF[EitherString](
+        onInstance = _ => Left(s"$what should not require an instance: ${method.prettyPrint}"),
+        onTypes = at => Right(onTypes(at)),
+        onValues = av => Right(onValues(av))
+      )
+      .flatten
+  }
+}

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DiffMacrosImpl.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DiffMacrosImpl.scala
@@ -262,7 +262,7 @@ trait DiffMacrosImpl
         value: Expr[A]
     ): MIO[Expr[DiffResult]] = {
       implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
-      val fields = caseClass.caseFieldValuesAt(value).toList
+      val fields = caseClass.caseFieldValuesAt(value, AtCallSite).toList
       val pn = Expr(Type.prettyPrint[A])
       val fn = Expr(Type.plainPrint[A])
       val sn = Expr(Type.shortName[A])

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCaseClassRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffCaseClassRule.scala
@@ -36,8 +36,8 @@ trait DiffCaseClassRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtension
         right: Expr[A]
     ): MIO[Expr[DiffResult]] = {
       implicit val DRT: Type[DiffResult] = DiffTypes.DiffResultType
-      val fieldsLeft = caseClass.caseFieldValuesAt(left).toList
-      val fieldsRight = caseClass.caseFieldValuesAt(right).toList
+      val fieldsLeft = caseClass.caseFieldValuesAt(left, AtCallSite).toList
+      val fieldsRight = caseClass.caseFieldValuesAt(right, AtCallSite).toList
       val pn = Expr(Type.prettyPrint[A])
       val fn = Expr(Type.plainPrint[A])
       val sn = Expr(Type.shortName[A])

--- a/docs/research/hearth-gap-annotation-extraction.md
+++ b/docs/research/hearth-gap-annotation-extraction.md
@@ -1,0 +1,90 @@
+# Hearth gap: no typed cross-platform annotation extraction
+
+Last updated: 2026-06-12. Status: **workaround in place** (shared `AnnotationSupport` in
+`derivation-commons`); should be deleted once Hearth provides the API.
+Filed as [kubuszok/hearth#283](https://github.com/kubuszok/hearth/issues/283).
+
+## Problem
+
+Hearth has no cross-platform API for reading annotations off constructor parameters or
+types and extracting literal arguments from them. Worse, the API that *does* exist is
+lossy on Scala 2:
+
+- `param.asUntyped.annotations` on Scala 2 runs the annotation trees through
+  `c.untypecheck`, which **strips `tree.tpe`** — making it impossible to match an
+  annotation by type (`ann.tree.tpe =:= annTpe` sees `null`).
+- There is no helper for extracting literal arguments, and the tree shapes differ per
+  platform: `Apply(_, List(Literal(Constant(v: String))))` on Scala 2 vs
+  `Apply(_, List(Literal(StringConstant(v))))` on Scala 3.
+
+## Impact in Kindlings
+
+Before deduplication, **12 modules** (avro, cats, circe, fast-show-pretty, jsoniter,
+pureconfig, sconfig, tapir-schema, ubjson, xml, yaml derivation + the field-config
+extensions) each carried a hand-rolled `AnnotationSupportScala2` / `AnnotationSupportScala3`
+pair — ~860 lines of copy-pasted platform-specific code in total. It now lives once in
+`derivation-commons/src/main/scala{,-2,-3}/hearth/kindlings/derivation/compiletime/AnnotationSupport*.scala`,
+but it is still platform-specific code that every Hearth user with annotation-driven
+derivation will have to rediscover and rewrite.
+
+## Reproducer
+
+Given a user-side annotation and case class:
+
+```scala
+final class fieldName(val name: String) extends scala.annotation.StaticAnnotation
+final case class Person(@fieldName("first_name") firstName: String)
+```
+
+Macro-side, with only Hearth's API:
+
+```scala
+// Goal: find @fieldName on the parameter and read out "first_name".
+val param: Parameter = ??? // from CaseClass.parse(...).primaryConstructor.parameters
+
+// Scala 3: works (terms keep their types)
+param.asUntyped.annotations.find(_.tpe =:= UntypedType.fromTyped[fieldName]) // Some(term)
+
+// Scala 2: NEVER matches — c.untypecheck strips tree.tpe, so tpe is null
+param.asUntyped.annotations // trees with tpe == null
+```
+
+The Scala 2 workaround has to bypass Hearth and read the raw symbol:
+
+```scala
+// Scala 2 only — note the direct c.universe access
+param.asUntyped.symbol.annotations.collectFirst {
+  case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
+}
+```
+
+And literal extraction must be duplicated per platform because the constant tree shapes
+differ (see `AnnotationSupportScala2.scala` vs `AnnotationSupportScala3.scala`).
+
+## Proposed Hearth API
+
+```scala
+// On Parameter and on Type (type-level annotations):
+def Parameter.annotationsOfType[Ann: Type]: List[UntypedExpr]   // typed matching, both platforms
+def Type.annotationsOfType[Ann: Type, A: Type]: List[UntypedExpr]
+
+// Literal extraction helpers (cross-platform tree matching):
+def UntypedExpr.literalArg[T]: Option[T]          // single-literal annotations
+def UntypedExpr.literalArgs: List[Any]            // positional literal args
+```
+
+Requirements:
+
+1. On Scala 2, annotation trees must keep their types (match before any `untypecheck`).
+2. Literal extraction must understand both `Constant(v)` (Scala 2) and
+   `StringConstant`/`IntConstant`/... (Scala 3).
+3. Should work on both `Parameter` (constructor params / fields) and types
+   (`typeSymbol.annotations`).
+
+## Reference
+
+- Kindlings shared workaround: `derivation-commons/.../compiletime/AnnotationSupport.scala`
+  (+ `Scala2`/`Scala3` siblings) — the abstract method set there is effectively the API
+  surface 12 real modules needed.
+- Original per-module copies: git history of e.g.
+  `circe-derivation/src/main/scala-2/.../AnnotationSupportScala2.scala`.

--- a/docs/research/hearth-gap-hkt-ctor-primitives.md
+++ b/docs/research/hearth-gap-hkt-ctor-primitives.md
@@ -1,0 +1,103 @@
+# Hearth gap: no cross-platform primitives for type constructors obtained at macro runtime
+
+Last updated: 2026-06-12. Status: **open** — ~790 lines of per-platform bridge code in
+kindlings exist solely because of this gap.
+Filed as [kubuszok/hearth#284](https://github.com/kubuszok/hearth/issues/284).
+
+## Problem
+
+`Type.Ctor1.of[G]` / `Type.Ctor2.of[G]` require a *compile-time literal* type
+constructor. HKT derivation (Functor, Traverse, FunctorK, ...) instead works with type
+constructors discovered *during expansion* — e.g. "field `x: G[A]` of the case class
+being derived; what is `G`?". Hearth offers no cross-platform way to:
+
+1. **Extract** the type constructor from an applied `Type[A]`
+   (Scala 2: `tpe.typeConstructor`; Scala 3: `AppliedType(ctor, _)`).
+2. **Extract type arguments** from an applied `Type[A]`
+   (Scala 2: `tpe.dealias.typeArgs`; Scala 3: `AppliedType(_, args)`).
+3. **Re-apply** a constructor obtained that way
+   (Scala 2: `c.universe.appliedType(ctor, args)`; Scala 3: `ctor.appliedTo(args)`).
+4. **Summon an implicit for a constructed applied type** — e.g. build `Functor[G]` from
+   anchor `Functor[_]` + extracted `G`, then search
+   (Scala 2: `c.inferImplicitValue`; Scala 3: `Implicits.search`).
+5. Work with **higher-order constructors** `Alg[_[_]]` (`CtorK1`-level): apply them to a
+   `Ctor1`, get a `Type[Alg[F]]`.
+6. **Compare** two constructors for identity (`typeSymbol` equality is what both
+   platforms end up using; nothing in Hearth exposes this for constructors).
+
+## Impact in Kindlings
+
+Every HKT module carries a per-platform "bridge" trait implementing 1–6 with raw
+`c.universe` / `quotes.reflect` code:
+
+- `cats-derivation`: `FunctorMacros.scala` (63 lines Scala 2 / 76 lines Scala 3),
+  `ConsKMacros.scala`, `FoldableMacros.scala`, `TraverseMacros.scala` — ~213 lines.
+- `cats-tagless-derivation`: `TaglessKBridgeScala2/3.scala` plus per-typeclass bridges
+  (`ApplyKMacros`, `FunctorKMacros`, `ContravariantKMacros`, `InvariantKMacros`,
+  `SemigroupalKMacros`, `InstrumentMacros`) — ~577 lines.
+
+Total: **17 files, ~790 lines** of near-identical pairs that differ only in which
+compiler API spells the operation. The bridges also force `Type[Any]`/`Expr[Any]`
+through their signatures, spreading untyped plumbing into otherwise-typed derivation
+code.
+
+## Reproducer
+
+```scala
+// Field of the derived case class: x: Option[Int].
+// Goal (all at macro-expansion time, cross-platform):
+val fieldType: Type[Any] = ???           // Type for Option[Int]
+
+// 1+2: decompose — WANT: Hearth API; HAVE: per-platform raw reflection
+// Scala 2:
+val tpe  = fieldType.asInstanceOf[c.WeakTypeTag[Any]].tpe
+val ctor = tpe.typeConstructor           // Option
+val args = tpe.dealias.typeArgs          // List(Int)
+// Scala 3:
+TypeRepr.of(using fieldType.asInstanceOf[scala.quoted.Type[Any]]).dealias match {
+  case AppliedType(ctor, args) => ...    // Option, List(Int)
+}
+
+// 4: summon Functor[Option] given only those pieces
+// Scala 2: c.inferImplicitValue(appliedType(functorCtor, List(ctor)))
+// Scala 3: Implicits.search(functorCtor.appliedTo(ctor))
+```
+
+Note `Type.Ctor1.fromUntyped[List](untypedCtor)` *exists* and is the one piece that
+works — but getting the `untypedCtor` and doing anything else with it requires dropping
+to platform APIs.
+
+## Proposed Hearth API
+
+```scala
+object Type {
+  /** Decompose an applied type into constructor + args; None if not applied. */
+  def decompose1[A: Type]: Option[(Type.Ctor1[AnyK], ??)]           // F[X]
+  def decompose2[A: Type]: Option[(Type.Ctor2[AnyK2], ??, ??)]      // F[X, Y]
+
+  object CtorK1 {                                                    // Alg[_[_]]
+    def of[HKT[_[_]]](implicit tag: ...): Type.CtorK1[HKT]
+    def fromUntyped[HKT[_[_]]](untyped: UntypedType): Type.CtorK1[HKT]
+    // .apply[F[_]](ctor: Type.Ctor1[F]): Type[HKT[F]] — already partially present
+  }
+}
+
+// Summon for a type assembled from extracted parts (anchor-style):
+// given anchor Type[TC[Probe]] and a Ctor1, search TC[G].
+def summonForCtor1[TC[_[_]], G[_]](anchor: Type[TC[AnyK]], g: Type.Ctor1[G]): Option[Expr_??]
+
+// Constructor identity:
+def Type.Ctor1.sameConstructorAs(other: UntypedType): Boolean      // typeSymbol equality
+```
+
+Exact shapes negotiable — the requirement is that the six operations above be doable
+without `c.universe` / `quotes.reflect`.
+
+## Reference
+
+- `cats-derivation/src/main/scala-2/.../FunctorMacros.scala` and
+  `.../scala-3/.../FunctorMacros.scala` — minimal complete pair showing all operations.
+- `cats-tagless-derivation/src/main/scala-{2,3}/.../TaglessKBridgeScala{2,3}.scala` —
+  the higher-order (`CtorK1`) variants.
+- `docs/contributing/hearth-hkt-derivation/SKILL.md` — the derivation patterns forced
+  around this gap.

--- a/docs/research/hearth-gap-type-of-bootstrap-cycle.md
+++ b/docs/research/hearth-gap-type-of-bootstrap-cycle.md
@@ -1,0 +1,67 @@
+# Hearth gap: `Type.of[A]` bootstrap cycle inside StandardMacroExtension contexts
+
+Last updated: 2026-06-12. Status: **open** — ~380 lines of per-platform workaround in
+circe-derivation and jsoniter-derivation field-config extensions.
+Filed as [kubuszok/hearth#285](https://github.com/kubuszok/hearth/issues/285).
+
+## Problem
+
+Cross-quotes `Type.of[A]` generates code that resolves an implicit/given `Type[A]`. In
+most macro code that's fine — the implicit comes from cross-quotes itself. But inside a
+`StandardMacroExtension` (e.g. a `JsonFieldConfig` discovery extension) the very value
+being defined *is* the implicit candidate in scope, so `Type.of[Configuration]` resolves
+to the definition currently being elaborated — an inescapable self-referential cycle
+(infinite loop / "recursive value" at expansion).
+
+There is no Hearth-provided way to obtain a `Type[A]` that bypasses implicit resolution.
+
+## Impact in Kindlings
+
+Four files exist only to host this workaround (plus the annotation-access duplication
+they drag in, see `hearth-gap-annotation-extraction.md`):
+
+- `circe-derivation/src/main/scala-2/.../CirceJsonFieldConfigExtension.scala` (~102 lines)
+- `circe-derivation/src/main/scala-3/.../CirceJsonFieldConfigExtension.scala` (~90 lines)
+- `jsoniter-derivation/src/main/scala-2/.../JsoniterJsonFieldConfigExtension.scala` (~99 lines)
+- `jsoniter-derivation/src/main/scala-3/.../JsoniterJsonFieldConfigExtension.scala` (~90 lines)
+
+## Reproducer / current workaround
+
+Scala 2 — bypass via raw `typeOf` + cast:
+
+```scala
+implicit val ConfigT: Type[Configuration] =
+  UntypedType.toTyped[Configuration](
+    sc2.c.universe.typeOf[Configuration].asInstanceOf[UntypedType]
+  )
+```
+
+Scala 3 — bypass via `scala.quoted.Type.of` + cast:
+
+```scala
+given scala.quoted.Quotes = sc3.quotes
+implicit val ConfigT: Type[Configuration] =
+  scala.quoted.Type.of[Configuration].asInstanceOf[Type[Configuration]]
+```
+
+Both casts are unchecked bridges between the compiler's `Type`/`WeakTypeTag` and
+Hearth's `Type` — exactly the kind of `asInstanceOf` Hearth exists to make unnecessary.
+
+## Proposed Hearth API
+
+Any one of:
+
+1. `Type.ofDirect[A]` (name negotiable): same as `Type.of[A]` but generated code does
+   NOT go through implicit resolution — it always materializes from the literal type
+   argument. Safe to call where a `Type[A]` given/implicit is being defined.
+2. Cross-quotes detection: when `Type.of[A]` expansion would resolve to the enclosing
+   definition itself, fall back to direct materialization instead of looping.
+3. At minimum: documented, supported `UntypedType.fromLiteral[A]`-style constructor so
+   the workaround doesn't need `asInstanceOf` across the typed/untyped boundary.
+
+## Reference
+
+- `CLAUDE.md` § "Cross-Compilation Pitfalls" → "`Type.of[A]` bootstrap cycle in
+  extensions".
+- The four extension files listed above; each contains a comment block headed
+  "Bootstrap Type values by bypassing cross-quotes Type.of".

--- a/fast-show-pretty/src/main/scala-2/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupportScala2.scala
+++ b/fast-show-pretty/src/main/scala-2/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,27 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupportScala3.scala
+++ b/fast-show-pretty/src/main/scala-3/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,27 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupport.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/AnnotationSupport.scala
@@ -3,23 +3,7 @@ package hearth.kindlings.fastshowpretty.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def hasTypeAnnotation[Ann: Type, A: Type]: Boolean =
-    findTypeAnnotationOfType[Ann, A].isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
-
-  final def getTypeAnnotationStringArg[Ann: Type, A: Type]: Option[String] =
-    findTypeAnnotationOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/iron-integration/src/main/scala/hearth/kindlings/ironintegration/internal/compiletime/IsValueTypeProviderForIron.scala
+++ b/iron-integration/src/main/scala/hearth/kindlings/ironintegration/internal/compiletime/IsValueTypeProviderForIron.scala
@@ -38,42 +38,44 @@ final class IsValueTypeProviderForIron extends StandardMacroExtension { loader =
             val runtimeConstraintType: Type[io.github.iltotore.iron.RuntimeConstraint[Inner, Constr]] =
               Type.Ctor2.of[io.github.iltotore.iron.RuntimeConstraint].apply[Inner, Constr]
 
-            // Unwrap: IronType is opaque — underlying value IS the same type at runtime
-            val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr => Expr.quote(Expr.splice(outerExpr).asInstanceOf[Inner])
+            // Summon RuntimeConstraint[Inner, Constr] at macro expansion time. Done eagerly
+            // (not inside the ctor callback) so that a missing instance becomes an aggregated
+            // skip reason instead of an exception crashing the compiler.
+            Expr.summonImplicit(using runtimeConstraintType).toOption match {
+              case None =>
+                skipped(
+                  s"${tpe.prettyPrint} is an Iron type, but no RuntimeConstraint instance was found for IronType[${Type[Inner].prettyPrint}, ${Type[Constr].prettyPrint}] — cannot generate validation"
+                )
 
-            // Wrap (runtime): validate via RuntimeConstraint[Inner, C].test + .message
-            val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
-              ctor = innerExpr => {
-                // Summon RuntimeConstraint[Inner, Constr] at macro expansion time
-                val constraintExpr = Expr
-                  .summonImplicit(using runtimeConstraintType)
-                  .toOption
-                  .getOrElse(
-                    throw new RuntimeException(
-                      s"No RuntimeConstraint instance found for IronType[${Type[Inner].prettyPrint}, ${Type[Constr].prettyPrint}]"
-                    )
-                  )
-                Expr.quote {
-                  val v = Expr.splice(innerExpr)
-                  val c = Expr.splice(constraintExpr)
-                  if (c.test(v)) Right(v.asInstanceOf[A])
-                  else Left("Should satisfy " + c.message)
-                }
-              },
-              method = None
-            )
+              case Some(constraintExpr) =>
+                // Unwrap: IronType is opaque — underlying value IS the same type at runtime
+                val unwrapExpr: Expr[A] => Expr[Inner] =
+                  outerExpr => Expr.quote(Expr.splice(outerExpr).asInstanceOf[Inner])
 
-            ProviderResult.Matched(
-              Existential[IsValueTypeOf[A, *], Inner](
-                new IsValueTypeOf[A, Inner] {
-                  override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
-                  override val wrap: CtorLikeOf[Inner, A] = eitherCtor
-                  override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
-                    Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                // Wrap (runtime): validate via RuntimeConstraint[Inner, C].test + .message
+                val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
+                  ctor = innerExpr =>
+                    Expr.quote {
+                      val v = Expr.splice(innerExpr)
+                      val c = Expr.splice(constraintExpr)
+                      if (c.test(v)) Right(v.asInstanceOf[A])
+                      else Left("Should satisfy " + c.message)
+                    },
+                  method = None
+                )
+
+                ProviderResult.Matched(
+                  Existential[IsValueTypeOf[A, *], Inner](
+                    new IsValueTypeOf[A, Inner] {
+                      override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
+                      override val wrap: CtorLikeOf[Inner, A] = eitherCtor
+                      override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
+                        Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                      )
+                    }
                   )
-                }
-              )
-            )
+                )
+            }
 
           case None => skipped(s"${tpe.prettyPrint} is not an Iron type")
         }

--- a/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/jsoniter-derivation/src/main/scala-2/hearth/kindlings/jsoniterderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/jsoniter-derivation/src/main/scala-3/hearth/kindlings/jsoniterderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/AnnotationSupport.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,15 +3,7 @@ package hearth.kindlings.jsoniterderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -19,6 +19,7 @@ import com.github.plokhotnyuk.jsoniter_scala.core.{
 
 trait CodecMacrosImpl
     extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.EncoderUseCachedDefWhenAvailableRuleImpl
     with rules.EncoderUseImplicitWhenAvailableRuleImpl
     with rules.EncoderHandleAsLiteralTypeRuleImpl

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
@@ -104,13 +104,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
       if (param.hasDefault) {
         param.defaultValue
           .flatMap { method =>
-            method
-              .fold(
-                onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-                onTypes = _ => Map.empty,
-                onValues = _ => Map.empty
-              )
-              .toOption
+            foldInstanceFree(method, "Default value")(
+              onTypes = _ => Map.empty,
+              onValues = _ => Map.empty
+            ).toOption
               .map { ee => import ee.Underlying; ee.value.upcast[Any] }
           }
           .foreach { defaultExpr =>
@@ -197,13 +194,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
       .filter { case (_, p) => hasAnnotationType[transientField](p) }
       .flatMap { case (fName, param) =>
         param.defaultValue.flatMap { method =>
-          method
-            .fold(
-              onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-              onTypes = _ => Map.empty,
-              onValues = _ => Map.empty
-            )
-            .toOption
+          foldInstanceFree(method, "Default value")(
+            onTypes = _ => Map.empty,
+            onValues = _ => Map.empty
+          ).toOption
             .map(expr => (fName, expr))
         }
       }
@@ -331,8 +325,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
                     fieldDataList.map(_._4(decodedValuesExpr)).toMap
                   // Merge with transient defaults
                   val fieldMap = nonTransientFieldMap ++ transientDefaults
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {
@@ -522,8 +515,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
               MIO.pure(combined.use { case (fieldInfos, lenGetter, lenSetter) =>
                 val fieldMap: Map[String, Expr_??] =
                   fieldInfos.map { case (name, _, getter, _) => (name, getter) }.toMap ++ transientDefaults
-                val constructExpr: Expr[A] = caseClass.primaryConstructor.fold(
-                  onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                val constructExpr: Expr[A] = foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                   onTypes = _ => Map.empty,
                   onValues = _ => fieldMap
                 ) match {
@@ -675,8 +667,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
                   val nonTransientFieldMap: Map[String, Expr_??] =
                     fieldDataList.map(_._4(decodedValuesExpr)).toMap
                   val fieldMap = nonTransientFieldMap ++ transientDefaults
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
@@ -792,14 +792,24 @@ trait DecoderHandleAsMapRuleImpl {
                                       case Some(cc) =>
                                         cc.construct[MIO](new CaseClass.ConstructField[MIO] {
                                           def apply(field: Parameter): MIO[Expr[field.tpe.Underlying]] =
-                                            MIO.fail(new RuntimeException("Unexpected parameter in enum singleton"))
+                                            MIO.fail(
+                                              CodecDerivationError
+                                                .UnexpectedParameterInSingleton(
+                                                  childName,
+                                                  "Unexpected parameter in enum singleton"
+                                                )
+                                            )
                                         }).flatMap {
                                           case Some(expr) => MIO.pure((childName, expr.asInstanceOf[Expr[K]]))
                                           case None       =>
-                                            MIO.fail(new RuntimeException(s"Cannot construct enum case $childName"))
+                                            val err =
+                                              CodecDerivationError.CannotConstructType(childName, isSingleton = true)
+                                            Log.error(err.message) >> MIO.fail(err)
                                         }
                                       case None =>
-                                        MIO.fail(new RuntimeException(s"Cannot construct enum case $childName"))
+                                        val err =
+                                          CodecDerivationError.CannotConstructType(childName, isSingleton = true)
+                                        Log.error(err.message) >> MIO.fail(err)
                                     }
                                 }
                               }

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsNamedTupleRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsNamedTupleRule.scala
@@ -49,8 +49,7 @@ trait DecoderHandleAsNamedTupleRuleImpl {
 
       NonEmptyList.fromList(indexedFields) match {
         case None =>
-          constructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+          foldInstanceFree(constructor, "Constructor")(
             onTypes = _ => Map.empty,
             onValues = _ => Map.empty
           ) match {
@@ -94,8 +93,7 @@ trait DecoderHandleAsNamedTupleRuleImpl {
                 .traverse { decodedValuesExpr =>
                   val fieldMap: Map[String, Expr_??] =
                     fieldDataList.map(_._4(decodedValuesExpr)).toMap
-                  constructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(constructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsOneValueClassRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsOneValueClassRule.scala
@@ -29,15 +29,16 @@ trait DecoderHandleAsOneValueClassRuleImpl {
               case (fName, param) :: Nil if IsValueType.unapply(Type[A]).isEmpty =>
                 import param.tpe.Underlying as Field
                 deriveDecoderRecursively[Field](using dctx.nest[Field](dctx.reader)).flatMap { decodedField =>
-                  cc.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(cc.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => Map(fName -> decodedField.as_??)
                   ) match {
                     case Right(constructExpr) =>
                       MIO.pure(Rule.matched(constructExpr.value.asInstanceOf[Expr[A]]))
                     case Left(error) =>
-                      MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
+                      val err =
+                        CodecDerivationError.CannotConstructType(Type[A].prettyPrint, isSingleton = false, Some(error))
+                      Log.error(err.message) >> MIO.fail(err)
                   }
                 }
               case _ =>

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsCaseClassRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsCaseClassRule.scala
@@ -22,13 +22,10 @@ trait EncoderHandleAsCaseClassRuleImpl {
   )(implicit AnyT: Type[Any]): List[Expr[Boolean]] = {
     val defaultAsAnyOpt: Option[Expr[Any]] = param.filter(_.hasDefault).flatMap { p =>
       p.defaultValue.flatMap { method =>
-        method
-          .fold(
-            onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-            onTypes = _ => Map.empty,
-            onValues = _ => Map.empty
-          )
-          .toOption
+        foldInstanceFree(method, "Default value")(
+          onTypes = _ => Map.empty,
+          onValues = _ => Map.empty
+        ).toOption
           .map { ee => import ee.Underlying; ee.value.upcast[Any] }
       }
     }

--- a/pureconfig-derivation/src/main/scala-2/hearth/kindlings/pureconfigderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/pureconfig-derivation/src/main/scala-2/hearth/kindlings/pureconfigderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/pureconfig-derivation/src/main/scala-3/hearth/kindlings/pureconfigderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/pureconfig-derivation/src/main/scala-3/hearth/kindlings/pureconfigderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/AnnotationSupport.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,15 +3,7 @@ package hearth.kindlings.pureconfigderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -17,6 +17,7 @@ import pureconfig.error.ConfigReaderFailures
 
 trait ReaderMacrosImpl
     extends PureconfigDerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.ReaderUseCachedDefWhenAvailableRuleImpl
     with rules.ReaderUseImplicitWhenAvailableRuleImpl
     with rules.ReaderHandleAsValueTypeRuleImpl

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsCaseClassRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsCaseClassRule.scala
@@ -99,13 +99,10 @@ trait ReaderHandleAsCaseClassRuleImpl {
 
       val transientDefaults: Map[String, Expr_??] = transientFields.flatMap { case (fName, param) =>
         param.defaultValue.flatMap { method =>
-          method
-            .fold(
-              onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-              onTypes = _ => Map.empty,
-              onValues = _ => Map.empty
-            )
-            .toOption
+          foldInstanceFree(method, "Default value")(
+            onTypes = _ => Map.empty,
+            onValues = _ => Map.empty
+          ).toOption
             .map(ee => (fName, ee))
         }
       }.toMap
@@ -154,13 +151,10 @@ trait ReaderHandleAsCaseClassRuleImpl {
               val defaultAsAnyOpt: Option[Expr[Any]] =
                 if (param.hasDefault)
                   param.defaultValue.flatMap { method =>
-                    method
-                      .fold(
-                        onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-                        onTypes = _ => Map.empty,
-                        onValues = _ => Map.empty
-                      )
-                      .toOption
+                    foldInstanceFree(method, "Default value")(
+                      onTypes = _ => Map.empty,
+                      onValues = _ => Map.empty
+                    ).toOption
                       .map { ee => import ee.Underlying; ee.value.upcast[Any] }
                   }
                 else None
@@ -322,8 +316,7 @@ trait ReaderHandleAsCaseClassRuleImpl {
                   val nonTransientFieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
                   val fieldMap: Map[String, Expr_??] = nonTransientFieldMap ++ transientDefaults
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsNamedTupleRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsNamedTupleRule.scala
@@ -52,8 +52,7 @@ trait ReaderHandleAsNamedTupleRuleImpl {
 
       NonEmptyList.fromList(fieldsList) match {
         case None =>
-          constructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+          foldInstanceFree(constructor, "Constructor")(
             onTypes = _ => Map.empty,
             onValues = _ => Map.empty
           ) match {
@@ -122,8 +121,7 @@ trait ReaderHandleAsNamedTupleRuleImpl {
                 .traverse { decodedValuesExpr =>
                   val fieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
-                  constructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(constructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/refined-integration/src/main/scala/hearth/kindlings/refinedintegration/internal/compiletime/IsValueTypeProviderForRefined.scala
+++ b/refined-integration/src/main/scala/hearth/kindlings/refinedintegration/internal/compiletime/IsValueTypeProviderForRefined.scala
@@ -39,51 +39,52 @@ final class IsValueTypeProviderForRefined extends StandardMacroExtension { loade
               Type.Ctor2.fromUntyped[eu.timepit.refined.api.Validate](impl.asUntyped).apply[Inner, Pred]
             }
 
-            // Unwrap: use Refined.unapply which works on both Scala 2 (AnyVal with .value)
-            // and Scala 3 (opaque type identity).
-            // Cast to Refined[Inner, Pred] first since A is abstract.
-            val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr =>
-              Expr.quote {
-                eu.timepit.refined.api.Refined
-                  .unapply(
-                    Expr.splice(outerExpr).asInstanceOf[eu.timepit.refined.api.Refined[Inner, Pred]]
-                  )
-                  .get
-              }
+            // Summon Validate[Inner, Pred] at macro expansion time (user's call site). Done
+            // eagerly (not inside the ctor callback) so that a missing instance becomes an
+            // aggregated skip reason instead of an exception crashing the compiler.
+            Expr.summonImplicit(using validateType).toOption match {
+              case None =>
+                skipped(
+                  s"${tpe.prettyPrint} is a Refined type, but no Validate instance was found for Refined[${Type[Inner].prettyPrint}, ${Type[Pred].prettyPrint}] — cannot generate validation"
+                )
 
-            val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
-              ctor = innerExpr => {
-                // Summon Validate[Inner, Pred] at macro expansion time (user's call site)
-                val validateExpr = Expr
-                  .summonImplicit(using validateType)
-                  .toOption
-                  .getOrElse(
-                    throw new RuntimeException(
-                      s"No Validate instance found for Refined[${Type[Inner].prettyPrint}, ${Type[Pred].prettyPrint}]"
-                    )
-                  )
+              case Some(validateExpr) =>
+                // Unwrap: use Refined.unapply which works on both Scala 2 (AnyVal with .value)
+                // and Scala 3 (opaque type identity).
+                // Cast to Refined[Inner, Pred] first since A is abstract.
+                val unwrapExpr: Expr[A] => Expr[Inner] = outerExpr =>
+                  Expr.quote {
+                    eu.timepit.refined.api.Refined
+                      .unapply(
+                        Expr.splice(outerExpr).asInstanceOf[eu.timepit.refined.api.Refined[Inner, Pred]]
+                      )
+                      .get
+                  }
+
                 // Use refineV which returns Either[String, Refined[Inner, Pred]] and works
                 // on both Scala 2 (AnyVal) and Scala 3 (opaque type)
-                Expr.quote {
-                  val v = Expr.splice(innerExpr)
-                  val validate = Expr.splice(validateExpr)
-                  eu.timepit.refined.refineV[Pred].apply[Inner](v)(validate).asInstanceOf[Either[String, A]]
-                }
-              },
-              method = None
-            )
+                val eitherCtor = CtorLikeOf.EitherStringOrValue[Inner, A](
+                  ctor = innerExpr =>
+                    Expr.quote {
+                      val v = Expr.splice(innerExpr)
+                      val validate = Expr.splice(validateExpr)
+                      eu.timepit.refined.refineV[Pred].apply[Inner](v)(validate).asInstanceOf[Either[String, A]]
+                    },
+                  method = None
+                )
 
-            ProviderResult.Matched(
-              Existential[IsValueTypeOf[A, *], Inner](
-                new IsValueTypeOf[A, Inner] {
-                  override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
-                  override val wrap: CtorLikeOf[Inner, A] = eitherCtor
-                  override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
-                    Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                ProviderResult.Matched(
+                  Existential[IsValueTypeOf[A, *], Inner](
+                    new IsValueTypeOf[A, Inner] {
+                      override val unwrap: Expr[A] => Expr[Inner] = unwrapExpr
+                      override val wrap: CtorLikeOf[Inner, A] = eitherCtor
+                      override lazy val ctors: CtorLikes[A] = NonEmptyList.one(
+                        Existential[CtorLikeOf[*, A], Inner](eitherCtor)
+                      )
+                    }
                   )
-                }
-              )
-            )
+                )
+            }
 
           case None => skipped(s"${tpe.prettyPrint} is not a Refined type")
         }

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ArbitraryMacrosImpl.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ArbitraryMacrosImpl.scala
@@ -8,6 +8,7 @@ import org.scalacheck.{Arbitrary, Gen}
 
 trait ArbitraryMacrosImpl
     extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.ArbitraryUseCachedRuleImpl
     with rules.ArbitraryUseImplicitRuleImpl
     with rules.ArbitraryBuiltInRuleImpl
@@ -196,5 +197,11 @@ private[compiletime] object ArbitraryDerivationError {
   final case class UnsupportedType(tpeName: String, reasons: List[String]) extends ArbitraryDerivationError {
     override def message: String =
       s"The type $tpeName was not handled by any Arbitrary derivation rule:\n${reasons.mkString("\n")}"
+  }
+  final case class EnumHasNoCases(tpeName: String) extends ArbitraryDerivationError {
+    override def message: String = s"Enum $tpeName has no cases"
+  }
+  final case class CannotConstructType(tpeName: String, reason: String) extends ArbitraryDerivationError {
+    override def message: String = s"Cannot construct $tpeName: $reason"
   }
 }

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/CogenMacrosImpl.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/CogenMacrosImpl.scala
@@ -171,4 +171,7 @@ private[compiletime] object CogenDerivationError {
     override def message: String =
       s"The type $tpeName was not handled by any Cogen derivation rule:\n${reasons.mkString("\n")}"
   }
+  final case class EnumHasNoCases(tpeName: String) extends CogenDerivationError {
+    override def message: String = s"Enum $tpeName has no cases"
+  }
 }

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ShrinkMacrosImpl.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ShrinkMacrosImpl.scala
@@ -8,6 +8,7 @@ import org.scalacheck.Shrink
 
 trait ShrinkMacrosImpl
     extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.ShrinkUseCachedRuleImpl
     with rules.ShrinkUseImplicitRuleImpl
     with rules.ShrinkBuiltInRuleImpl
@@ -186,5 +187,11 @@ private[compiletime] object ShrinkDerivationError {
   final case class UnsupportedType(tpeName: String, reasons: List[String]) extends ShrinkDerivationError {
     override def message: String =
       s"The type $tpeName was not handled by any Shrink derivation rule:\n${reasons.mkString("\n")}"
+  }
+  final case class EnumHasNoCases(tpeName: String) extends ShrinkDerivationError {
+    override def message: String = s"Enum $tpeName has no cases"
+  }
+  final case class CannotConstructType(tpeName: String, reason: String) extends ShrinkDerivationError {
+    override def message: String = s"Cannot construct $tpeName: $reason"
   }
 }

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/ArbitraryHandleAsCaseClassRule.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/ArbitraryHandleAsCaseClassRule.scala
@@ -41,8 +41,7 @@ trait ArbitraryHandleAsCaseClassRuleImpl { this: ArbitraryMacrosImpl & MacroComm
       NonEmptyList.fromList(fieldsList) match {
         case None =>
           // Zero-parameter case class
-          caseClass.primaryConstructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+          foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
             onTypes = _ => Map.empty,
             onValues = _ => Map.empty
           ) match {
@@ -51,7 +50,8 @@ trait ArbitraryHandleAsCaseClassRuleImpl { this: ArbitraryMacrosImpl & MacroComm
                 Expr.quote(_root_.org.scalacheck.Gen.const[A](Expr.splice(constructExpr.value.asInstanceOf[Expr[A]])))
               )
             case Left(error) =>
-              MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
+              val err = ArbitraryDerivationError.CannotConstructType(Type[A].prettyPrint, error)
+              Log.error(err.message) >> MIO.fail(err)
           }
 
         case Some(fields) =>
@@ -123,14 +123,14 @@ trait ArbitraryHandleAsCaseClassRuleImpl { this: ArbitraryMacrosImpl & MacroComm
                   val fieldMap: Map[String, Expr_??] = makeAccessors.map(_(valuesExpr)).toMap
 
                   // Build constructor
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {
                     case Right(constructExpr) => MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
                     case Left(error)          =>
-                      MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
+                      val err = ArbitraryDerivationError.CannotConstructType(Type[A].prettyPrint, error)
+                      Log.error(err.message) >> MIO.fail(err)
                   }
                 }
                 .map { builder =>

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/ArbitraryHandleAsEnumRule.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/ArbitraryHandleAsEnumRule.scala
@@ -30,12 +30,11 @@ trait ArbitraryHandleAsEnumRuleImpl { this: ArbitraryMacrosImpl & MacroCommons &
 
       childrenList match {
         case Nil =>
-          MIO.fail(new RuntimeException(s"Enum ${Type[A].prettyPrint} has no cases"))
-        case children =>
+          val err = ArbitraryDerivationError.EnumHasNoCases(Type[A].prettyPrint)
+          Log.error(err.message) >> MIO.fail(err)
+        case child :: children =>
           // Derive Gen for each enum case
-          NonEmptyList
-            .fromList(children)
-            .get
+          NonEmptyList(child, children)
             .parTraverse { case (_, enumChild) =>
               import enumChild.Underlying as CaseType
               Log.namedScope(s"Deriving Arbitrary for enum case ${CaseType.prettyPrint}") {
@@ -45,10 +44,11 @@ trait ArbitraryHandleAsEnumRuleImpl { this: ArbitraryMacrosImpl & MacroCommons &
               }
             }
             .map { caseGens =>
-              val oneOfExpr: Expr[_root_.org.scalacheck.Gen[A]] = caseGens.toList match {
-                case singleGen :: Nil =>
-                  singleGen
-                case firstGen :: secondGen :: rest =>
+              val firstGen = caseGens.head
+              val oneOfExpr: Expr[_root_.org.scalacheck.Gen[A]] = caseGens.tail match {
+                case Nil =>
+                  firstGen
+                case secondGen :: rest =>
                   if (rest.isEmpty) {
                     Expr.quote {
                       _root_.org.scalacheck.Gen.oneOf(Expr.splice(firstGen), Expr.splice(secondGen))
@@ -66,8 +66,6 @@ trait ArbitraryHandleAsEnumRuleImpl { this: ArbitraryMacrosImpl & MacroCommons &
                         .oneOf(Expr.splice(firstGen), Expr.splice(secondGen), Expr.splice(restGens)*)
                     }
                   }
-                case Nil =>
-                  throw new RuntimeException(s"Enum ${Type[A].prettyPrint} has no cases")
               }
               Expr.quote {
                 _root_.org.scalacheck.Gen.sized { n =>

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/CogenHandleAsEnumRule.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/CogenHandleAsEnumRule.scala
@@ -29,12 +29,11 @@ trait CogenHandleAsEnumRuleImpl { this: CogenMacrosImpl & MacroCommons & StdExte
 
       childrenList match {
         case Nil =>
-          MIO.fail(new RuntimeException(s"Enum ${Type[A].prettyPrint} has no cases"))
-        case children =>
+          val err = CogenDerivationError.EnumHasNoCases(Type[A].prettyPrint)
+          Log.error(err.message) >> MIO.fail(err)
+        case child :: children =>
           // Derive Cogen for each enum case
-          NonEmptyList
-            .fromList(children)
-            .get
+          NonEmptyList(child, children)
             .parTraverse { case (_, enumChild) =>
               import enumChild.Underlying as CaseType
               Log.namedScope(s"Deriving Cogen for enum case ${CaseType.prettyPrint}") {

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/ShrinkHandleAsCaseClassRule.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/ShrinkHandleAsCaseClassRule.scala
@@ -86,14 +86,14 @@ trait ShrinkHandleAsCaseClassRuleImpl { this: ShrinkMacrosImpl & MacroCommons & 
                     val elemExpr: Expr[Any] = Expr.quote(Expr.splice(arrExpr)(Expr.splice(Expr(idx))))
                     (name, castFn(elemExpr))
                   }.toMap
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {
                     case Right(constructExpr) => MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
                     case Left(error)          =>
-                      MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
+                      val err = ShrinkDerivationError.CannotConstructType(Type[A].prettyPrint, error)
+                      Log.error(err.message) >> MIO.fail(err)
                   }
                 }
                 .map { reconstructBuilder =>

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/ShrinkHandleAsEnumRule.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/rules/ShrinkHandleAsEnumRule.scala
@@ -29,12 +29,11 @@ trait ShrinkHandleAsEnumRuleImpl { this: ShrinkMacrosImpl & MacroCommons & StdEx
 
       childrenList match {
         case Nil =>
-          MIO.fail(new RuntimeException(s"Enum ${Type[A].prettyPrint} has no cases"))
-        case children =>
+          val err = ShrinkDerivationError.EnumHasNoCases(Type[A].prettyPrint)
+          Log.error(err.message) >> MIO.fail(err)
+        case child :: children =>
           // Derive Shrink for each enum case
-          NonEmptyList
-            .fromList(children)
-            .get
+          NonEmptyList(child, children)
             .parTraverse { case (_, enumChild) =>
               import enumChild.Underlying as CaseType
               Log.namedScope(s"Deriving Shrink for enum case ${CaseType.prettyPrint}") {

--- a/sconfig-derivation/src/main/scala-2/hearth/kindlings/sconfigderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/sconfig-derivation/src/main/scala-2/hearth/kindlings/sconfigderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/sconfig-derivation/src/main/scala-3/hearth/kindlings/sconfigderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/sconfig-derivation/src/main/scala-3/hearth/kindlings/sconfigderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/AnnotationSupport.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,15 +3,7 @@ package hearth.kindlings.sconfigderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -10,6 +10,7 @@ import org.ekrich.config.ConfigValue
 
 trait ReaderMacrosImpl
     extends SconfigDerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.ReaderUseCachedDefWhenAvailableRuleImpl
     with rules.ReaderUseImplicitWhenAvailableRuleImpl
     with rules.ReaderHandleAsValueTypeRuleImpl

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsCaseClassRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsCaseClassRule.scala
@@ -95,13 +95,10 @@ trait ReaderHandleAsCaseClassRuleImpl {
 
       val transientDefaults: Map[String, Expr_??] = transientFields.flatMap { case (fName, param) =>
         param.defaultValue.flatMap { method =>
-          method
-            .fold(
-              onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-              onTypes = _ => Map.empty,
-              onValues = _ => Map.empty
-            )
-            .toOption
+          foldInstanceFree(method, "Default value")(
+            onTypes = _ => Map.empty,
+            onValues = _ => Map.empty
+          ).toOption
             .map(ee => (fName, ee))
         }
       }.toMap
@@ -149,13 +146,10 @@ trait ReaderHandleAsCaseClassRuleImpl {
               val defaultAsAnyOpt: Option[Expr[Any]] =
                 if (param.hasDefault)
                   param.defaultValue.flatMap { method =>
-                    method
-                      .fold(
-                        onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-                        onTypes = _ => Map.empty,
-                        onValues = _ => Map.empty
-                      )
-                      .toOption
+                    foldInstanceFree(method, "Default value")(
+                      onTypes = _ => Map.empty,
+                      onValues = _ => Map.empty
+                    ).toOption
                       .map { ee => import ee.Underlying; ee.value.upcast[Any] }
                   }
                 else None
@@ -322,8 +316,7 @@ trait ReaderHandleAsCaseClassRuleImpl {
                   val nonTransientFieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
                   val fieldMap: Map[String, Expr_??] = nonTransientFieldMap ++ transientDefaults
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsNamedTupleRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsNamedTupleRule.scala
@@ -52,8 +52,7 @@ trait ReaderHandleAsNamedTupleRuleImpl {
 
       NonEmptyList.fromList(fieldsList) match {
         case None =>
-          constructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+          foldInstanceFree(constructor, "Constructor")(
             onTypes = _ => Map.empty,
             onValues = _ => Map.empty
           ) match {
@@ -117,8 +116,7 @@ trait ReaderHandleAsNamedTupleRuleImpl {
                 .traverse { decodedValuesExpr =>
                   val fieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
-                  constructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(constructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/tapir-schema-derivation/src/main/scala-2/hearth/kindlings/tapirschemaderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/tapir-schema-derivation/src/main/scala-2/hearth/kindlings/tapirschemaderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,35 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-
-  override protected def allParamAnnotations(param: Parameter): List[UntypedExpr] =
-    param.asUntyped.symbol.annotations.map(ann => c.untypecheck(ann.tree))
-
-  override protected def allTypeAnnotations[A: Type]: List[UntypedExpr] = {
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.map(ann => c.untypecheck(ann.tree))
-  }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/tapir-schema-derivation/src/main/scala-3/hearth/kindlings/tapirschemaderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/tapir-schema-derivation/src/main/scala-3/hearth/kindlings/tapirschemaderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,35 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-
-  override protected def allParamAnnotations(param: Parameter): List[UntypedExpr] =
-    param.asUntyped.annotations.toList
-
-  override protected def allTypeAnnotations[A: Type]: List[UntypedExpr] = {
-    val aTpe = UntypedType.fromTyped[A]
-    aTpe.typeSymbol.annotations.toList
-  }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/AnnotationSupport.scala
+++ b/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,26 +3,7 @@ package hearth.kindlings.tapirschemaderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def findTypeAnnotationOfType[Ann: Type, A: Type]: Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  /** Collect ALL annotations on a parameter (regardless of type). */
-  protected def allParamAnnotations(param: Parameter): List[UntypedExpr]
-
-  /** Collect ALL annotations on a type (regardless of type). */
-  protected def allTypeAnnotations[A: Type]: List[UntypedExpr]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
-
-  final def getTypeAnnotationStringArg[Ann: Type, A: Type]: Option[String] =
-    findTypeAnnotationOfType[Ann, A].flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/ubjson-derivation/src/main/scala-2/hearth/kindlings/ubjsonderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/ubjson-derivation/src/main/scala-2/hearth/kindlings/ubjsonderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/ubjson-derivation/src/main/scala-3/hearth/kindlings/ubjsonderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/ubjson-derivation/src/main/scala-3/hearth/kindlings/ubjsonderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/AnnotationSupport.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,15 +3,7 @@ package hearth.kindlings.ubjsonderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -10,6 +10,7 @@ import hearth.kindlings.ubjsonderivation.annotations.{fieldName as fieldNameAnn,
 
 trait CodecMacrosImpl
     extends hearth.kindlings.derivation.compiletime.DerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.EncoderUseCachedDefWhenAvailableRuleImpl
     with rules.EncoderUseImplicitWhenAvailableRuleImpl
     with rules.EncoderHandleAsBuiltInRuleImpl

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
@@ -85,13 +85,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
             .filter { case (_, p) => hasAnnotationType[transientField](p) }
             .flatMap { case (fName, param) =>
               param.defaultValue.flatMap { method =>
-                method
-                  .fold(
-                    onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-                    onTypes = _ => Map.empty,
-                    onValues = _ => Map.empty
-                  )
-                  .toOption
+                foldInstanceFree(method, "Default value")(
+                  onTypes = _ => Map.empty,
+                  onValues = _ => Map.empty
+                ).toOption
                   .map(expr => (fName, expr))
               }
             }
@@ -184,14 +181,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
                         if (param.hasDefault) {
                           param.defaultValue
                             .flatMap { method =>
-                              method
-                                .fold(
-                                  onInstance =
-                                    _ => throw new RuntimeException("Default value should not need instance"),
-                                  onTypes = _ => Map.empty,
-                                  onValues = _ => Map.empty
-                                )
-                                .toOption
+                              foldInstanceFree(method, "Default value")(
+                                onTypes = _ => Map.empty,
+                                onValues = _ => Map.empty
+                              ).toOption
                                 .map { ee => import ee.Underlying; ee.value.upcast[Any] }
                             }
                             .foreach { defaultExpr =>
@@ -237,14 +230,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
                         if (isCollOrMapField && param.hasDefault) {
                           param.defaultValue
                             .flatMap { method =>
-                              method
-                                .fold(
-                                  onInstance =
-                                    _ => throw new RuntimeException("Default value should not need instance"),
-                                  onTypes = _ => Map.empty,
-                                  onValues = _ => Map.empty
-                                )
-                                .toOption
+                              foldInstanceFree(method, "Default value")(
+                                onTypes = _ => Map.empty,
+                                onValues = _ => Map.empty
+                              ).toOption
                                 .map { ee => import ee.Underlying; ee.value.upcast[Any] }
                             }
                             .foreach { defaultExpr =>
@@ -272,8 +261,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
                   val nonTransientFieldMap: Map[String, Expr_??] =
                     fieldDataList.map(_._4(decodedValuesExpr)).toMap
                   val fieldMap = nonTransientFieldMap ++ transientDefaults
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {
@@ -457,13 +445,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
             .filter { case (_, p) => hasAnnotationType[transientField](p) }
             .flatMap { case (fName, param) =>
               param.defaultValue.flatMap { method =>
-                method
-                  .fold(
-                    onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-                    onTypes = _ => Map.empty,
-                    onValues = _ => Map.empty
-                  )
-                  .toOption
+                foldInstanceFree(method, "Default value")(
+                  onTypes = _ => Map.empty,
+                  onValues = _ => Map.empty
+                ).toOption
                   .map(expr => (fName, expr))
               }
             }
@@ -498,8 +483,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
                   val nonTransientFieldMap: Map[String, Expr_??] =
                     fieldDataList.map(_._4(decodedValuesExpr)).toMap
                   val fieldMap = nonTransientFieldMap ++ transientDefaults
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/EncoderHandleAsCaseClassRule.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/EncoderHandleAsCaseClassRule.scala
@@ -99,13 +99,10 @@ trait EncoderHandleAsCaseClassRuleImpl {
                         val param = paramsByName.get(fName)
                         val defaultAsAnyOpt: Option[Expr[Any]] = param.filter(_.hasDefault).flatMap { p =>
                           p.defaultValue.flatMap { method =>
-                            method
-                              .fold(
-                                onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-                                onTypes = _ => Map.empty,
-                                onValues = _ => Map.empty
-                              )
-                              .toOption
+                            foldInstanceFree(method, "Default value")(
+                              onTypes = _ => Map.empty,
+                              onValues = _ => Map.empty
+                            ).toOption
                               .map { ee => import ee.Underlying; ee.value.upcast[Any] }
                           }
                         }

--- a/xml-derivation/src/main/scala-2/hearth/kindlings/xmlderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/xml-derivation/src/main/scala-2/hearth/kindlings/xmlderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/xml-derivation/src/main/scala-3/hearth/kindlings/xmlderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/xml-derivation/src/main/scala-3/hearth/kindlings/xmlderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/AnnotationSupport.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,15 +3,7 @@ package hearth.kindlings.xmlderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/DecoderDerivationError.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/DecoderDerivationError.scala
@@ -6,4 +6,12 @@ private[compiletime] object DecoderDerivationError {
       extends DecoderDerivationError(
         s"Cannot derive XmlDecoder for type $typeName:\n${reasons.mkString("\n")}"
       )
+  final case class CannotConstructType(typeName: String, constructorError: Option[String] = None)
+      extends DecoderDerivationError(
+        constructorError.fold(s"Cannot construct $typeName")(err => s"Cannot construct $typeName: $err")
+      )
+  final case class SingletonDisappeared(typeName: String)
+      extends DecoderDerivationError(
+        s"Singleton disappeared for $typeName"
+      )
 }

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -9,6 +9,7 @@ import hearth.kindlings.xmlderivation.internal.runtime.XmlDerivationUtils
 
 trait DecoderMacrosImpl
     extends XmlDerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.DecoderUseCachedDefWhenAvailableRuleImpl
     with rules.DecoderUseImplicitWhenAvailableRuleImpl
     with rules.DecoderHandleAsBuiltInRuleImpl

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
@@ -69,8 +69,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
               if (isTransient) {
                 val defaultValue: Expr[Any] = param.defaultValue match {
                   case Some(method) =>
-                    method.fold(
-                      onInstance = _ => throw new RuntimeException("Default value should not need instance"),
+                    foldInstanceFree(method, "Default value")(
                       onTypes = _ => Map.empty,
                       onValues = _ => Map.empty
                     ) match {
@@ -134,7 +133,8 @@ trait DecoderHandleAsCaseClassRuleImpl {
                   Right(Expr.splice(constructExpr))
                 })
               case None =>
-                MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}"))
+                val err = DecoderDerivationError.CannotConstructType(Type[A].prettyPrint)
+                Log.error(err.message) >> MIO.fail(err)
             }
       }
     }
@@ -143,8 +143,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
     private def resolveDefaultValue(fName: String, param: Parameter): Expr[Any] =
       param.defaultValue match {
         case Some(method) =>
-          method.fold(
-            onInstance = _ => throw new RuntimeException("Default value should not need instance"),
+          foldInstanceFree(method, "Default value")(
             onTypes = _ => Map.empty,
             onValues = _ => Map.empty
           ) match {
@@ -325,14 +324,14 @@ trait DecoderHandleAsCaseClassRuleImpl {
             .traverse { decodedValuesExpr =>
               val fieldMap: Map[String, Expr_??] =
                 makeAccessors.map(_(decodedValuesExpr)).toMap
-              constructor.fold(
-                onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+              foldInstanceFree(constructor, "Constructor")(
                 onTypes = _ => Map.empty,
                 onValues = _ => fieldMap
               ) match {
                 case Right(constructExpr) => MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
                 case Left(error)          =>
-                  MIO.fail(new RuntimeException(s"Cannot construct ${Type[A].prettyPrint}: $error"))
+                  val err = DecoderDerivationError.CannotConstructType(Type[A].prettyPrint, Some(error))
+                  Log.error(err.message) >> MIO.fail(err)
               }
             }
             .map { builder =>

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderHandleAsSingletonRule.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderHandleAsSingletonRule.scala
@@ -27,7 +27,8 @@ trait DecoderHandleAsSingletonRuleImpl {
                   case Some(singletonExpr) =>
                     MIO.pure(Expr.quote(Right(Expr.splice(singletonExpr))))
                   case None =>
-                    MIO.fail(new RuntimeException(s"Singleton disappeared for ${Type[A].prettyPrint}"))
+                    val err = DecoderDerivationError.SingletonDisappeared(Type[A].prettyPrint)
+                    Log.error(err.message) >> MIO.fail(err)
                 }
               }
               result <- dctx.getHelper[A].flatMap {

--- a/yaml-derivation/src/main/scala-2/hearth/kindlings/yamlderivation/internal/compiletime/AnnotationSupportScala2.scala
+++ b/yaml-derivation/src/main/scala-2/hearth/kindlings/yamlderivation/internal/compiletime/AnnotationSupportScala2.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala2
 
-trait AnnotationSupportScala2 extends AnnotationSupport { this: MacroCommonsScala2 =>
-  import c.universe.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.symbol.annotations.collectFirst {
-      case ann if ann.tree.tpe =:= annTpe => c.untypecheck(ann.tree)
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(Constant(value: String)))) => Some(value)
-      case _                                                => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala2
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala2 { this: MacroCommonsScala2 => }

--- a/yaml-derivation/src/main/scala-3/hearth/kindlings/yamlderivation/internal/compiletime/AnnotationSupportScala3.scala
+++ b/yaml-derivation/src/main/scala-3/hearth/kindlings/yamlderivation/internal/compiletime/AnnotationSupportScala3.scala
@@ -3,19 +3,7 @@ package internal.compiletime
 
 import hearth.MacroCommonsScala3
 
-trait AnnotationSupportScala3 extends AnnotationSupport { this: MacroCommonsScala3 =>
-  import quotes.reflect.*
-
-  override protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr] = {
-    val annTpe = UntypedType.fromTyped[Ann]
-    param.asUntyped.annotations.find { term =>
-      term.tpe =:= annTpe
-    }
-  }
-
-  override protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String] =
-    annotation match {
-      case Apply(_, List(Literal(StringConstant(value)))) => Some(value)
-      case _                                              => None
-    }
-}
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupportScala3
+    extends AnnotationSupport
+    with hearth.kindlings.derivation.compiletime.AnnotationSupportScala3 { this: MacroCommonsScala3 => }

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/AnnotationSupport.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/AnnotationSupport.scala
@@ -3,15 +3,7 @@ package hearth.kindlings.yamlderivation.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.*
 
-trait AnnotationSupport { this: MacroCommons & StdExtensions =>
-
-  protected def findAnnotationOfType[Ann: Type](param: Parameter): Option[UntypedExpr]
-
-  protected def extractStringLiteralFromAnnotation(annotation: UntypedExpr): Option[String]
-
-  final def hasAnnotationType[Ann: Type](param: Parameter): Boolean =
-    findAnnotationOfType[Ann](param).isDefined
-
-  final def getAnnotationStringArg[Ann: Type](param: Parameter): Option[String] =
-    findAnnotationOfType[Ann](param).flatMap(extractStringLiteralFromAnnotation)
+/** Thin delegate re-exporting the shared implementation from derivation-commons. */
+trait AnnotationSupport extends hearth.kindlings.derivation.compiletime.AnnotationSupport {
+  this: MacroCommons & StdExtensions =>
 }

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -12,6 +12,7 @@ import org.virtuslab.yaml.{ConstructError, Node, YamlDecoder, YamlError}
 
 trait DecoderMacrosImpl
     extends YamlDerivationTimeout
+    with hearth.kindlings.derivation.compiletime.MethodFolds
     with rules.DecoderUseCachedDefWhenAvailableRuleImpl
     with rules.DecoderUseImplicitWhenAvailableRuleImpl
     with rules.DecoderHandleAsLiteralTypeRuleImpl

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
@@ -54,13 +54,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
 
       val transientDefaults: Map[String, Expr_??] = transientFields.flatMap { case (fName, param) =>
         param.defaultValue.flatMap { method =>
-          method
-            .fold(
-              onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-              onTypes = _ => Map.empty,
-              onValues = _ => Map.empty
-            )
-            .toOption
+          foldInstanceFree(method, "Default value")(
+            onTypes = _ => Map.empty,
+            onValues = _ => Map.empty
+          ).toOption
             .map(expr => (fName, expr))
         }
       }.toMap
@@ -108,13 +105,10 @@ trait DecoderHandleAsCaseClassRuleImpl {
               val defaultAsAnyOpt: Option[Expr[Any]] =
                 if (param.hasDefault)
                   param.defaultValue.flatMap { method =>
-                    method
-                      .fold(
-                        onInstance = _ => throw new RuntimeException("Default value should not need instance"),
-                        onTypes = _ => Map.empty,
-                        onValues = _ => Map.empty
-                      )
-                      .toOption
+                    foldInstanceFree(method, "Default value")(
+                      onTypes = _ => Map.empty,
+                      onValues = _ => Map.empty
+                    ).toOption
                       .map { ee => import ee.Underlying; ee.value.upcast[Any] }
                   }
                 else None
@@ -235,8 +229,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
                   val nonTransientFieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
                   val fieldMap: Map[String, Expr_??] = nonTransientFieldMap ++ transientDefaults
-                  caseClass.primaryConstructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsNamedTupleRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsNamedTupleRule.scala
@@ -51,8 +51,7 @@ trait DecoderHandleAsNamedTupleRuleImpl {
 
       NonEmptyList.fromList(fieldsList) match {
         case None =>
-          constructor.fold(
-            onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+          foldInstanceFree(constructor, "Constructor")(
             onTypes = _ => Map.empty,
             onValues = _ => Map.empty
           ) match {
@@ -115,8 +114,7 @@ trait DecoderHandleAsNamedTupleRuleImpl {
                 .traverse { decodedValuesExpr =>
                   val fieldMap: Map[String, Expr_??] =
                     makeAccessors.map(_(decodedValuesExpr)).toMap
-                  constructor.fold(
-                    onInstance = _ => throw new RuntimeException("Constructor should not need instance"),
+                  foldInstanceFree(constructor, "Constructor")(
                     onTypes = _ => Map.empty,
                     onValues = _ => fieldMap
                   ) match {


### PR DESCRIPTION
… gaps

Replace every macro-time throw new RuntimeException (and untyped MIO.fail(new RuntimeException)) in compiletime sources with the MIO error channel and per-module typed error ADTs:

- derivation-commons gains MethodFolds.foldInstanceFree, replacing the 92 unreachable `onInstance = _ => throw` branches in Method.fold call sites across 9 modules with a Left that flows into existing error handling
- cats-derivation and cats-tagless-derivation get error hierarchies (CatsDerivationError + CatsDerivationErrorSupport, CatsTaglessDerivationError) replacing ~230 compiler-crashing throws; independent probe parses now aggregate via parTuple so all failures are reported, not just the first
- throws inside synchronous Hearth callbacks (LambdaBuilder.buildWith, OverrideBody) throw the typed error with the enclosing construction wrapped in MIO(...) so NonFatal routing surfaces them as derivation errors
- scalacheck gains EnumHasNoCases/CannotConstructType cases (and drops NonEmptyList.fromList(...).get + an unreachable Nil branch); circe gains UnexpectedParameterInSingleton; xml gains CannotConstructType and SingletonDisappeared
- iron/refined providers hoist the implicit summon to parse-time; a missing RuntimeConstraint/Validate becomes an aggregated skip reason, not a crash

Deduplicate AnnotationSupport: one superset implementation in derivation-commons (same thin-delegate pattern as LoadStandardExtensionsOnce); the 11 per-module copies become 3-line delegates (~800 lines removed).

Document the Hearth API gaps that force the remaining platform-specific code, with reproducers in docs/research/ and filed upstream:
- kubuszok/hearth#283 typed annotation extraction (Scala 2 untypecheck strips tree.tpe)
- kubuszok/hearth#284 type-constructor primitives for HKT derivation
- kubuszok/hearth#285 Type.of bootstrap cycle in StandardMacroExtension

Verified: test-jvm-2_13 and test-jvm-3 green after full clean.

---

## Update: all three Hearth gaps are now FIXED upstream and consumed here

Hearth kubuszok/hearth#286 fixes #283/#284/#285; this PR now runs against its CI-published snapshot **`0.3.1-32-gc1117d2-SNAPSHOT`** and replaces the documented workarounds with the new APIs (commit 5b5d3b8):

- **hearth#283 (annotation extraction):** the shared `AnnotationSupport` trait is now fully concrete — implemented on `Parameter/Type.annotationsOfType[Ann]` + `Annotations.decodedConstructorArguments` with unchanged public signatures. circe-derivation migrated as the representative module: its `AnnotationSupportScala2/3.scala` platform halves are **deleted**; the derivation-commons platform halves are reduced to empty aliases kept only until the remaining 4 modules migrate their mixins (then ~2,000 more lines become deletable).
- **hearth#284 (HKT ctor primitives):** cats-derivation `FunctorMacros` Scala-2/Scala-3 bridge pair collapsed into shared `FunctorMacrosImpl` using `Type.decompose1` (live re-applicable `Ctor1`), `sameTypeConstructorAs`, and `CtorK1.of[Functor].apply` for instance summoning — the raw `c.universe`/`quotes.reflect` bodies are gone. Same pattern applies to the Traverse/Foldable/tagless bridges when migrated.
- **hearth#285 (Type.of bootstrap cycle):** `CirceJsonFieldConfigExtension` (both platforms) drops the "Bootstrap Type values" `asInstanceOf` cast blocks for plain `implicit val ConfigT: Type[Configuration] = Type.of[Configuration]` — cross-quotes now handles self-referential implicit `Type`/`Ctor` definitions. jsoniter's equivalent block can migrate the same way.

Bonus: the end-to-end verification caught a Hearth-side regression (unions over types compiled in the same run were refused — the previously-failing `ParrotOrHamster` tests in `CirceScala3Spec` now pass, circeDerivation3 419/419).

Note: the pinned snapshot version embeds hearth PR #286's merge-commit sha; it must be refreshed if that PR is updated before merging.