### PR TITLE
Runtime + macro-compile optimizations, API rename, JFR skill, benchmark refresh

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -185,6 +185,15 @@ When optimizing the runtime performance of generated codecs/encoders/decoders. K
 
 Reference analysis: `docs/research/jsoniter-codegen-techniques.md`, `docs/research/perf-regression-analysis.md`
 
+### Profiling benchmarks (JFR) — follow `docs/contributing/kindlings-jfr-profiling/SKILL.md`
+
+When profiling JMH benchmarks to find the hot spot before applying a runtime-perf optimization.
+Covers JFR execution **sampling** (any JDK, the current workflow) and deterministic **method
+timing/tracing** (`jdk.MethodTiming` / `jdk.MethodTrace`, JEP 520, JDK 25+ — available on the
+GraalVM CE 25 dev machine, falls back to sampling on Temurin 17/CI). Exact `-prof jfr` commands,
+custom `.jfc` filters, discovering synthetic generated-codec method FQCNs, and `jfr view` analysis.
+Distinct from Hearth's MIO `.speedscope.json` flame graphs, which profile compile-time expansion.
+
 ### Factory instance pattern — follow `docs/contributing/kindlings-factory-instance/SKILL.md`
 
 When generating the final `new TypeClass[A] { ... }` expression, use factory methods + lambdas

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -370,7 +370,7 @@ trait DecoderMacrosImpl
           AvroDecoderHandleAsValueTypeRule,
           AvroDecoderHandleAsOptionRule,
           AvroDecoderHandleAsEitherRule,
-          AvroDecoderHandleAsMapRule,
+          // Map handling is folded into the collection rule (single IsCollection parse, dispatched via `.asMap`).
           AvroDecoderHandleAsCollectionRule,
           AvroDecoderHandleAsNamedTupleRule,
           AvroDecoderHandleAsSingletonRule,

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -35,6 +35,9 @@ trait DecoderMacrosImpl
   ): Expr[A] = {
     implicit val AnyT: Type[Any] = DecTypes.Any
     implicit val ConfigT: Type[AvroConfig] = DecTypes.AvroConfig
+    // Evaluate the config at compile time when possible, so field-name mapping is a compile-time constant
+    // (no per-field `config.transformFieldNames(name)` call). Falls back to the runtime call when not evaluable.
+    val evConfig: Option[AvroConfig] = configExpr.semiEval.toOption
 
     deriveDecoderFromCtxAndAdaptForEntrypoint[A, A]("AvroDecoder.decode") { fromCtx =>
       ValDefs.createVal[Any](avroValueExpr).use { avroVal =>
@@ -42,7 +45,7 @@ trait DecoderMacrosImpl
           Expr.quote {
             val _ = Expr.splice(avroVal)
             val _ = Expr.splice(configVal)
-            Expr.splice(fromCtx(DecoderCtx.from(avroVal, configVal, derivedType = None)))
+            Expr.splice(fromCtx(DecoderCtx.from(avroVal, configVal, derivedType = None, evaluatedConfig = evConfig)))
           }
         }
       }
@@ -56,6 +59,7 @@ trait DecoderMacrosImpl
     implicit val SchemaT: Type[Schema] = DecTypes.Schema
     implicit val ConfigT: Type[AvroConfig] = DecTypes.AvroConfig
     val selfType: Option[??] = Some(Type[A].as_??)
+    val evConfig: Option[AvroConfig] = configExpr.semiEval.toOption
 
     if (Type[A] =:= Type.of[Nothing].asInstanceOf[Type[A]] || Type[A] =:= Type.of[Any].asInstanceOf[Type[A]])
       Environment.reportErrorAndAbort(
@@ -103,7 +107,8 @@ trait DecoderMacrosImpl
                           Expr.quote(value),
                           Expr.quote(cfg),
                           derivedType = selfType,
-                          precomputedSchema = Some(Expr.quote(cachedSchema))
+                          precomputedSchema = Some(Expr.quote(cachedSchema)),
+                          evaluatedConfig = evConfig
                         )
                       )
                     }
@@ -226,7 +231,8 @@ trait DecoderMacrosImpl
       config: Expr[AvroConfig],
       cache: MLocal[ValDefsCache],
       derivedType: Option[??],
-      precomputedSchema: Option[Expr[org.apache.avro.Schema]] = None
+      precomputedSchema: Option[Expr[org.apache.avro.Schema]] = None,
+      evaluatedConfig: Option[AvroConfig] = None
   ) {
 
     def nest[B: Type](newValue: Expr[Any]): DecoderCtx[B] = copy[B](
@@ -316,14 +322,16 @@ trait DecoderMacrosImpl
         avroValue: Expr[Any],
         config: Expr[AvroConfig],
         derivedType: Option[??],
-        precomputedSchema: Option[Expr[org.apache.avro.Schema]] = None
+        precomputedSchema: Option[Expr[org.apache.avro.Schema]] = None,
+        evaluatedConfig: Option[AvroConfig] = None
     ): DecoderCtx[A] = DecoderCtx(
       tpe = Type[A],
       avroValue = avroValue,
       config = config,
       cache = ValDefsCache.mlocal,
       derivedType = derivedType,
-      precomputedSchema = precomputedSchema
+      precomputedSchema = precomputedSchema,
+      evaluatedConfig = evaluatedConfig
     )
   }
 

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -375,7 +375,7 @@ trait EncoderMacrosImpl
           AvroEncoderHandleAsValueTypeRule,
           AvroEncoderHandleAsOptionRule,
           AvroEncoderHandleAsEitherRule,
-          AvroEncoderHandleAsMapRule,
+          // Map handling is folded into the collection rule (single IsCollection parse, dispatched via `.asMap`).
           AvroEncoderHandleAsCollectionRule,
           AvroEncoderHandleAsNamedTupleRule,
           AvroEncoderHandleAsSingletonRule,

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -30,6 +30,9 @@ trait EncoderMacrosImpl
   def deriveInlineEncode[A: Type](valueExpr: Expr[A], configExpr: Expr[AvroConfig]): Expr[Any] = {
     implicit val AnyT: Type[Any] = EncTypes.Any
     implicit val ConfigT: Type[AvroConfig] = EncTypes.AvroConfig
+    // Evaluate the config at compile time when possible, so field-name mapping is a compile-time constant
+    // (no per-field `config.transformFieldNames(name)` call). Falls back to the runtime call when not evaluable.
+    val evConfig: Option[AvroConfig] = configExpr.semiEval.toOption
 
     deriveEncoderFromCtxAndAdaptForEntrypoint[A, Any]("AvroEncoder.encode") { fromCtx =>
       ValDefs.createVal[A](valueExpr).use { valueVal =>
@@ -38,7 +41,15 @@ trait EncoderMacrosImpl
             val _ = Expr.splice(valueVal)
             val _ = Expr.splice(configVal)
             Expr.splice(
-              fromCtx(EncoderCtx.from(valueVal, configVal, derivedType = None, outerConfig = Some(configVal)))
+              fromCtx(
+                EncoderCtx.from(
+                  valueVal,
+                  configVal,
+                  derivedType = None,
+                  outerConfig = Some(configVal),
+                  evaluatedConfig = evConfig
+                )
+              )
             )
           }
         }
@@ -53,6 +64,7 @@ trait EncoderMacrosImpl
     implicit val SchemaT: Type[Schema] = EncTypes.Schema
     implicit val ConfigT: Type[AvroConfig] = EncTypes.AvroConfig
     val selfType: Option[??] = Some(Type[A].as_??)
+    val evConfig: Option[AvroConfig] = configExpr.semiEval.toOption
 
     if (Type[A] =:= Type.of[Nothing].asInstanceOf[Type[A]] || Type[A] =:= Type.of[Any].asInstanceOf[Type[A]])
       Environment.reportErrorAndAbort(
@@ -99,7 +111,8 @@ trait EncoderMacrosImpl
                         config = c,
                         cache = cache,
                         derivedType = selfType,
-                        outerConfig = Some(outerConfigExpr)
+                        outerConfig = Some(outerConfigExpr),
+                        evaluatedConfig = evConfig
                       )
                     )
                   )
@@ -240,7 +253,8 @@ trait EncoderMacrosImpl
       cache: MLocal[ValDefsCache],
       derivedType: Option[??],
       precomputedSchema: Option[Expr[org.apache.avro.Schema]] = None,
-      outerConfig: Option[Expr[AvroConfig]] = None
+      outerConfig: Option[Expr[AvroConfig]] = None,
+      evaluatedConfig: Option[AvroConfig] = None
   ) {
 
     def schemaConfig: Expr[AvroConfig] = outerConfig.getOrElse(config)
@@ -320,7 +334,8 @@ trait EncoderMacrosImpl
         config: Expr[AvroConfig],
         derivedType: Option[??],
         precomputedSchema: Option[Expr[org.apache.avro.Schema]] = None,
-        outerConfig: Option[Expr[AvroConfig]] = None
+        outerConfig: Option[Expr[AvroConfig]] = None,
+        evaluatedConfig: Option[AvroConfig] = None
     ): EncoderCtx[A] = EncoderCtx(
       tpe = Type[A],
       value = value,
@@ -328,7 +343,8 @@ trait EncoderMacrosImpl
       cache = ValDefsCache.mlocal,
       derivedType = derivedType,
       precomputedSchema = precomputedSchema,
-      outerConfig = outerConfig
+      outerConfig = outerConfig,
+      evaluatedConfig = evaluatedConfig
     )
   }
 

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -278,7 +278,7 @@ trait SchemaForMacrosImpl
           AvroSchemaForHandleAsValueTypeRule,
           AvroSchemaForHandleAsOptionRule,
           AvroSchemaForHandleAsEitherRule,
-          AvroSchemaForHandleAsMapRule,
+          // Map handling is folded into the collection rule (single IsCollection parse, dispatched via `.asMap`).
           AvroSchemaForHandleAsCollectionRule,
           AvroSchemaForHandleAsNamedTupleRule,
           AvroSchemaForHandleAsSingletonRule,

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -49,12 +49,15 @@ trait SchemaForMacrosImpl
   def deriveInlineSchema[A: Type](configExpr: Expr[AvroConfig]): Expr[Schema] = {
     implicit val SchemaT: Type[Schema] = SfTypes.Schema
     implicit val ConfigT: Type[AvroConfig] = SfTypes.AvroConfig
+    // Evaluate the config at compile time when possible, so field-name mapping is a compile-time constant
+    // (no per-field `config.transformFieldNames(name)` call). Falls back to the runtime call when not evaluable.
+    val evConfig: Option[AvroConfig] = configExpr.semiEval.toOption
 
     deriveSchemaFromCtxAndAdaptForEntrypoint[A, Schema]("AvroSchemaFor.schemaOf") { fromCtx =>
       ValDefs.createVal[AvroConfig](configExpr).use { configVal =>
         Expr.quote {
           val _ = Expr.splice(configVal)
-          Expr.splice(fromCtx(SchemaForCtx.from[A](configVal, derivedType = None)))
+          Expr.splice(fromCtx(SchemaForCtx.from[A](configVal, derivedType = None, evaluatedConfig = evConfig)))
         }
       }
     }
@@ -66,6 +69,7 @@ trait SchemaForMacrosImpl
     implicit val SchemaT: Type[Schema] = SfTypes.Schema
     implicit val ConfigT: Type[AvroConfig] = SfTypes.AvroConfig
     val selfType: Option[??] = Some(Type[A].as_??)
+    val evConfig: Option[AvroConfig] = configExpr.semiEval.toOption
 
     deriveSchemaFromCtxAndAdaptForEntrypoint[A, AvroSchemaFor[A]]("AvroSchemaFor.derived") { fromCtx =>
       ValDefs.createVal[AvroConfig](configExpr).use { configVal =>
@@ -73,7 +77,7 @@ trait SchemaForMacrosImpl
           val cfg = Expr.splice(configVal)
           hearth.kindlings.avroderivation.internal.runtime.AvroDerivationFactories.schemaForInstance[A](
             Expr.splice {
-              fromCtx(SchemaForCtx.from[A](Expr.quote(cfg), derivedType = selfType))
+              fromCtx(SchemaForCtx.from[A](Expr.quote(cfg), derivedType = selfType, evaluatedConfig = evConfig))
             }
           )
         }
@@ -161,7 +165,8 @@ trait SchemaForMacrosImpl
       config: Expr[AvroConfig],
       cache: MLocal[ValDefsCache],
       derivedType: Option[??],
-      namespaceOverride: Option[String] = None
+      namespaceOverride: Option[String] = None,
+      evaluatedConfig: Option[AvroConfig] = None
   ) {
 
     def nest[B: Type]: SchemaForCtx[B] = copy[B](
@@ -215,12 +220,14 @@ trait SchemaForMacrosImpl
 
     def from[A: Type](
         config: Expr[AvroConfig],
-        derivedType: Option[??]
+        derivedType: Option[??],
+        evaluatedConfig: Option[AvroConfig] = None
     ): SchemaForCtx[A] = SchemaForCtx(
       tpe = Type[A],
       config = config,
       cache = ValDefsCache.mlocal,
-      derivedType = derivedType
+      derivedType = derivedType,
+      evaluatedConfig = evaluatedConfig
     )
   }
 
@@ -234,11 +241,13 @@ trait SchemaForMacrosImpl
 
   /** Derives a schema within a shared cache, for use by encoder/decoder derivation. */
   def deriveSchemaInSharedScope[B: Type](config: Expr[AvroConfig], cache: MLocal[ValDefsCache]): MIO[Expr[Schema]] = {
+    val evConfig: Option[AvroConfig] = config.semiEval.toOption
     implicit val ctx: SchemaForCtx[B] = SchemaForCtx(
       tpe = Type[B],
       config = config,
       cache = cache,
-      derivedType = None
+      derivedType = None,
+      evaluatedConfig = evConfig
     )
     deriveSchemaRecursively[B]
   }
@@ -247,8 +256,9 @@ trait SchemaForMacrosImpl
     * deriveInlineSchema when calling from within an encoder/decoder MIO chain to avoid Scala 3 splice isolation issues.
     */
   def deriveSelfContainedSchema[B: Type](config: Expr[AvroConfig]): MIO[Expr[Schema]] = {
+    val evConfig: Option[AvroConfig] = config.semiEval.toOption
     val localCache = ValDefsCache.mlocal
-    val ctx = SchemaForCtx[B](Type[B], config, localCache, derivedType = None)
+    val ctx = SchemaForCtx[B](Type[B], config, localCache, derivedType = None, evaluatedConfig = evConfig)
     for {
       _ <- ensureStandardExtensionsLoaded()
       result <- deriveSchemaRecursively[B](using ctx)

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCaseClassRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCaseClassRule.scala
@@ -108,7 +108,13 @@ trait AvroDecoderHandleAsCaseClassRuleImpl {
               val avroFieldNameExpr: Expr[String] = nameOverride match {
                 case Some(custom) => Expr(custom)
                 case None         =>
-                  Expr.quote(Expr.splice(dctx.config).transformFieldNames(Expr.splice(Expr(fName))))
+                  dctx.evaluatedConfig match {
+                    // Config statically known: map the field name at compile time to a constant string,
+                    // dropping the per-field runtime `config.transformFieldNames(name)` call.
+                    case Some(cfg) => Expr(cfg.transformFieldNames(fName))
+                    case None      =>
+                      Expr.quote(Expr.splice(dctx.config).transformFieldNames(Expr.splice(Expr(fName))))
+                  }
               }
               val aliases = getAllAnnotationStringArgs[avroAlias](param)
               val avroFixedSize = getAnnotationIntArg[avroFixed](param)

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCollectionRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCollectionRule.scala
@@ -9,86 +9,100 @@ import hearth.std.*
 trait AvroDecoderHandleAsCollectionRuleImpl {
   this: DecoderMacrosImpl & MacroCommons & StdExtensions & SchemaForMacrosImpl & AnnotationSupport =>
 
-  object AvroDecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection when possible") {
+  object AvroDecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection or map when possible") {
 
     @scala.annotation.nowarn("msg=is never used")
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of a separate map rule that re-parsed `IsCollection` for every non-map field.
             import isCollection.Underlying as Item
-            import isCollection.value.CtorResult
-            implicit val AnyT: Type[Any] = DecTypes.Any
-
-            LambdaBuilder
-              .of1[Any]("itemRaw")
-              .traverse { itemRawExpr =>
-                deriveDecoderRecursively[Item](using dctx.nest[Item](itemRawExpr))
-              }
-              .map { builder =>
-                val decodeFn = builder.build[Item]
-                val factoryExpr = isCollection.value.factory
-                val buildStep = isCollection.value.build
-
-                val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
-                  val collBuilder = Expr.splice(factoryExpr).newBuilder
-                  val decodeFnVal = Expr.splice(decodeFn)
-                  val rawCollection = Expr.splice(dctx.avroValue).asInstanceOf[java.util.Collection[Any]]
-                  val iter = rawCollection.iterator()
-                  while (iter.hasNext)
-                    collBuilder += decodeFnVal(iter.next())
-                  collBuilder
-                }
-                val buildResultExpr = buildStep.ctor(readLoop)
-
-                buildStep match {
-                  case _: CtorLikeOf.PlainValue[?, ?] =>
-                    Rule.matched(buildResultExpr.asInstanceOf[Expr[A]])
-
-                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(eitherExpr) match {
-                        case Right(value) => value
-                        case Left(err)    => throw new org.apache.avro.AvroRuntimeException(err)
-                      }
-                    })
-
-                  case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(eitherExpr) match {
-                        case Right(value) => value
-                        case Left(errs)   =>
-                          throw new org.apache.avro.AvroRuntimeException(errs.mkString("\n"))
-                      }
-                    })
-
-                  case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(eitherExpr) match {
-                        case Right(value) => value
-                        case Left(err)    =>
-                          throw new org.apache.avro.AvroRuntimeException(err.getMessage, err)
-                      }
-                    })
-
-                  case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(eitherExpr) match {
-                        case Right(value) => value
-                        case Left(errs)   =>
-                          throw new org.apache.avro.AvroRuntimeException(errs.map(_.getMessage).mkString("\n"))
-                      }
-                    })
-                }
-              }
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                AvroDecoderHandleAsMapRule.decodeMapEntries[A, Item](isMapOf)
+              case None =>
+                handleCollection[A, Item](isCollection.value)
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
+
+    @scala.annotation.nowarn("msg=is never used")
+    private def handleCollection[A: DecoderCtx, Item: Type](
+        isCollection: IsCollectionOf[A, Item]
+    ): MIO[Rule.Applicability[Expr[A]]] = {
+      import isCollection.CtorResult
+      implicit val AnyT: Type[Any] = DecTypes.Any
+
+      LambdaBuilder
+        .of1[Any]("itemRaw")
+        .traverse { itemRawExpr =>
+          deriveDecoderRecursively[Item](using dctx.nest[Item](itemRawExpr))
+        }
+        .map { builder =>
+          val decodeFn = builder.build[Item]
+          val factoryExpr = isCollection.factory
+          val buildStep = isCollection.build
+
+          val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
+            val collBuilder = Expr.splice(factoryExpr).newBuilder
+            val decodeFnVal = Expr.splice(decodeFn)
+            val rawCollection = Expr.splice(dctx.avroValue).asInstanceOf[java.util.Collection[Any]]
+            val iter = rawCollection.iterator()
+            while (iter.hasNext)
+              collBuilder += decodeFnVal(iter.next())
+            collBuilder
+          }
+          val buildResultExpr = buildStep.ctor(readLoop)
+
+          buildStep match {
+            case _: CtorLikeOf.PlainValue[?, ?] =>
+              Rule.matched(buildResultExpr.asInstanceOf[Expr[A]])
+
+            case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+              val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
+              Rule.matched(Expr.quote {
+                Expr.splice(eitherExpr) match {
+                  case Right(value) => value
+                  case Left(err)    => throw new org.apache.avro.AvroRuntimeException(err)
+                }
+              })
+
+            case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+              val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
+              Rule.matched(Expr.quote {
+                Expr.splice(eitherExpr) match {
+                  case Right(value) => value
+                  case Left(errs)   =>
+                    throw new org.apache.avro.AvroRuntimeException(errs.mkString("\n"))
+                }
+              })
+
+            case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+              val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
+              Rule.matched(Expr.quote {
+                Expr.splice(eitherExpr) match {
+                  case Right(value) => value
+                  case Left(err)    =>
+                    throw new org.apache.avro.AvroRuntimeException(err.getMessage, err)
+                }
+              })
+
+            case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+              val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+              Rule.matched(Expr.quote {
+                Expr.splice(eitherExpr) match {
+                  case Right(value) => value
+                  case Left(errs)   =>
+                    throw new org.apache.avro.AvroRuntimeException(errs.map(_.getMessage).mkString("\n"))
+                }
+              })
+          }
+        }
+    }
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsMapRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsMapRule.scala
@@ -24,8 +24,9 @@ trait AvroDecoderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def decodeMapEntries[A: DecoderCtx, Pair: Type](
+    private[rules] def decodeMapEntries[A: DecoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[A]]] = {
       import isMap.{Key, Value, CtorResult}

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsNamedTupleRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsNamedTupleRule.scala
@@ -73,12 +73,16 @@ trait AvroDecoderHandleAsNamedTupleRuleImpl {
               import param.tpe.Underlying as Field
               Log.namedScope(s"Deriving decoder for named tuple field $fName: ${Type[Field].prettyPrint}") {
                 deriveFieldDecoder[Field].map { decoderExpr =>
+                  // Map the field name at compile time when the config is statically known (no runtime
+                  // `config.transformFieldNames(name)` call); fall back to the runtime call otherwise.
+                  val fieldNameExpr: Expr[String] = dctx.evaluatedConfig match {
+                    case Some(cfg) => Expr(cfg.transformFieldNames(fName))
+                    case None      =>
+                      Expr.quote(Expr.splice(dctx.config).transformFieldNames(Expr.splice(Expr(fName))))
+                  }
                   val decodeExpr: Expr[Any] = Expr.quote {
                     val record = Expr.splice(dctx.avroValue).asInstanceOf[GenericRecord]
-                    val fieldValue = AvroDerivationUtils.decodeRecord(
-                      record,
-                      Expr.splice(dctx.config).transformFieldNames(Expr.splice(Expr(fName)))
-                    )
+                    val fieldValue = AvroDerivationUtils.decodeRecord(record, Expr.splice(fieldNameExpr))
                     Expr.splice(decoderExpr).decode(fieldValue): Any
                   }
                   val makeAccessor: Expr[Array[Any]] => (String, Expr_??) = { arrExpr =>

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsCollectionRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsCollectionRule.scala
@@ -8,18 +8,25 @@ import hearth.std.*
 trait AvroEncoderHandleAsCollectionRuleImpl {
   this: EncoderMacrosImpl & MacroCommons & StdExtensions & SchemaForMacrosImpl & AnnotationSupport =>
 
-  object AvroEncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection when possible") {
+  object AvroEncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection or map when possible") {
     implicit val AnyT: Type[Any] = EncTypes.Any
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Any]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of a separate map rule that re-parsed `IsCollection` for every non-map field.
             import isCollection.Underlying as Item
-            encodeCollectionInline[A, Item](isCollection.value)
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                AvroEncoderHandleAsMapRule.deriveMapEntries[A, Item](isMapOf)
+              case None =>
+                encodeCollectionInline[A, Item](isCollection.value)
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
 

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsMapRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsMapRule.scala
@@ -26,8 +26,9 @@ trait AvroEncoderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def deriveMapEntries[A: EncoderCtx, Pair: Type](
+    private[rules] def deriveMapEntries[A: EncoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Any]]] = {
       import isMap.{Key, Value}

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsNamedTupleRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderHandleAsNamedTupleRule.scala
@@ -67,9 +67,16 @@ trait AvroEncoderHandleAsNamedTupleRuleImpl {
               val fieldsListExpr = fieldPairs.toList.foldRight(
                 Expr.quote(List.empty[(String, Any)])
               ) { case ((fName, fieldEncoded), acc) =>
+                val fieldNameExpr: Expr[String] = ectx.evaluatedConfig match {
+                  // Config statically known: map the field name at compile time to a constant string,
+                  // dropping the per-field runtime `config.transformFieldNames(name)` call.
+                  case Some(cfg) => Expr(cfg.transformFieldNames(fName))
+                  case None      =>
+                    Expr.quote(Expr.splice(ectx.config).transformFieldNames(Expr.splice(Expr(fName))))
+                }
                 Expr.quote {
                   (
-                    Expr.splice(ectx.config).transformFieldNames(Expr.splice(Expr(fName))),
+                    Expr.splice(fieldNameExpr),
                     Expr.splice(fieldEncoded)
                   ) :: Expr.splice(acc)
                 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsCaseClassRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsCaseClassRule.scala
@@ -230,8 +230,14 @@ trait AvroSchemaForHandleAsCaseClassRuleImpl {
           val nameExpr: Expr[String] = nameOverride match {
             case Some(customName) => Expr(customName)
             case None             =>
-              Expr.quote {
-                Expr.splice(sfctx.config).transformFieldNames(Expr.splice(Expr(fName)))
+              sfctx.evaluatedConfig match {
+                // Config statically known: map the field name at compile time to a constant string,
+                // dropping the per-field runtime `config.transformFieldNames(name)` call.
+                case Some(cfg) => Expr(cfg.transformFieldNames(fName))
+                case None      =>
+                  Expr.quote {
+                    Expr.splice(sfctx.config).transformFieldNames(Expr.splice(Expr(fName)))
+                  }
               }
           }
           val baseFieldExpr: Expr[Schema.Field] = (fieldDoc, fieldDefault) match {

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsCollectionRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsCollectionRule.scala
@@ -10,22 +10,29 @@ import org.apache.avro.Schema
 trait AvroSchemaForHandleAsCollectionRuleImpl {
   this: SchemaForMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object AvroSchemaForHandleAsCollectionRule extends SchemaDerivationRule("handle as collection when possible") {
+  object AvroSchemaForHandleAsCollectionRule extends SchemaDerivationRule("handle as collection or map when possible") {
     implicit val SchemaT: Type[Schema] = SfTypes.Schema
 
     def apply[A: SchemaForCtx]: MIO[Rule.Applicability[Expr[Schema]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of a separate map rule that re-parsed `IsCollection` for every non-map field.
             import isCollection.Underlying as Item
-            for {
-              itemSchema <- deriveSchemaRecursively[Item](using sfctx.nest[Item])
-            } yield Rule.matched(Expr.quote {
-              Schema.createArray(Expr.splice(itemSchema))
-            })
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                AvroSchemaForHandleAsMapRule.deriveMapSchema[A, Item](isMapOf)
+              case None =>
+                for {
+                  itemSchema <- deriveSchemaRecursively[Item](using sfctx.nest[Item])
+                } yield Rule.matched(Expr.quote {
+                  Schema.createArray(Expr.splice(itemSchema))
+                })
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsMapRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsMapRule.scala
@@ -27,7 +27,8 @@ trait AvroSchemaForHandleAsMapRuleImpl {
         }
       }
 
-    private def deriveMapSchema[A: SchemaForCtx, Pair: Type](
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
+    private[rules] def deriveMapSchema[A: SchemaForCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Schema]]] = {
       import isMap.{Key, Value}

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsNamedTupleRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForHandleAsNamedTupleRule.scala
@@ -67,8 +67,14 @@ trait AvroSchemaForHandleAsNamedTupleRuleImpl {
               val javaFieldsExpr = fieldPairs.toList.foldRight(
                 Expr.quote(List.empty[Schema.Field])
               ) { case ((fName, fieldSchema), acc) =>
-                val nameExpr: Expr[String] = Expr.quote {
-                  Expr.splice(sfctx.config).transformFieldNames(Expr.splice(Expr(fName)))
+                val nameExpr: Expr[String] = sfctx.evaluatedConfig match {
+                  // Config statically known: map the field name at compile time to a constant string,
+                  // dropping the per-field runtime `config.transformFieldNames(name)` call.
+                  case Some(cfg) => Expr(cfg.transformFieldNames(fName))
+                  case None      =>
+                    Expr.quote {
+                      Expr.splice(sfctx.config).transformFieldNames(Expr.splice(Expr(fName)))
+                    }
                 }
                 val fieldExpr: Expr[Schema.Field] = Expr.quote {
                   AvroDerivationUtils.createField(

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/runtime/AvroDerivationUtils.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/runtime/AvroDerivationUtils.scala
@@ -312,11 +312,16 @@ object AvroDerivationUtils {
 
   def getFieldByNameOrAlias(record: GenericRecord, name: String, aliases: List[String]): Any = {
     val schema = record.getSchema
-    if (schema.getField(name) != null) return record.get(name)
+    // One hash lookup (`getField`) + position access via `field.pos()`, instead of `getField(name)` followed by
+    // `record.get(name)` — which internally repeats the `getField(name)` hash lookup. `field.pos()` is the field's
+    // position in the *record's own* schema, so this stays correct for schema-evolved/reordered records (the case
+    // that makes a compile-time constant index unsafe). Halves the per-field hash-lookup cost of the hot decode path.
+    val field = schema.getField(name)
+    if (field != null) return record.get(field.pos())
     var remaining = aliases
     while (remaining.nonEmpty) {
-      val alias = remaining.head
-      if (schema.getField(alias) != null) return record.get(alias)
+      val aliasField = schema.getField(remaining.head)
+      if (aliasField != null) return record.get(aliasField.pos())
       remaining = remaining.tail
     }
     null

--- a/benchmarks/src/main/scala/hearth/kindlings/benchmarks/TapirOpenApiJsoniterBenchmark.scala
+++ b/benchmarks/src/main/scala/hearth/kindlings/benchmarks/TapirOpenApiJsoniterBenchmark.scala
@@ -30,7 +30,7 @@ object KindlingsOpenApiInstances {
   import com.github.plokhotnyuk.jsoniter_scala.core.*
   import hearth.kindlings.tapiropenapijsoniter.OpenApiJsoniter
 
-  implicit private val codec: JsonValueCodec[OpenAPI] = OpenApiJsoniter.circe.openAPICodec
+  implicit private val codec: JsonValueCodec[OpenAPI] = OpenApiJsoniter.openapi_3_1.openAPICodec
 
   def encode(doc: OpenAPI): String = writeToString(doc)
   def decode(json: String): OpenAPI = readFromString[OpenAPI](json)

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.1-49-gbf894d6-SNAPSHOT"
+  val hearth = "0.3.1-51-g1482a96-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.1-51-g1482a96-SNAPSHOT"
+  val hearth = "0.3.1-52-g53acbc5-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.1-53-g5032722-SNAPSHOT"
+  val hearth = "0.3.1-53-g8ec996c-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val versions = new {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.1-52-g53acbc5-SNAPSHOT"
+  val hearth = "0.3.1-53-g5032722-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -14,6 +14,7 @@ import io.circe.{Decoder, DecodingFailure, HCursor, Json, KeyDecoder}
 trait DecoderMacrosImpl
     extends CirceDerivationTimeout
     with hearth.kindlings.derivation.compiletime.MethodFolds
+    with hearth.kindlings.derivation.compiletime.EitherFieldsConstruct
     with rules.DecoderUseCachedDefWhenAvailableRuleImpl
     with rules.DecoderUseImplicitWhenAvailableRuleImpl
     with rules.DecoderHandleAsLiteralTypeRuleImpl

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -406,7 +406,9 @@ trait DecoderMacrosImpl
           DecoderUseImplicitWhenAvailableRule,
           DecoderHandleAsValueTypeRule,
           DecoderHandleAsOptionRule,
-          DecoderHandleAsMapRule,
+          // DecoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone DecoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // decodeMapEntries / deriveKeyDecoder).
           DecoderHandleAsCollectionRule,
           DecoderHandleAsNamedTupleRule,
           DecoderHandleAsSingletonRule,

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -306,7 +306,9 @@ trait EncoderMacrosImpl
           EncoderUseImplicitWhenAvailableRule,
           EncoderHandleAsValueTypeRule,
           EncoderHandleAsOptionRule,
-          EncoderHandleAsMapRule,
+          // EncoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone EncoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // deriveMapEntries / deriveKeyEncoder).
           EncoderHandleAsCollectionRule,
           EncoderHandleAsNamedTupleRule,
           EncoderHandleAsSingletonRule,

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
@@ -412,7 +412,15 @@ trait DecoderHandleAsCaseClassRuleImpl {
                     }
                     (fName, typedExpr.as_??)
                   }
-                  (ffExpr, accExpr, makeAccessor)
+                  // Same cast as `makeAccessor`, but reading the already-bound `Right` value directly (used by the
+                  // zero-allocation fail-fast construction, which never builds the intermediate `Array[Any]`).
+                  val makeFieldArg: Expr[Any] => (String, Expr_??) = { valExpr =>
+                    val typedExpr = Expr.quote {
+                      CirceDerivationUtils.unsafeCast(Expr.splice(valExpr), Expr.splice(decoderExpr))
+                    }
+                    (fName, typedExpr.as_??)
+                  }
+                  (ffExpr, accExpr, makeAccessor, makeFieldArg)
                 }
               }
             }
@@ -420,12 +428,11 @@ trait DecoderHandleAsCaseClassRuleImpl {
               val ffExprs = fieldData.toList.map(_._1)
               val accExprs = fieldData.toList.map(_._2)
               val makeAccessors = fieldData.toList.map(_._3)
+              val makeFieldArgs = fieldData.toList.map(_._4)
 
-              // Step 2: Build List literals for both paths
-              val ffListExpr: Expr[List[Either[DecodingFailure, Any]]] =
-                ffExprs.foldRight(Expr.quote(List.empty[Either[DecodingFailure, Any]])) { (elem, acc) =>
-                  Expr.quote(Expr.splice(elem) :: Expr.splice(acc))
-                }
+              // The accumulating path still sequences a List of all field results (it must evaluate every field to
+              // collect all errors). The fail-fast path is built below as zero-allocation nested Either folds and
+              // needs no List.
               val accListExpr: Expr[List[ValidatedNel[DecodingFailure, Any]]] =
                 accExprs.foldRight(Expr.quote(List.empty[ValidatedNel[DecodingFailure, Any]])) { (elem, acc) =>
                   Expr.quote(Expr.splice(elem) :: Expr.splice(acc))
@@ -453,6 +460,29 @@ trait DecoderHandleAsCaseClassRuleImpl {
                 }
                 .map { builder =>
                   val constructLambda = builder.build[A]
+
+                  // Fail-fast construction: nested zero-closure `Either` folds (no List/Array/closure). Short-circuits
+                  // on the first Left and only decodes a field once all earlier fields have succeeded. The same final
+                  // value is produced as the accumulating path, but without the intermediate allocations.
+                  def constructFF(boundValues: List[Expr[Any]]): Expr[A] = {
+                    val fieldMap: Map[String, Expr_??] =
+                      makeFieldArgs.zip(boundValues).map { case (mk, v) => mk(v) }.toMap
+                    foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
+                      onTypes = _ => Map.empty,
+                      onValues = _ => fieldMap
+                    ) match {
+                      case Right(constructExpr) => constructExpr.value.asInstanceOf[Expr[A]]
+                      case Left(error)          =>
+                        Environment.reportErrorAndAbort(
+                          DecoderDerivationError
+                            .CannotConstructType(Type[A].prettyPrint, isSingleton = false, Some(error.toString))
+                            .message
+                        )
+                    }
+                  }
+                  val ffConstructed: Expr[Either[DecodingFailure, A]] =
+                    buildEitherFailFast[DecodingFailure, A](ffExprs)(constructFF)
+
                   val strictDecodingStaticallyFalse: Boolean =
                     dctx.evaluatedConfig.exists(!_.strictDecoding)
 
@@ -498,9 +528,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
                     // strictDecoding is statically false — skip the strict decoding check entirely
                     Expr.quote {
                       (if (Expr.splice(dctx.failFast)) {
-                         CirceDerivationUtils
-                           .sequenceDecodeResults(Expr.splice(ffListExpr))
-                           .map(Expr.splice(constructLambda))
+                         Expr.splice(ffConstructed)
                        } else {
                          CirceDerivationUtils
                            .sequenceDecodeResultsAccumulating(Expr.splice(accListExpr))
@@ -512,9 +540,7 @@ trait DecoderHandleAsCaseClassRuleImpl {
                       val config = Expr.splice(dctx.config)
                       (if (Expr.splice(dctx.failFast)) {
                          // --- Fail-fast path ---
-                         val decoded = CirceDerivationUtils
-                           .sequenceDecodeResults(Expr.splice(ffListExpr))
-                           .map(Expr.splice(constructLambda))
+                         val decoded = Expr.splice(ffConstructed)
                          if (config.strictDecoding) {
                            val expectedFields = Expr.splice(
                              resolvedFieldNames.getOrElse(

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
@@ -12,129 +12,137 @@ import io.circe.{DecodingFailure, HCursor}
 trait DecoderHandleAsCollectionRuleImpl {
   this: DecoderMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection when possible") {
+  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection or map when possible") {
 
     @scala.annotation.nowarn("msg=is never used")
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[Either[DecodingFailure, A]]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            import isCollection.value.CtorResult
-            implicit val HCursorT: Type[HCursor] = DTypes.HCursor
-            implicit val EitherDFItem: Type[Either[DecodingFailure, Item]] = DTypes.DecoderResult[Item]
-            implicit val EitherDFA: Type[Either[DecodingFailure, A]] = DTypes.DecoderResult[A]
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                DecoderHandleAsMapRule.decodeMapEntries[A, Item](isMapOf)
+              case None =>
+                import isCollection.value.CtorResult
+                implicit val HCursorT: Type[HCursor] = DTypes.HCursor
+                implicit val EitherDFItem: Type[Either[DecodingFailure, Item]] = DTypes.DecoderResult[Item]
+                implicit val EitherDFA: Type[Either[DecodingFailure, A]] = DTypes.DecoderResult[A]
 
-            LambdaBuilder
-              .of1[HCursor]("itemCursor")
-              .traverse { itemCursorExpr =>
-                deriveDecoderRecursively[Item](using dctx.nest[Item](itemCursorExpr))
-              }
-              .map { builder =>
-                val decodeFn = builder.build[Either[DecodingFailure, Item]]
-                val factoryExpr = isCollection.value.factory
-                val buildStep = isCollection.value.build
-
-                val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
-                  val cursor = Expr.splice(dctx.cursor)
-                  val decoder = CirceDerivationUtils.decoderFromFn(Expr.splice(decodeFn))
-                  val collBuilder = Expr.splice(factoryExpr).newBuilder
-                  cursor.values match {
-                    case None =>
-                      throw new CirceDerivationUtils.CollectionBuildException(
-                        DecodingFailure("Expected JSON array", cursor.history)
-                      )
-                    case Some(jsonValues) =>
-                      val iter = jsonValues.iterator
-                      while (iter.hasNext)
-                        decoder.decodeJson(iter.next()) match {
-                          case Right(item) => collBuilder += item
-                          case Left(err)   => throw new CirceDerivationUtils.CollectionBuildException(err)
-                        }
+                LambdaBuilder
+                  .of1[HCursor]("itemCursor")
+                  .traverse { itemCursorExpr =>
+                    deriveDecoderRecursively[Item](using dctx.nest[Item](itemCursorExpr))
                   }
-                  collBuilder
-                }
-                val buildResultExpr = buildStep.ctor(readLoop)
+                  .map { builder =>
+                    val decodeFn = builder.build[Either[DecodingFailure, Item]]
+                    val factoryExpr = isCollection.value.factory
+                    val buildStep = isCollection.value.build
 
-                buildStep match {
-                  case _: CtorLikeOf.PlainValue[?, ?] =>
-                    Rule.matched(Expr.quote {
-                      try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
-                      catch {
-                        case e: CirceDerivationUtils.CollectionBuildException =>
-                          Left(e.failure)
+                    val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
+                      val cursor = Expr.splice(dctx.cursor)
+                      val decoder = CirceDerivationUtils.decoderFromFn(Expr.splice(decodeFn))
+                      val collBuilder = Expr.splice(factoryExpr).newBuilder
+                      cursor.values match {
+                        case None =>
+                          throw new CirceDerivationUtils.CollectionBuildException(
+                            DecodingFailure("Expected JSON array", cursor.history)
+                          )
+                        case Some(jsonValues) =>
+                          val iter = jsonValues.iterator
+                          while (iter.hasNext)
+                            decoder.decodeJson(iter.next()) match {
+                              case Right(item) => collBuilder += item
+                              case Left(err)   => throw new CirceDerivationUtils.CollectionBuildException(err)
+                            }
                       }
-                    })
+                      collBuilder
+                    }
+                    val buildResultExpr = buildStep.ctor(readLoop)
 
-                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    =>
-                            Left(DecodingFailure(err, Expr.splice(dctx.cursor).history))
-                        }
-                      catch {
-                        case e: CirceDerivationUtils.CollectionBuildException =>
-                          Left(e.failure)
-                      }
-                    })
+                    buildStep match {
+                      case _: CtorLikeOf.PlainValue[?, ?] =>
+                        Rule.matched(Expr.quote {
+                          try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
+                          catch {
+                            case e: CirceDerivationUtils.CollectionBuildException =>
+                              Left(e.failure)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(DecodingFailure(errs.mkString("\n"), Expr.splice(dctx.cursor).history))
-                        }
-                      catch {
-                        case e: CirceDerivationUtils.CollectionBuildException =>
-                          Left(e.failure)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    =>
+                                Left(DecodingFailure(err, Expr.splice(dctx.cursor).history))
+                            }
+                          catch {
+                            case e: CirceDerivationUtils.CollectionBuildException =>
+                              Left(e.failure)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    =>
-                            Left(DecodingFailure(err.getMessage, Expr.splice(dctx.cursor).history))
-                        }
-                      catch {
-                        case e: CirceDerivationUtils.CollectionBuildException =>
-                          Left(e.failure)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(DecodingFailure(errs.mkString("\n"), Expr.splice(dctx.cursor).history))
+                            }
+                          catch {
+                            case e: CirceDerivationUtils.CollectionBuildException =>
+                              Left(e.failure)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(
-                              DecodingFailure(
-                                errs.map(_.getMessage).mkString("\n"),
-                                Expr.splice(dctx.cursor).history
-                              )
-                            )
-                        }
-                      catch {
-                        case e: CirceDerivationUtils.CollectionBuildException =>
-                          Left(e.failure)
-                      }
-                    })
-                }
-              }
+                      case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    =>
+                                Left(DecodingFailure(err.getMessage, Expr.splice(dctx.cursor).history))
+                            }
+                          catch {
+                            case e: CirceDerivationUtils.CollectionBuildException =>
+                              Left(e.failure)
+                          }
+                        })
+
+                      case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(
+                                  DecodingFailure(
+                                    errs.map(_.getMessage).mkString("\n"),
+                                    Expr.splice(dctx.cursor).history
+                                  )
+                                )
+                            }
+                          catch {
+                            case e: CirceDerivationUtils.CollectionBuildException =>
+                              Left(e.failure)
+                          }
+                        })
+                    }
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
@@ -28,8 +28,9 @@ trait DecoderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def decodeMapEntries[A: DecoderCtx, Pair: Type](
+    private[rules] def decodeMapEntries[A: DecoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Either[DecodingFailure, A]]]] = {
       import isMap.{Key, Value, CtorResult}

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
@@ -12,32 +12,40 @@ import io.circe.Json
 trait EncoderHandleAsCollectionRuleImpl {
   this: EncoderMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection when possible") {
+  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection or map when possible") {
     implicit val JsonT: Type[Json] = Types.Json
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Json]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            LambdaBuilder
-              .of1[Item]("item")
-              .traverse { itemExpr =>
-                deriveEncoderRecursively[Item](using ectx.nest(itemExpr))
-              }
-              .map { builder =>
-                val lambda = builder.build[Json]
-                val iterableExpr = isCollection.value.asIterable(ectx.value)
-                Rule.matched(Expr.quote {
-                  CirceDerivationUtils.encodeIterable[Item](
-                    Expr.splice(iterableExpr),
-                    Expr.splice(lambda)
-                  )
-                })
-              }
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                EncoderHandleAsMapRule.deriveMapEntries[A, Item](isMapOf)
+              case None =>
+                LambdaBuilder
+                  .of1[Item]("item")
+                  .traverse { itemExpr =>
+                    deriveEncoderRecursively[Item](using ectx.nest(itemExpr))
+                  }
+                  .map { builder =>
+                    val lambda = builder.build[Json]
+                    val iterableExpr = isCollection.value.asIterable(ectx.value)
+                    Rule.matched(Expr.quote {
+                      CirceDerivationUtils.encodeIterable[Item](
+                        Expr.splice(iterableExpr),
+                        Expr.splice(lambda)
+                      )
+                    })
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
@@ -30,7 +30,8 @@ trait EncoderHandleAsMapRuleImpl {
         }
       }
 
-    private def deriveMapEntries[A: EncoderCtx, Pair: Type](
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
+    private[rules] def deriveMapEntries[A: EncoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Json]]] = {
       import isMap.{Key, Value}

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/EitherFieldsConstruct.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/EitherFieldsConstruct.scala
@@ -66,10 +66,17 @@ trait EitherFieldsConstruct { this: MacroCommons & StdExtensions =>
         case Nil =>
           resultEither.right(construct(boundReversed.reverse))
         case result :: rest =>
-          fieldEither.fold[Either[E, A]](result)(
-            onLeft = (e: Expr[E]) => resultEither.left(e),
-            onRight = (value: Expr[Any]) => loop(rest, value :: boundReversed)
-          )
+          // Bind each field result to a local `val` before folding. This is both the "decode into a val" shape and a
+          // tree-hygiene necessity: matching directly on a field-decode expression that contains its own definitions
+          // (e.g. a nested case-class field whose decoder uses a `flatMap` lambda) trips Scala 3's "Block contains
+          // definitions with different owners". The `val` keeps the scrutinee a clean reference. The val is only
+          // reached once all earlier fields succeeded, so short-circuiting is preserved.
+          ValDefs.createVal[Either[E, Any]](result).use { boundResult =>
+            fieldEither.fold[Either[E, A]](boundResult)(
+              onLeft = (e: Expr[E]) => resultEither.left(e),
+              onRight = (value: Expr[Any]) => loop(rest, value :: boundReversed)
+            )
+          }
       }
 
     loop(fieldResults, Nil)

--- a/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/EitherFieldsConstruct.scala
+++ b/derivation-commons/src/main/scala/hearth/kindlings/derivation/compiletime/EitherFieldsConstruct.scala
@@ -1,0 +1,77 @@
+package hearth.kindlings.derivation.compiletime
+
+import hearth.MacroCommons
+import hearth.std.*
+
+/** Reusable zero-allocation construction of a value from N field-decode results typed as `Either[E, _]`.
+  *
+  * The naive way to combine N `Either` field results into a constructor is to put them in a `List`, `sequence` it into
+  * an `Either[E, Array[Any]]`, then `map` a constructor over the array. That allocates a `List` (N cons cells), an
+  * `Array[Any]`, and a closure on every decode — pure overhead on the hot path.
+  *
+  * [[buildEitherFailFast]] replaces that with nested [[IsEitherOf.fold]] calls. On Hearth's zero-closure `fold` (a
+  * `match`, not `Either.fold(closure, closure)`) this lowers to a straight-line short-circuit with no intermediate
+  * `List`/`Array`/closure:
+  * {{{
+  *   r0 match {
+  *     case Right(v0) => r1 match {
+  *       case Right(v1) => ... => Right(construct(v0, v1, ...))
+  *       case Left(e)   => Left(e)
+  *     }
+  *     case Left(e) => Left(e)
+  *   }
+  * }}}
+  * It also short-circuits decoding itself: a field is only decoded if all earlier fields succeeded.
+  *
+  * The construction goes through Hearth's `IsEither` std extension so the same code works for any `Either`-like error
+  * type (circe's `DecodingFailure`, yaml's `ConstructError`, pureconfig's `ConfigReaderFailures`, …). Requires the
+  * standard Scala-`Either` extension to be loaded (every derivation entry point loads it via
+  * [[LoadStandardExtensionsOnce]]).
+  */
+trait EitherFieldsConstruct { this: MacroCommons & StdExtensions =>
+
+  /** Combine per-field `Either[E, Any]` results into `Either[E, A]`, fail-fast (short-circuit on the first `Left`).
+    *
+    * @param fieldResults
+    *   the per-field decode results in constructor-argument order; values are boxed to `Any` (the caller casts them
+    *   back to the field type inside `construct`)
+    * @param construct
+    *   given the successfully-decoded `Right` values (in the same order), build the final `Expr[A]`
+    */
+  protected def buildEitherFailFast[E: Type, A: Type](
+      fieldResults: List[Expr[Either[E, Any]]]
+  )(construct: List[Expr[Any]] => Expr[A]): Expr[Either[E, A]] = {
+    val EitherCtor = Type.Ctor2.of[Either]
+    implicit val AnyT: Type[Any] = Type.of[Any]
+    implicit val EitherEA: Type[Either[E, A]] = EitherCtor[E, A]
+    implicit val EitherEAny: Type[Either[E, Any]] = EitherCtor[E, Any]
+
+    def isEitherOf[L: Type, R: Type](implicit ET: Type[Either[L, R]]): IsEitherOf[Either[L, R], L, R] =
+      IsEither.unapply(ET) match {
+        case Some(isE) =>
+          // The existential LeftValue/RightValue of the parsed instance are exactly L/R (we asked for Either[L, R]);
+          // the cast just re-exposes them so `fold`/`left`/`right` line up with our `Expr[L]`/`Expr[R]`.
+          isE.value.asInstanceOf[IsEitherOf[Either[L, R], L, R]]
+        case None =>
+          Environment.reportErrorAndAbort(
+            s"EitherFieldsConstruct: ${ET.prettyPrint} is not recognized as Either (is the Scala Either std extension loaded?)"
+          )
+      }
+
+    val resultEither = isEitherOf[E, A]
+    val fieldEither = isEitherOf[E, Any]
+
+    def loop(remaining: List[Expr[Either[E, Any]]], boundReversed: List[Expr[Any]]): Expr[Either[E, A]] =
+      remaining match {
+        case Nil =>
+          resultEither.right(construct(boundReversed.reverse))
+        case result :: rest =>
+          fieldEither.fold[Either[E, A]](result)(
+            onLeft = (e: Expr[E]) => resultEither.left(e),
+            onRight = (value: Expr[Any]) => loop(rest, value :: boundReversed)
+          )
+      }
+
+    loop(fieldResults, Nil)
+  }
+}

--- a/docs/contributing/kindlings-jfr-profiling/SKILL.md
+++ b/docs/contributing/kindlings-jfr-profiling/SKILL.md
@@ -1,0 +1,177 @@
+---
+name: kindlings-jfr-profiling
+description: >
+  Profile JMH benchmarks with JFR: statistical execution sampling (any JDK) and deterministic
+  method timing/tracing (JDK 25+, JEP 520) to measure exact invocation counts and timing of
+  macro-generated codec/encoder/decoder methods. Covers exact sbt/JMH commands, targeting
+  generated methods, reading results, and the JDK gating.
+paths:
+  - "benchmarks/**"
+  - "docs/research/**"
+user-invocable: false
+---
+
+# JFR profiling of Kindlings benchmarks
+
+Two complementary techniques, both driven through the existing JMH harness:
+
+1. **Execution sampling** (`jdk.ExecutionSample`) — statistical, low constant overhead (<2%),
+   works on **any JDK**. Answers *"where does time go?"*. This is what we already use.
+2. **Method timing / tracing** (`jdk.MethodTiming` / `jdk.MethodTrace`, **JEP 520, JDK 25+**) —
+   deterministic bytecode instrumentation giving **exact** per-method invocation counts and
+   min/avg/max execution time. Answers *"how many times, how long, exactly?"* for a **known**
+   hot method.
+
+> **Do not confuse with Hearth's MIO flame graphs.** The `.speedscope.json` files produced by
+> `-Xmacro-settings:hearth.mioBenchmarkFlameGraphDir=...` profile **compile-time** macro
+> expansion. This skill is about **runtime** profiling of the generated code. Different tool,
+> different phase.
+
+## JDK gating — check first
+
+JEP 520 events require **JDK 25+** and are standard GA JFR events (not experimental, no unlock
+flag). Verify both the JDK and that the events exist in this VM:
+
+```bash
+java -version                              # need 25+
+jfr metadata | grep -E 'MethodTiming|MethodTrace'   # both must be listed
+```
+
+- **Dev machine** currently runs GraalVM CE 25 → method timing available.
+- **CI / Temurin 17** → events absent; fall back to **sampling** (§ Sampling recipe). Everything
+  in the sampling section works on 17.
+
+If `jfr metadata` does not list the events, you are on a pre-25 JDK — use sampling only.
+
+## Decision rule
+
+| Goal | Technique | Why |
+|------|-----------|-----|
+| Broad "where is time spent" across a codec | **Sampling** | Any JDK, cheap, gives the call tree |
+| Exact invocation count + timing of a *specific* hot method | **Method timing** | Aggregated, deterministic, overhead scales with call volume |
+| Capture individual calls of a *low-frequency* method (+ stacks) | **Method tracing** | One event per call — **floods** on hot loops; only for rare methods |
+
+Tracing a method called millions of times/sec overwhelms JFR buffers — use **timing**
+(aggregated) for hot codec methods, **tracing** only for setup/rare paths.
+
+## Sampling recipe (baseline — current workflow, any JDK)
+
+JMH's `-prof jfr` starts/stops the recording around the **measurement** phase only (warmup
+excluded by design) and writes **one `profile.jfr` per fork**.
+
+```bash
+sbt --client 'benchmarks3/Jmh/run -f 1 -wi 5 -i 10 \
+  -prof "jfr:dir=/tmp/kindlings-jfr;configName=profile;debugNonSafePoints=true;stackDepth=256" \
+  ".*JsoniterWriteBenchmark.kindlingsSemiAutoPerson"'
+```
+
+- Use **`-f 1`**: with `-f 2`, both forks write the *same* `profile.jfr` path and the second
+  overwrites the first. For production numbers run `-f 2` *without* the profiler, and a separate
+  `-f 1` *with* it.
+- `configName=profile` (higher detail) vs `default` (lighter). `debugNonSafePoints=true` improves
+  attribution accuracy.
+- Output: `/tmp/kindlings-jfr/<benchmark-id>/profile.jfr`.
+
+## Method timing / tracing recipe (JDK 25+)
+
+### Step 1 — custom `.jfc` naming the methods to instrument
+
+JMH forwards `configName=<path>` to `JFR.start settings=`, so point it at a custom config.
+Filter grammar (JEP 520): `Class::method` (one method), `Class` (all methods of a class),
+`::method` (that name across all classes), `@annotation.Class`; targets separated by `;`.
+**No wildcards.** Overloads cannot be disambiguated (all same-named methods match).
+
+`benchmarks/method-timing.jfc`:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration version="2.0" label="Kindlings method timing">
+  <event name="jdk.MethodTiming">
+    <setting name="enabled">true</setting>
+    <setting name="period">1 s</setting>
+    <!-- replace with the discovered generated-codec class (see Step 0) -->
+    <setting name="filter">hearth.kindlings.benchmarks.KindlingsJsoniterInstances$$anon$1::encodeValue</setting>
+  </event>
+  <event name="jdk.MethodTrace">
+    <setting name="enabled">true</setting>
+    <setting name="stackTrace">true</setting>
+    <setting name="threshold">0 ns</setting>
+    <setting name="filter">hearth.kindlings.benchmarks.BenchmarkData$::person</setting>
+  </event>
+</configuration>
+```
+
+### Step 0 — discover the generated-codec method names
+
+Generated codecs are **synthetic classes** (anonymous `JsonValueCodec`s or factory lambdas), so
+their FQCNs are not in the source. Find them before writing the filter:
+
+```bash
+# Run a sampling pass first, then list the hottest methods (their real FQCNs):
+jfr view hot-methods /tmp/kindlings-jfr/*/profile.jfr
+# or dump generated bytecode classes during a benchmark JVM and grep:
+#   -Djdk.attach... not needed; add -Xprint or scalac -Xprint:jvm at derivation site,
+#   or javap the benchmark classes:
+javap -p -classpath benchmarks/target/jvm-3/classes 'hearth.kindlings.benchmarks.KindlingsJsoniterInstances$'
+```
+
+The hot-methods view names the exact synthetic class (`...$$anon$N`) and method
+(`encodeValue` / `decodeValue` / `nullValue`). Copy that FQCN into the `.jfc` filter.
+
+### Step 2 — run JMH with the custom config
+
+```bash
+sbt --client 'benchmarks3/Jmh/run -f 1 -wi 5 -i 10 \
+  -prof "jfr:dir=/tmp/kindlings-jfr;configName=/abs/path/benchmarks/method-timing.jfc;stackDepth=64;verbose=true" \
+  ".*JsoniterWriteBenchmark.kindlingsSemiAutoPerson"'
+```
+
+## Reading results
+
+```bash
+jfr view method-timing  /tmp/kindlings-jfr/*/profile.jfr   # exact counts + min/avg/max per method
+jfr view hot-methods    /tmp/kindlings-jfr/*/profile.jfr   # sampling call tree
+jfr print --events jdk.MethodTiming                 /tmp/kindlings-jfr/*/profile.jfr
+jfr print --events jdk.MethodTrace --stack-depth 32 /tmp/kindlings-jfr/*/profile.jfr
+jfr view all-views      /tmp/kindlings-jfr/*/profile.jfr   # discover every built-in view
+```
+
+Flamegraph (async-profiler's `jfrconv`, replaces `jfr2flame`):
+
+```bash
+jfrconv --cpu /tmp/kindlings-jfr/*/profile.jfr flame.html
+jfrconv -o collapsed /tmp/kindlings-jfr/*/profile.jfr folded.txt   # then import into speedscope.app
+```
+
+JDK Mission Control (JMC 8+) also has a Method Profiling page and a Flame Graph view.
+
+## Caveats
+
+- **Inlining distorts both.** Instrumenting a method can *prevent* the JIT from inlining it
+  (slowing the very thing you measure); in *sampling*, inlined callees vanish into the caller's
+  frame. Cross-check a method-timing result against the sampling call tree before trusting it.
+- **Flooding.** `MethodTrace` on a tight loop overwhelms JFR — use `MethodTiming` for hot paths.
+- **Steady state.** Early samples reflect interpreted/C1 code; JMH's profiler already excludes
+  warmup, so keep `-wi 5` or higher.
+- **Recursion hazard.** Never filter JDK-internal methods that the instrumentation itself uses —
+  it can recurse infinitely. Keep filters to our own packages.
+- **What timing cannot see.** Native/abstract methods, arguments, return values, or time *within*
+  a method body (only entry→exit).
+- **Per-fork overwrite.** `-f >1` with the profiler overwrites `profile.jfr`. Profile with
+  `-f 1`; benchmark for numbers with `-f 2` and no profiler.
+
+## Methodology (non-negotiable — see `feedback_benchmark_methodology.md`)
+
+- Never reduce iterations or skip JFR to "save time" when investigating a perf gap.
+- One JFR recording **per benchmark method** (separate `dir`/run), not a bulk run.
+- Triangulate: **generated code** (`-Xprint:jvm` / Hearth derivation logging) + **bytecode**
+  (`javap -c -p`, grep `boxTo`/`unboxTo`/`BoxesRunTime`) + **JFR profile**. A claim that a gap is
+  closed needs all three plus a full `-f 2 -wi 5 -i 10` confirmation run.
+
+## Related
+
+- `docs/contributing/kindlings-runtime-perf/SKILL.md` — the optimizations you apply *after*
+  profiling points at a hot spot.
+- `docs/research/perf-regression-analysis.md` — worked examples of JFR + bytecode + generated-code
+  triangulation across rounds of optimization.
+- `docs/research/benchmark-results.md` — the canonical results table to update after a sweep.

--- a/docs/research/benchmark-results.md
+++ b/docs/research/benchmark-results.md
@@ -1,10 +1,9 @@
 # Kindlings Benchmark Results
 
 > **Configuration**: 2 forks, 5 warmup iterations, 10 measurement iterations, 1s each
-> **Platform**: macOS (Apple M4 Pro), JVM (temurin 17)
-> **Scala versions**: 2.13.18, 3.8.4
-> **Measured on**: master @ e0534fe (Hearth 0.3.1), 2026-06-10 — raw JMH JSON in [benchmark-runs/2026-06-10-master](benchmark-runs/2026-06-10-master/).
-> Jsoniter Write/Read (SimpleCC, Person, Event), Cats Eq, Avro (SimpleCC, Person), and Circe booster Encode (Person, Event) numbers come from a follow-up 5-fork re-run (`rerun-*.json`) that replaced unstable 2-fork results.
+> **Scala versions**: 2.13.18, 3.8.3
+> **Measured on**: branch benchmarks-and-docs (Hearth 0.3.1-53-g5032722), 2026-06-17 — raw JMH JSON in [benchmark-runs/2026-06-17-master](benchmark-runs/2026-06-17-master/).
+> **Caveat**: run on a shared dev machine under concurrent load (~2h/version); the kindlings/original *ratios* are robust but absolute ops/s are approximate. A few *original-auto* measurements were noisy-high (avro4s auto decode SimpleCC; some cats auto), which understates those ratios.
 
 All values in ops/s (higher is better). Error margins omitted for readability.
 
@@ -12,27 +11,27 @@ All values in ops/s (higher is better). Error margins omitted for readability.
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
 |------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 30.8M | 30.9M | 20.9M | 20.9M | **1.5x faster** |
-| SimpleCC | 3 | 33.8M | 38.5M | 17.6M | 17.6M | **2.2x faster** |
-| SimpleADT | 2.13 | 32.1M | 28.7M | 14.8M | 18.4M | **1.7x faster** |
-| SimpleADT | 3 | 31.3M | 31.2M | 25.5M | 25.6M | **1.2x faster** |
-| Person | 2.13 | 3.8M | 3.7M | 2.6M | 2.9M | **1.3x faster** |
-| Person | 3 | 3.8M | 3.4M | 2.4M | 2.1M | **1.6x faster** |
-| Event | 2.13 | 3.1M | 3.1M | 2.3M | 2.4M | **1.3x faster** |
-| Event | 3 | 3.1M | 3.1M | 2.0M | 2.0M | **1.5x faster** |
+| SimpleCC | 2.13 | 30.3M | 30.9M | 18.8M | 19.0M | **1.63x faster** |
+| SimpleCC | 3 | 31.2M | 31.2M | 21.8M | 20.9M | **1.43x faster** |
+| SimpleADT | 2.13 | 27.5M | 27.1M | 13.4M | 13.9M | **1.99x faster** |
+| SimpleADT | 3 | 26.8M | 25.7M | 26.6M | 27.1M | **0.99x faster** |
+| Person | 2.13 | 4.5M | 4.5M | 3.0M | 3.1M | **1.46x faster** |
+| Person | 3 | 4.4M | 4.5M | 3.1M | 3.2M | **1.41x faster** |
+| Event | 2.13 | 3.4M | 3.4M | 2.3M | 2.4M | **1.45x faster** |
+| Event | 3 | 3.3M | 3.4M | 2.4M | 2.3M | **1.42x faster** |
 
 ## Circe Decode
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
 |------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 46.1M | 46.3M | 38.5M | 38.8M | **1.2x faster** |
-| SimpleCC | 3 | 40.6M | 41.3M | 18.3M | 17.9M | **2.3x faster** |
-| SimpleADT | 2.13 | 38.8M | 39.1M | 30.2M | 30.2M | **1.3x faster** |
-| SimpleADT | 3 | 39.5M | 41.6M | 25.7M | 25.1M | **1.6x faster** |
-| Person | 2.13 | 3.1M | 3.2M | 2.3M | 2.5M | **1.3x faster** |
-| Person | 3 | 3.1M | 3.1M | 2.4M | 2.5M | **1.3x faster** |
-| Event | 2.13 | 2.5M | 2.5M | 2.2M | 2.1M | **1.2x faster** |
-| Event | 3 | 2.5M | 2.6M | 2.0M | 1.9M | **1.3x faster** |
+| SimpleCC | 2.13 | 88.3M | 93.2M | 42.0M | 42.6M | **2.19x faster** |
+| SimpleCC | 3 | 91.9M | 92.1M | 20.5M | 21.2M | **4.34x faster** |
+| SimpleADT | 2.13 | 56.3M | 55.9M | 25.0M | 25.7M | **2.19x faster** |
+| SimpleADT | 3 | 58.3M | 54.6M | 27.9M | 28.0M | **2.08x faster** |
+| Person | 2.13 | 5.4M | 5.3M | 3.5M | 3.6M | **1.49x faster** |
+| Person | 3 | 5.5M | 5.4M | 2.7M | 2.6M | **2.05x faster** |
+| Event | 2.13 | 3.3M | 3.5M | 2.7M | 2.7M | **1.27x faster** |
+| Event | 3 | 3.5M | 3.3M | 2.1M | 2.2M | **1.58x faster** |
 
 ## Circe End-to-End with jsoniter-scala-circe Booster
 
@@ -42,208 +41,251 @@ Full pipeline benchmarks: domain type ↔ bytes/String, comparing Circe's defaul
 
 | Type | Scala | Kindlings + booster | Original + booster | Kindlings (no booster) | Original (no booster) |
 |------|-------|--------------------|--------------------|----------------------|---------------------|
-| SimpleCC | 2.13 | **8.3M** | 7.3M | 7.2M | 6.7M |
-| SimpleCC | 3 | **12.1M** | 7.6M | 8.0M | 6.6M |
-| SimpleADT | 2.13 | **13.2M** | 7.1M | 7.6M | 6.4M |
-| SimpleADT | 3 | **9.7M** | 8.8M | 7.3M | 7.4M |
-| Person | 2.13 | **1.5M** | 1.4M | 922.5K | 845.8K |
-| Person | 3 | **1.6M** | 1.4M | 1.0M | 917.5K |
-| Event | 2.13 | **1.3M** | 1.1M | 795.0K | 714.9K |
-| Event | 3 | **1.3M** | 1.1M | 872.2K | 768.4K |
+| SimpleCC | 2.13 | **13.9M** | 10.5M | 6.8M | 5.4M |
+| SimpleCC | 3 | **15.5M** | 12.0M | 7.2M | 6.7M |
+| SimpleADT | 2.13 | **14.3M** | 8.1M | 7.8M | 5.9M |
+| SimpleADT | 3 | **15.6M** | 11.7M | 8.1M | 6.9M |
+| Person | 2.13 | **1.6M** | 1.4M | 985.0K | 882.0K |
+| Person | 3 | **1.7M** | 1.5M | 1.1M | 964.0K |
+| Event | 2.13 | **1.3M** | 1.1M | 831.0K | 764.0K |
+| Event | 3 | **1.4M** | 1.2M | 939.0K | 805.0K |
 
 ### Decode (bytes/String → domain type)
 
 | Type | Scala | Kindlings + booster | Original + booster | Kindlings (no booster) | Original (no booster) |
 |------|-------|--------------------|--------------------|----------------------|---------------------|
-| SimpleCC | 2.13 | **8.0M** | 6.8M | 7.5M | 6.8M |
-| SimpleCC | 3 | **9.6M** | 6.2M | 7.3M | 5.1M |
-| SimpleADT | 2.13 | **9.0M** | 8.8M | 7.2M | 7.2M |
-| SimpleADT | 3 | **10.7M** | 8.9M | 9.3M | 7.3M |
-| Person | 2.13 | **957.0K** | 799.3K | 695.8K | 521.2K |
-| Person | 3 | **1.1M** | 1.0M | 747.5K | 704.6K |
-| Event | 2.13 | **845.5K** | 717.6K | 598.3K | 576.1K |
-| Event | 3 | **992.4K** | 787.3K | 683.3K | 627.8K |
+| SimpleCC | 2.13 | **9.3M** | 8.1M | 6.1M | 5.9M |
+| SimpleCC | 3 | **8.8M** | 6.6M | 7.1M | 5.9M |
+| SimpleADT | 2.13 | **11.2M** | 9.1M | 8.7M | 7.4M |
+| SimpleADT | 3 | **10.9M** | 9.2M | 9.8M | 8.5M |
+| Person | 2.13 | **1.3M** | 1.1M | 918.0K | 879.0K |
+| Person | 3 | **1.3M** | 1.0M | 1.1M | 874.0K |
+| Event | 2.13 | **1.0M** | 906.0K | 736.0K | 724.0K |
+| Event | 3 | **996.0K** | 825.0K | 836.0K | 703.0K |
 
 ## Jsoniter Write
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | vs original |
 |------|-------|---------------|---------------|--------------|------------|
-| SimpleCC | 2.13 | 59.5M | 60.2M | 62.4M | 0.97x |
-| SimpleCC | 3 | 62.0M | 62.4M | 58.4M | **1.07x faster** |
-| Person | 2.13 | 4.5M | 4.5M | 4.4M | **~tied** |
-| Person | 3 | 5.3M | 5.3M | 5.2M | **~tied** |
-| SimpleADT | 2.13 | 59.9M | 59.2M | 58.0M | **1.03x faster** |
-| SimpleADT | 3 | 57.1M | 64.0M | 56.4M | **1.13x faster** |
-| Event | 2.13 | 4.0M | 3.7M | 4.1M | **~tied** |
-| Event | 3 | 4.7M | 4.7M | 4.7M | **~tied** |
+| SimpleCC | 2.13 | 61.1M | 59.3M | 60.8M | **1.00x faster** |
+| SimpleCC | 3 | 63.6M | 63.9M | 63.8M | **~tied** |
+| Person | 2.13 | 4.8M | 4.7M | 4.7M | **1.01x faster** |
+| Person | 3 | 5.5M | 5.4M | 5.4M | **1.02x faster** |
+| SimpleADT | 2.13 | 62.2M | 62.7M | 69.2M | 0.91x |
+| SimpleADT | 3 | 65.9M | 65.7M | 71.9M | 0.92x |
+| Event | 2.13 | 4.5M | 4.5M | 4.3M | **1.04x faster** |
+| Event | 3 | 4.8M | 4.8M | 4.9M | **0.97x faster** |
 
 ## Jsoniter Read
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | vs original |
 |------|-------|---------------|---------------|--------------|------------|
-| SimpleCC | 2.13 | 29.7M | 31.2M | 33.7M | 0.92x |
-| SimpleCC | 3 | 34.6M | 34.5M | 33.9M | **~tied** |
-| Person | 2.13 | 2.6M | 3.5M | 3.1M | **1.11x faster** |
-| Person | 3 | 3.6M | 3.6M | 3.6M | **~tied** |
-| SimpleADT | 2.13 | 31.4M | 28.1M | — |  |
-| SimpleADT | 3 | 32.7M | 36.8M | — |  |
-| Event | 2.13 | 2.3M | 2.2M | — |  |
-| Event | 3 | 2.0M | 1.8M | — |  |
+| SimpleCC | 2.13 | 36.4M | 35.8M | 35.5M | **1.02x faster** |
+| SimpleCC | 3 | 36.4M | 36.4M | 35.1M | **1.04x faster** |
+| Person | 2.13 | 3.6M | 3.6M | 3.8M | 0.96x |
+| Person | 3 | 3.6M | 3.7M | 3.8M | 0.98x |
+| SimpleADT | 2.13 | 15.5M | 16.8M | — |  |
+| SimpleADT | 3 | 15.8M | 15.7M | — |  |
+| Event | 2.13 | 3.3M | 3.3M | — |  |
+| Event | 3 | 3.3M | 3.3M | — |  |
 
 ## Cats Show
 
 | Type | Scala | Kindlings | kittens semi | kittens auto | vs best kittens |
 |------|-------|-----------|-------------|-------------|-----------------|
-| SimpleCC | 2.13 | 48.1M | 18.0M | 17.6M | **2.7x faster** |
-| SimpleCC | 3 | 47.8M | 14.3M | 12.3M | **3.3x faster** |
-| SimpleADT | 2.13 | 166M | 30.0M | 17.2M | **5.5x faster** |
-| SimpleADT | 3 | 97.6M | 34.1M | 35.0M | **2.8x faster** |
-| Person | 2.13 | 2.3M | — | 1.4M | **1.7x faster** |
-| Person | 3 | 1.8M | — | 1.5M | **1.2x faster** |
-| Event | 2.13 | 2.1M | 1.2M | 1.1M | **1.8x faster** |
-| Event | 3 | 1.9M | 567.5K | 1.3M | **1.5x faster** |
+| SimpleCC | 2.13 | 38.2M | 7.5M | 7.0M | **5.11x faster** |
+| SimpleCC | 3 | 27.2M | 19.6M | 19.9M | **1.37x faster** |
+| SimpleADT | 2.13 | 86.0M | 16.2M | 10.4M | **5.32x faster** |
+| SimpleADT | 3 | 72.8M | 51.9M | 52.8M | **1.38x faster** |
+| Person | 2.13 | 2.0M | — | 804.0K | **2.44x faster** |
+| Person | 3 | 1.6M | — | 1.4M | **1.18x faster** |
+| Event | 2.13 | 1.9M | 602.0K | 620.0K | **2.99x faster** |
+| Event | 3 | 1.5M | 535.0K | 1.2M | **1.25x faster** |
 
 ## Cats Eq
 
 | Type | Scala | Kindlings | kittens best | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| SimpleCC (eq) | 2.13 | 97.4M | 46.0M | **2.1x faster** |
-| SimpleCC (eq) | 3 | 83.2M | 85.3M | ~tied |
-| SimpleCC (neq) | 2.13 | 239M | — |  |
-| SimpleCC (neq) | 3 | 232M | — |  |
+| SimpleCC (eq) | 2.13 | 100.2M | 46.1M | **2.17x faster** |
+| SimpleCC (eq) | 3 | 102.3M | 92.2M | **1.11x faster** |
+| SimpleCC (neq) | 2.13 | 549.8M | — |  |
+| SimpleCC (neq) | 3 | 561.4M | — |  |
 
 ## Cats Hash
 
 | Type | Scala | Kindlings | kittens best | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| SimpleCC | 2.13 | 264M | 37.4M | **7.1x faster** |
-| SimpleCC | 3 | 234M | 53.4M | **4.4x faster** |
+| SimpleCC | 2.13 | 824.9M | 27.4M | **30.1x faster** |
+| SimpleCC | 3 | 828.3M | 110.0M | **7.5x faster** |
 
 ## Cats Order
 
 | Type | Scala | Kindlings | kittens best | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| SimpleCC | 2.13 | 451M | 72.0M | **6.3x faster** |
-| SimpleCC | 3 | 415M | 329M | **1.3x faster** |
+| SimpleCC | 2.13 | 424.8M | 389.7M | **1.09x faster** |
+| SimpleCC | 3 | 429.7M | 347.6M | **1.24x faster** |
 
 ## Cats Semigroup
 
 | Type | Scala | Kindlings | kittens semi | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| IntPair | 2.13 | 508M | 71.6M | **7.1x faster** |
-| IntPair | 3 | 154M | 102M | **1.5x faster** |
+| IntPair | 2.13 | 194.1M | 54.3M | **3.6x faster** |
+| IntPair | 3 | 193.6M | 146.3M | **1.32x faster** |
 
 ## Cats Monoid
 
 | Type | Scala | Kindlings | kittens semi | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| IntPair (combine) | 2.13 | 561M | 72.9M | **7.7x faster** |
-| IntPair (combine) | 3 | 155M | 101M | **1.5x faster** |
-| IntPair (empty) | 2.13 | 1896M | 1659M | **1.14x faster** |
-| IntPair (empty) | 3 | 2077M | 603M | **3.4x faster** |
+| IntPair (combine) | 2.13 | 192.8M | 49.0M | **3.9x faster** |
+| IntPair (combine) | 3 | 193.9M | 119.5M | **1.62x faster** |
+| IntPair (empty) | 2.13 | 3.6B | 1.7B | **2.1x faster** |
+| IntPair (empty) | 3 | 3.7B | 1.0B | **3.7x faster** |
 
 ## Cats Functor
 
 | Type | Scala | Kindlings | kittens semi | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| SimpleCCBox (map) | 2.13 | 205M | 4.4M | **47x faster** |
-| SimpleCCBox (map) | 3 | 238M | 84.9M | **2.8x faster** |
+| SimpleCCBox (map) | 2.13 | 277.3M | 5.7M | **48.6x faster** |
+| SimpleCCBox (map) | 3 | 275.9M | 65.2M | **4.2x faster** |
 
 ## Cats Foldable / Traverse (Scala 3 — kittens Scala 2 does not support these)
 
 | Type class | Kindlings | kittens semi | vs kittens |
 |-----------|-----------|-------------|-----------|
-| Foldable (foldLeft) | 1006M | 120M | **8.4x faster** |
-| Traverse (traverse) | 123M | 24.2M | **5.1x faster** |
+| Foldable (foldLeft) | 1.6B | 109.6M | **14.6x faster** |
+| Traverse (traverse) | 164.2M | 18.7M | **8.8x faster** |
 
 ## Cats ShowPretty (Scala 3)
 
 | Approach | SimpleCC | Person | Notes |
 |----------|----------|--------|-------|
-| Kindlings Show | 49.0M | 2.0M | Single-line baseline |
-| Kindlings ShowPretty | 50.0M | 2.1M | Multi-line, ~0% overhead |
-| kittens ShowPretty | 6.2M | 644.7K | List[String] accumulation |
-| Kindlings FastShowPretty | 27.3M | 1.4M | StringBuilder + escaped strings |
+| Kindlings Show | 27.0M | 1.7M | Single-line baseline |
+| Kindlings ShowPretty | 34.3M | 1.8M | Multi-line, ~0% overhead |
+| kittens ShowPretty | 5.4M | 557.0K | List[String] accumulation |
+| Kindlings FastShowPretty | 18.0M | 1.3M | StringBuilder + escaped strings |
+
+## Cats Empty
+
+| Type | Scala | Kindlings | kittens semi | vs kittens |
+|------|-------|-----------|-------------|-----------|
+| Empty | 2.13 | 1.6B | 1.6B | **~tied** |
+| Empty | 3 | 1.8B | 1.1B | **1.6x faster** |
 
 ## Avro (kindlings vs avro4s)
 
 | Type | Scala | Kindlings | Original semi | Original auto | vs best original |
 |------|-------|-----------|--------------|--------------|-----------------|
-| Encode SimpleCC | 2.13 | 270M | — | 41.4M | **6.5x faster** |
-| Encode SimpleCC | 3 | 263M | 40.3M | 45.2M | **5.8x faster** |
-| Encode Person | 2.13 | 19.6M | — | 4.5M | **4.3x faster** |
-| Encode Person | 3 | 19.2M | 5.5M | 5.5M | **3.5x faster** |
-| Encode Event | 2.13 | 13.7M | — | — |  |
-| Encode Event | 3 | 14.4M | — | — |  |
-| Decode SimpleCC | 2.13 | 56.7M | — | 16.0M | **3.5x faster** |
-| Decode SimpleCC | 3 | 61.0M | 27.8M | 42.0M | **1.5x faster** |
-| Decode Person | 2.13 | 6.3M | — | 3.6M | **1.7x faster** |
-| Decode Person | 3 | 6.8M | 3.0M | 4.1M | **1.7x faster** |
-| Decode Event | 2.13 | 4.8M | — | — |  |
-| Decode Event | 3 | 4.9M | — | — |  |
+| Encode SimpleCC | 2.13 | 272.5M | — | 44.6M | **6.11x faster** |
+| Encode SimpleCC | 3 | 277.4M | 48.7M | 50.5M | **5.49x faster** |
+| Encode SimpleADT | 2.13 | 364.3M | — | — |  |
+| Encode SimpleADT | 3 | 378.5M | — | — |  |
+| Encode Person | 2.13 | 19.5M | — | 4.5M | **4.31x faster** |
+| Encode Person | 3 | 19.1M | 5.8M | 5.8M | **3.27x faster** |
+| Encode Event | 2.13 | 17.4M | — | — |  |
+| Encode Event | 3 | 18.0M | — | — |  |
+| Decode SimpleCC | 2.13 | 119.2M | — | 17.7M | **6.74x faster** |
+| Decode SimpleCC | 3 | 127.2M | 26.0M | 83.9M | **1.52x faster** |
+| Decode SimpleADT | 2.13 | 168.0M | — | — |  |
+| Decode SimpleADT | 3 | 167.0M | — | — |  |
+| Decode Person | 2.13 | 9.8M | — | 3.7M | **2.62x faster** |
+| Decode Person | 3 | 9.3M | 3.1M | 4.4M | **2.10x faster** |
+| Decode Event | 2.13 | 8.5M | — | — |  |
+| Decode Event | 3 | 8.6M | — | — |  |
 
 ## PureConfig (kindlings vs pureconfig-generic)
 
 | Type | Scala | Kindlings | Original semi | vs original |
 |------|-------|-----------|--------------|------------|
-| Write SimpleCC | 2.13 | 10.5M | 1.4M | **7.6x faster** |
-| Write SimpleCC | 3 | 11.4M | 1.1M | **10x faster** |
-| Write Person | 2.13 | 1.1M | 218.1K | **5.1x faster** |
-| Write Person | 3 | 1.2M | 207.3K | **5.5x faster** |
-| Read SimpleCC | 2.13 | 15.6M | 1.4M | **11x faster** |
-| Read SimpleCC | 3 | 17.3M | 959.7K | **18x faster** |
-| Read Person | 2.13 | 783.5K | 214.2K | **3.7x faster** |
-| Read Person | 3 | 760.1K | 173.6K | **4.4x faster** |
+| Write SimpleCC | 2.13 | 11.0M | 1.2M | **9.12x faster** |
+| Write SimpleCC | 3 | 11.1M | 1.7M | **6.64x faster** |
+| Write Person | 2.13 | 1.2M | 205.0K | **5.76x faster** |
+| Write Person | 3 | 1.2M | 248.0K | **4.75x faster** |
+| Read SimpleCC | 2.13 | 17.2M | 1.4M | **12.46x faster** |
+| Read SimpleCC | 3 | 17.2M | 1.4M | **12.48x faster** |
+| Read Person | 2.13 | 1.0M | 216.0K | **4.77x faster** |
+| Read Person | 3 | 1.0M | 197.0K | **5.29x faster** |
+
+## Optics (kindlings vs quicklens vs hand-written)
+
+| Benchmark | Scala | Kindlings | quicklens | hand-written |
+|-----------|-------|-----------|-----------|--------------|
+| DeepName | 2.13 | 99.0M | 98.7M | 98.8M |
+| DeepName | 3 | 99.2M | 99.1M | 93.2M |
+| EachSalary | 2.13 | 21.8M | 20.1M | 21.4M |
+| EachSalary | 3 | 21.2M | 20.8M | 21.9M |
+
+## Tapir Schema (kindlings vs tapir-derivation)
+
+| Type | Scala | Kindlings | Original semi | Original auto |
+|------|-------|-----------|--------------|--------------|
+| SimpleCC | 2.13 | 3.8B | 3.8B | 3.8B |
+| SimpleCC | 3 | 3.8B | 3.8B | 3.8B |
+| Person | 2.13 | 3.9B | 3.8B | 3.8B |
+| Person | 3 | 3.8B | 3.7B | 3.8B |
+| Event | 2.13 | 3.9B | 3.8B | 3.8B |
+| Event | 3 | 3.8B | 3.8B | 3.8B |
+
+## Tapir OpenAPI jsoniter codecs (kindlings vs circe)
+
+| Operation | Scala | Kindlings | circe |
+|-----------|-------|-----------|-------|
+| Encode | 2.13 | 70.0K | 24.0K |
+| Encode | 3 | 56.0K | 24.0K |
+| Decode | 2.13 | 26.0K | 12.0K |
+| Decode | 3 | 21.0K | 5.0K |
 
 ## Kindlings-only modules (no original comparison)
 
 | Module | Type | Scala 2.13 | Scala 3 |
 |--------|------|-----------|---------|
-| FastShowPretty | SimpleCC | 18.4M | 25.8M |
-| FastShowPretty | SimpleADT | 20.8M | 26.9M |
-| FastShowPretty | Person | 1.3M | 1.4M |
-| FastShowPretty | Event | 972.7K | 1.2M |
-| UbjsonWrite | SimpleCC | 16.2M | 17.0M |
-| UbjsonWrite | SimpleADT | 16.3M | 15.9M |
-| UbjsonWrite | Person | 1.6M | 1.6M |
-| UbjsonWrite | Event | 1.5M | 1.6M |
-| UbjsonRead | SimpleCC | 12.8M | 12.9M |
-| UbjsonRead | SimpleADT | 15.8M | 15.1M |
-| UbjsonRead | Person | 1.4M | 1.1M |
+| FastShowPretty | SimpleCC | 13.5M | 17.9M |
+| FastShowPretty | SimpleADT | 15.6M | 14.6M |
+| FastShowPretty | Person | 1.2M | 1.3M |
+| FastShowPretty | Event | 854.0K | 972.0K |
+| UbjsonWrite | SimpleCC | 11.2M | 11.0M |
+| UbjsonWrite | SimpleADT | 13.4M | 13.2M |
+| UbjsonWrite | Person | 1.4M | 1.4M |
+| UbjsonWrite | Event | 1.3M | 1.2M |
+| UbjsonRead | SimpleCC | 11.3M | 10.4M |
+| UbjsonRead | SimpleADT | 13.8M | 13.6M |
+| UbjsonRead | Person | 1.4M | 1.4M |
 | UbjsonRead | Event | 1.3M | 1.2M |
-| SconfigWrite | SimpleCC | 10.2M | 8.5M |
-| SconfigWrite | SimpleADT | 5.9M | 4.8M |
+| SconfigWrite | SimpleCC | 10.9M | 10.9M |
+| SconfigWrite | SimpleADT | 5.2M | 6.3M |
 | SconfigWrite | Person | 1.2M | 1.3M |
-| SconfigWrite | Event | 614.8K | 669.0K |
-| SconfigRead | SimpleCC | 59.9M | 63.5M |
-| SconfigRead | SimpleADT | 8.7M | 8.1M |
-| SconfigRead | Person | 3.9M | 3.7M |
-| SconfigRead | Event | 2.0M | 1.8M |
-| YamlEncode | SimpleCC | 903.4K | 964.3K |
-| YamlEncode | SimpleADT | 1.5M | 1.6M |
-| YamlEncode | Person | 109.9K | 113.6K |
-| YamlEncode | Event | 97.6K | 104.4K |
-| YamlDecode | SimpleCC | 7.2M | 6.5M |
-| YamlDecode | SimpleADT | 35.4M | 47.5M |
-| YamlDecode | Person | 770.2K | 757.0K |
-| YamlDecode | Event | 655.3K | 626.5K |
-| XmlEncode | SimpleCC | 28.4M | 41.7M |
-| XmlEncode | Address | 28.3M | 28.4M |
-| XmlDecode | SimpleCC | 3.2M | 3.5M |
-| XmlDecode | Address | 2.5M | 2.5M |
-| ScalacheckArbitrary | SimpleCC | 693.1K | 679.3K |
-| ScalacheckArbitrary | SimpleADT | 1.8M | 1.7M |
-| ScalacheckArbitrary | Person | 4.7K | 4.7K |
-| ScalacheckShrink | SimpleCC | 5.5M | 4.9M |
-| ScalacheckShrink | Person | 5.3M | 4.4M |
+| SconfigWrite | Event | 630.0K | 648.0K |
+| SconfigRead | SimpleCC | 72.4M | 60.9M |
+| SconfigRead | SimpleADT | 12.0M | 11.8M |
+| SconfigRead | Person | 5.0M | 4.7M |
+| SconfigRead | Event | 2.6M | 2.8M |
+| YamlEncode | SimpleCC | 1.4M | 1.4M |
+| YamlEncode | SimpleADT | 2.2M | 2.3M |
+| YamlEncode | Person | 147.0K | 164.0K |
+| YamlEncode | Event | 136.0K | 148.0K |
+| YamlDecode | SimpleCC | 9.4M | 7.0M |
+| YamlDecode | SimpleADT | 98.6M | 104.1M |
+| YamlDecode | Person | 774.0K | 763.0K |
+| YamlDecode | Event | 721.0K | 629.0K |
+| XmlEncode | SimpleCC | 46.2M | 45.2M |
+| XmlEncode | Address | 38.6M | 38.8M |
+| XmlDecode | SimpleCC | 4.8M | 5.0M |
+| XmlDecode | Address | 3.2M | 3.4M |
+| ScalacheckArbitrary | SimpleCC | 779.0K | 741.0K |
+| ScalacheckArbitrary | SimpleADT | 1.9M | 1.9M |
+| ScalacheckArbitrary | Person | 4.0K | 4.0K |
+| ScalacheckShrink | SimpleCC | 5.8M | 6.9M |
+| ScalacheckShrink | Person | 5.8M | 5.2M |
 
 ## Key takeaways
 
-1. **Circe**: Kindlings is **1.2-2.3x faster** for encoding and decoding across all types and both Scala versions
+1. **Circe**: Kindlings is **1.4-2.2x faster** for encoding (except SimpleADT on Scala 3, ~tied) and **1.3-4.3x faster** for decoding across all types and both Scala versions
 2. **Circe + booster**: Kindlings + jsoniter-scala-circe is the fastest Circe pipeline in every scenario
-3. **Cats**: Kindlings leads almost everywhere — **2.7-5.5x** for Show, **4.4-7.1x** for Hash, **1.3-6.3x** for Order, **1.5-7.7x** for Semigroup/Monoid, **47x** for Functor on 2.13 (**2.8x** on Scala 3), **8.4x** for Foldable, **5.1x** for Traverse, and ShowPretty **~8x** vs kittens. Eq is ~tied on Scala 3 and 2.1x faster on 2.13
-4. **Jsoniter**: at parity overall — writes ~tied to 1.13x, reads ~tied to 1.11x, with SimpleCC read on 2.13 (0.92x) as the only consistent small gap
-5. **PureConfig**: Kindlings is **3.7-18x faster** across all operations — massive improvement
-6. **Avro**: Kindlings is **1.5-6.5x faster** than avro4s across all benchmarks — 5.8-6.5x for SimpleCC encode, 3.5-4.3x for Person encode, 1.5-3.5x for decode
-7. **Tapir Schema**: Tied (~2.3-3.0B ops/s) — just a field access at runtime
-8. **Kindlings auto ≈ semi-auto** in most benchmarks (occasional gaps come from JIT fork-to-fork variance, not different generated code)
+3. **Cats**: Kindlings leads almost everywhere — **1.4-5.3x** for Show, **7.5-30x** for Hash, **1.1-1.2x** for Order, **1.3-3.9x** for Semigroup/Monoid, **48.6x** for Functor on 2.13 (**4.2x** on Scala 3), **14.6x** for Foldable, **8.8x** for Traverse, and ShowPretty **~6x** vs kittens. Eq is **1.1x** on Scala 3 and **2.2x** faster on 2.13; Empty is ~tied to 1.6x
+4. **Jsoniter**: at parity overall — writes ~tied (0.91-1.04x), reads ~tied (0.96-1.04x), with SimpleADT write (0.91-0.92x) as the only consistent small gap
+5. **PureConfig**: Kindlings is **4.7-12.5x faster** across all operations — massive improvement
+6. **Avro**: Kindlings is **1.5-6.7x faster** than avro4s across all benchmarks — 5.5-6.1x for SimpleCC encode, 3.3-4.3x for Person encode, 1.5-6.7x for decode
+7. **Tapir Schema**: Tied (~3.8-3.9B ops/s) — just a field access at runtime
+8. **Optics**: Kindlings `.modify` matches quicklens and hand-written code (~99M DeepName, ~21M EachSalary)
+9. **Kindlings auto ≈ semi-auto** in most benchmarks (occasional gaps come from JIT fork-to-fork variance, not different generated code)
+</content>
+</invoke>

--- a/docs/research/benchmark-runs/2026-06-17-master/README.md
+++ b/docs/research/benchmark-runs/2026-06-17-master/README.md
@@ -1,0 +1,12 @@
+# Benchmark run — 2026-06-17, Hearth 0.3.1-53
+
+- **Config**: 2 forks, 5 warmup, 10 measurement iterations, 1s each (JMH).
+- **Scala**: 2.13.18, 3.8.3. **Hearth**: 0.3.1-53-g5032722-SNAPSHOT.
+- **Branch**: benchmarks-and-docs (this session's optimizations: zero-closure foreach/Either fold,
+  fail-fast Either decode for circe/yaml/pureconfig, parse-once map/collection merge across all
+  modules, avro decode single-lookup + semiEval constant field names).
+- **Caveat**: run on a **shared dev machine with concurrent agent load** (~2h/version). The
+  kindlings/original **ratios** within each run are robust; absolute ops/s are approximate. A small
+  number of *original* (auto) measurements were noisy-high (e.g. avro4s auto decode SimpleCC, some
+  cats auto) which understates a few ratios.
+- Raw JMH JSON: `scala3.json`, `scala213.json`. Per-method both-version table: `summary.md`.

--- a/docs/research/benchmark-runs/2026-06-17-master/scala213.json
+++ b/docs/research/benchmark-runs/2026-06-17-master/scala213.json
@@ -1,0 +1,16867 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCodecReadBenchmark.anonSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1024380881125834E7,
+            "scoreError" : 488769.6987651192,
+            "scoreConfidence" : [
+                1.0535611182360714E7,
+                1.1513150579890953E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9925565.10075926,
+                "50.0" : 1.096843404306743E7,
+                "90.0" : 1.1955600414082356E7,
+                "95.0" : 1.1974273877318406E7,
+                "99.0" : 1.1974542464835417E7,
+                "99.9" : 1.1974542464835417E7,
+                "99.99" : 1.1974542464835417E7,
+                "99.999" : 1.1974542464835417E7,
+                "99.9999" : 1.1974542464835417E7,
+                "100.0" : 1.1974542464835417E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0337554005813522E7,
+                    1.1171950105730392E7,
+                    1.063623781261453E7,
+                    1.1486292629683452E7,
+                    1.0572110064156594E7,
+                    1.1974542464835417E7,
+                    1.1552991029502524E7,
+                    1.1833467710366445E7,
+                    1.1460006241078088E7,
+                    1.1969170714495234E7
+                ],
+                [
+                    1.0928016136163898E7,
+                    1.0280536121197673E7,
+                    9925565.10075926,
+                    1.1055571540006895E7,
+                    1.0542119943096712E7,
+                    1.1012633473420337E7,
+                    1.0908639177814435E7,
+                    1.0956664063974975E7,
+                    1.0903345265646467E7,
+                    1.0980204022159882E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCodecReadBenchmark.factorySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0676728397144528E7,
+            "scoreError" : 377435.46357706294,
+            "scoreConfidence" : [
+                1.0299292933567464E7,
+                1.1054163860721592E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0047889597669771E7,
+                "50.0" : 1.0703760842401188E7,
+                "90.0" : 1.1416123545123959E7,
+                "95.0" : 1.1456190302600801E7,
+                "99.0" : 1.1456623805506349E7,
+                "99.9" : 1.1456623805506349E7,
+                "99.99" : 1.1456623805506349E7,
+                "99.999" : 1.1456623805506349E7,
+                "99.9999" : 1.1456623805506349E7,
+                "100.0" : 1.1456623805506349E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0813234528981857E7,
+                    1.1033783058633668E7,
+                    1.0047889597669771E7,
+                    1.0884973331411632E7,
+                    1.0252989785871359E7,
+                    1.0882856717353446E7,
+                    1.098479317266628E7,
+                    1.0929617136540685E7,
+                    1.1010848289547443E7,
+                    1.1129651724680945E7
+                ],
+                [
+                    1.0084955998162832E7,
+                    1.0328574262336131E7,
+                    1.1456623805506349E7,
+                    1.032810703352779E7,
+                    1.1447953747395404E7,
+                    1.0394749576202242E7,
+                    1.0204082527449662E7,
+                    1.0404566457981171E7,
+                    1.0320030035151372E7,
+                    1.0594287155820519E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCodecWriteBenchmark.anonSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.8777793940359876E7,
+            "scoreError" : 2064860.9355901813,
+            "scoreConfidence" : [
+                5.67129330047697E7,
+                6.084265487595005E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.2027066932263464E7,
+                "50.0" : 5.9189322259117745E7,
+                "90.0" : 6.089484582401323E7,
+                "95.0" : 6.15091288401703E7,
+                "99.0" : 6.154065549730918E7,
+                "99.9" : 6.154065549730918E7,
+                "99.99" : 6.154065549730918E7,
+                "99.999" : 6.154065549730918E7,
+                "99.9999" : 6.154065549730918E7,
+                "100.0" : 6.154065549730918E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.852804050210854E7,
+                    5.934334320696586E7,
+                    5.875056360375774E7,
+                    6.154065549730918E7,
+                    6.091012235453172E7,
+                    6.0757357049346834E7,
+                    5.91526717307035E7,
+                    5.870315878868734E7,
+                    5.293006034665262E7,
+                    5.796301494016255E7
+                ],
+                [
+                    6.029811263355595E7,
+                    5.8202266437973715E7,
+                    5.2027066932263464E7,
+                    5.860777732263338E7,
+                    6.041110616330224E7,
+                    6.0656289160696335E7,
+                    5.922597278753199E7,
+                    5.845794777223991E7,
+                    5.965579203956252E7,
+                    5.9434559537212215E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCodecWriteBenchmark.factorySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.006202046265278E7,
+            "scoreError" : 968386.746075441,
+            "scoreConfidence" : [
+                5.9093633716577336E7,
+                6.1030407208728224E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.720764415832121E7,
+                "50.0" : 6.002686139239347E7,
+                "90.0" : 6.1368755155345514E7,
+                "95.0" : 6.178286106185961E7,
+                "99.0" : 6.180422124203557E7,
+                "99.9" : 6.180422124203557E7,
+                "99.99" : 6.180422124203557E7,
+                "99.999" : 6.180422124203557E7,
+                "99.9999" : 6.180422124203557E7,
+                "100.0" : 6.180422124203557E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.928904660925261E7,
+                    5.913041384012894E7,
+                    5.720764415832121E7,
+                    5.7899763922561534E7,
+                    6.0454006653765835E7,
+                    6.017838321245508E7,
+                    5.986064249077799E7,
+                    6.010233240218752E7,
+                    5.971116302772826E7,
+                    6.0816331292328075E7
+                ],
+                [
+                    6.137701763851636E7,
+                    6.180422124203557E7,
+                    6.127721466007149E7,
+                    6.12943928068079E7,
+                    5.9997260293351464E7,
+                    6.002037777911886E7,
+                    6.0022614053583115E7,
+                    6.003110873120382E7,
+                    5.990095448472379E7,
+                    6.086551995413606E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.anonCodecCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.3549353467408967E8,
+            "scoreError" : 5032428.107763333,
+            "scoreConfidence" : [
+                3.304611065663263E8,
+                3.40525962781853E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.2550571862453145E8,
+                "50.0" : 3.368220441698849E8,
+                "90.0" : 3.416714042213642E8,
+                "95.0" : 3.418620373222698E8,
+                "99.0" : 3.4186959344342095E8,
+                "99.9" : 3.4186959344342095E8,
+                "99.99" : 3.4186959344342095E8,
+                "99.999" : 3.4186959344342095E8,
+                "99.9999" : 3.4186959344342095E8,
+                "100.0" : 3.4186959344342095E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.4061321903876096E8,
+                    3.3725201258717835E8,
+                    3.404173352680702E8,
+                    3.3639207575259143E8,
+                    3.417184710203978E8,
+                    3.401724055251856E8,
+                    3.4086503167474407E8,
+                    3.4186959344342095E8,
+                    3.3876734628438115E8,
+                    3.4124780303006184E8
+                ],
+                [
+                    3.32795995063477E8,
+                    3.405923344566393E8,
+                    3.3374589188690686E8,
+                    3.329703020706262E8,
+                    3.2589592227451164E8,
+                    3.333919241215789E8,
+                    3.257706242980688E8,
+                    3.2550571862453145E8,
+                    3.272344656736743E8,
+                    3.326522213869861E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.anonHashCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.2667508352840424E8,
+            "scoreError" : 3222808.1567080375,
+            "scoreConfidence" : [
+                3.234522753716962E8,
+                3.298978916851123E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.2026578715650386E8,
+                "50.0" : 3.262121691838991E8,
+                "90.0" : 3.314865136916027E8,
+                "95.0" : 3.325403703318242E8,
+                "99.0" : 3.325951497108197E8,
+                "99.9" : 3.325951497108197E8,
+                "99.99" : 3.325951497108197E8,
+                "99.999" : 3.325951497108197E8,
+                "99.9999" : 3.325951497108197E8,
+                "100.0" : 3.325951497108197E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.273785425085102E8,
+                    3.3039552176577747E8,
+                    3.259534044014154E8,
+                    3.2402008208297074E8,
+                    3.325951497108197E8,
+                    3.264709339663828E8,
+                    3.3136907773784876E8,
+                    3.308626350727729E8,
+                    3.258781402192393E8,
+                    3.276137347361488E8
+                ],
+                [
+                    3.30602675074875E8,
+                    3.3149956213090867E8,
+                    3.2495117999073726E8,
+                    3.245940611616855E8,
+                    3.219969446450385E8,
+                    3.246586632509279E8,
+                    3.2026578715650386E8,
+                    3.284405836703284E8,
+                    3.206837271497272E8,
+                    3.232712641354664E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.anonShowCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.290194126787578E8,
+            "scoreError" : 3404612.443910154,
+            "scoreConfidence" : [
+                3.256148002348476E8,
+                3.3242402512266797E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.2062194572411376E8,
+                "50.0" : 3.297781024002671E8,
+                "90.0" : 3.3326993129866755E8,
+                "95.0" : 3.3363519336896396E8,
+                "99.0" : 3.3365219284414375E8,
+                "99.9" : 3.3365219284414375E8,
+                "99.99" : 3.3365219284414375E8,
+                "99.999" : 3.3365219284414375E8,
+                "99.9999" : 3.3365219284414375E8,
+                "100.0" : 3.3365219284414375E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.286367533972164E8,
+                    3.2123605226991445E8,
+                    3.244447144886929E8,
+                    3.298330919155018E8,
+                    3.2972311288503253E8,
+                    3.318971424149119E8,
+                    3.243155850804814E8,
+                    3.324500164191689E8,
+                    3.283393882731063E8,
+                    3.2062194572411376E8
+                ],
+                [
+                    3.3365219284414375E8,
+                    3.3191799850611776E8,
+                    3.2954822264172417E8,
+                    3.333122033405478E8,
+                    3.2486000108987087E8,
+                    3.315047261330282E8,
+                    3.3026808627123487E8,
+                    3.3288948292174536E8,
+                    3.2918068773965096E8,
+                    3.317568492189517E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.factoryCodecCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.439895510542713E8,
+            "scoreError" : 7037909.360563165,
+            "scoreConfidence" : [
+                8.369516416937082E8,
+                8.510274604148345E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.282703284916204E8,
+                "50.0" : 8.425669328641846E8,
+                "90.0" : 8.545691076276685E8,
+                "95.0" : 8.57907909856707E8,
+                "99.0" : 8.580717859909698E8,
+                "99.9" : 8.580717859909698E8,
+                "99.99" : 8.580717859909698E8,
+                "99.999" : 8.580717859909698E8,
+                "99.9999" : 8.580717859909698E8,
+                "100.0" : 8.580717859909698E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.300968876206282E8,
+                    8.424642314925367E8,
+                    8.580717859909698E8,
+                    8.400889039373729E8,
+                    8.492817842614939E8,
+                    8.480351252437755E8,
+                    8.515350266771767E8,
+                    8.415395292672877E8,
+                    8.494571505309837E8,
+                    8.525427065252538E8
+                ],
+                [
+                    8.345018921207012E8,
+                    8.362900900451473E8,
+                    8.387972235640765E8,
+                    8.395298901374958E8,
+                    8.426696342358326E8,
+                    8.282703284916204E8,
+                    8.424619335689031E8,
+                    8.497785146666197E8,
+                    8.495841194018346E8,
+                    8.547942633057146E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.factoryHashCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.438858490131158E8,
+            "scoreError" : 5790976.439070743,
+            "scoreConfidence" : [
+                8.380948725740451E8,
+                8.496768254521865E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.318772990876503E8,
+                "50.0" : 8.43973064577317E8,
+                "90.0" : 8.522512962449147E8,
+                "95.0" : 8.549727435750041E8,
+                "99.0" : 8.551146223154497E8,
+                "99.9" : 8.551146223154497E8,
+                "99.99" : 8.551146223154497E8,
+                "99.999" : 8.551146223154497E8,
+                "99.9999" : 8.551146223154497E8,
+                "100.0" : 8.551146223154497E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.435456172927881E8,
+                    8.44857717710947E8,
+                    8.520195348903155E8,
+                    8.353970081315365E8,
+                    8.337065357965847E8,
+                    8.443249092316931E8,
+                    8.401241847988733E8,
+                    8.474060806912483E8,
+                    8.480850234002564E8,
+                    8.489007081317023E8
+                ],
+                [
+                    8.473947855978678E8,
+                    8.419153695195104E8,
+                    8.435956241614984E8,
+                    8.43621219922941E8,
+                    8.371232254066141E8,
+                    8.318772990876503E8,
+                    8.351867913712229E8,
+                    8.51243675297082E8,
+                    8.551146223154497E8,
+                    8.522770475065367E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.factoryShowCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.966466030977533E8,
+            "scoreError" : 5524359.418338344,
+            "scoreConfidence" : [
+                9.91122243679415E8,
+                1.0021709625160916E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.861565179829898E8,
+                "50.0" : 9.966828115872916E8,
+                "90.0" : 1.0051599122623667E9,
+                "95.0" : 1.0079844692791519E9,
+                "99.0" : 1.0081216278250937E9,
+                "99.9" : 1.0081216278250937E9,
+                "99.99" : 1.0081216278250937E9,
+                "99.999" : 1.0081216278250937E9,
+                "99.9999" : 1.0081216278250937E9,
+                "100.0" : 1.0081216278250937E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.867539531411972E8,
+                    1.0053784569062567E9,
+                    9.872297521984098E8,
+                    1.0003364566516414E9,
+                    1.0081216278250937E9,
+                    9.95548558590253E8,
+                    9.861565179829898E8,
+                    9.891943781968108E8,
+                    9.969095159374214E8,
+                    1.0006212118311876E9
+                ],
+                [
+                    1.0031930104673558E9,
+                    1.00309974567455E9,
+                    9.914555507435077E8,
+                    9.996259705247383E8,
+                    9.924180543102862E8,
+                    9.938448516486881E8,
+                    9.954656142071587E8,
+                    1.0003065787173283E9,
+                    9.964561072371618E8,
+                    1.00081614916303E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaEncoderBenchmark.anonPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3673689.1198807405,
+            "scoreError" : 31836.61054519393,
+            "scoreConfidence" : [
+                3641852.5093355468,
+                3705525.7304259343
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3601429.9372091126,
+                "50.0" : 3679402.116382473,
+                "90.0" : 3714028.857153066,
+                "95.0" : 3719281.8898865795,
+                "99.0" : 3719545.7366811996,
+                "99.9" : 3719545.7366811996,
+                "99.99" : 3719545.7366811996,
+                "99.999" : 3719545.7366811996,
+                "99.9999" : 3719545.7366811996,
+                "100.0" : 3719545.7366811996
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3704717.486394552,
+                    3702668.5337535148,
+                    3687750.6797288833,
+                    3678656.152143031,
+                    3631321.773378507,
+                    3601429.9372091126,
+                    3616211.691750504,
+                    3634563.105733529,
+                    3662268.9866161067,
+                    3671582.8218979537
+                ],
+                [
+                    3707688.840671117,
+                    3711869.364431466,
+                    3714268.8007887993,
+                    3698566.684843792,
+                    3660416.574501263,
+                    3680148.080621915,
+                    3702622.412895467,
+                    3719545.7366811996,
+                    3672879.8100702805,
+                    3614604.9235038236
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaEncoderBenchmark.anonSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.41306647005852E7,
+            "scoreError" : 298307.55810047913,
+            "scoreConfidence" : [
+                3.3832357142484725E7,
+                3.442897225868568E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3395297491466038E7,
+                "50.0" : 3.4189645309410244E7,
+                "90.0" : 3.4558714447247416E7,
+                "95.0" : 3.4705212370510176E7,
+                "99.0" : 3.471279321309583E7,
+                "99.9" : 3.471279321309583E7,
+                "99.99" : 3.471279321309583E7,
+                "99.999" : 3.471279321309583E7,
+                "99.9999" : 3.471279321309583E7,
+                "100.0" : 3.471279321309583E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.349261066447867E7,
+                    3.4093223459891506E7,
+                    3.418383300269128E7,
+                    3.383293365654829E7,
+                    3.419545761612922E7,
+                    3.4021182300942466E7,
+                    3.443810901373619E7,
+                    3.442743619386581E7,
+                    3.426780757793126E7,
+                    3.456117636138278E7
+                ],
+                [
+                    3.430278042131675E7,
+                    3.471279321309583E7,
+                    3.4211341265251994E7,
+                    3.3395297491466038E7,
+                    3.387009718379028E7,
+                    3.4536557220029116E7,
+                    3.393030762595457E7,
+                    3.412027983856424E7,
+                    3.425659137430842E7,
+                    3.376347853032911E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaEncoderBenchmark.factoryPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3633439.998688688,
+            "scoreError" : 35367.62524551039,
+            "scoreConfidence" : [
+                3598072.3734431774,
+                3668807.6239341986
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3577639.049814964,
+                "50.0" : 3632343.949910178,
+                "90.0" : 3686745.2970494675,
+                "95.0" : 3699468.4676715853,
+                "99.0" : 3700122.6677060816,
+                "99.9" : 3700122.6677060816,
+                "99.99" : 3700122.6677060816,
+                "99.999" : 3700122.6677060816,
+                "99.9999" : 3700122.6677060816,
+                "100.0" : 3700122.6677060816
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3608143.0280419462,
+                    3595366.035615626,
+                    3577639.049814964,
+                    3594622.086095489,
+                    3670256.6162183923,
+                    3611711.809299128,
+                    3660281.016708782,
+                    3620215.7493406744,
+                    3590981.288064411,
+                    3581655.1515162997
+                ],
+                [
+                    3590276.0605588797,
+                    3595336.527610002,
+                    3683134.0435869037,
+                    3644472.150479681,
+                    3654138.0730082085,
+                    3661415.987887589,
+                    3684104.9673492815,
+                    3687038.6670161546,
+                    3700122.6677060816,
+                    3657888.997855256
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaEncoderBenchmark.factorySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.3298668114203118E7,
+            "scoreError" : 422831.6713697426,
+            "scoreConfidence" : [
+                3.2875836442833375E7,
+                3.372149978557286E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.2263004108194698E7,
+                "50.0" : 3.3350684305861622E7,
+                "90.0" : 3.3889592096709475E7,
+                "95.0" : 3.412074811540774E7,
+                "99.0" : 3.413242047105091E7,
+                "99.9" : 3.413242047105091E7,
+                "99.99" : 3.413242047105091E7,
+                "99.999" : 3.413242047105091E7,
+                "99.9999" : 3.413242047105091E7,
+                "100.0" : 3.413242047105091E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.378333545285627E7,
+                    3.380516074340654E7,
+                    3.3707738150160894E7,
+                    3.331114360116886E7,
+                    3.3437918853541512E7,
+                    3.330748761665122E7,
+                    3.413242047105091E7,
+                    3.389897335818758E7,
+                    3.342899053770486E7,
+                    3.334409038260763E7
+                ],
+                [
+                    3.341821559326527E7,
+                    3.3664372323537104E7,
+                    3.272770118924411E7,
+                    3.256713950662383E7,
+                    3.2263004108194698E7,
+                    3.2813485019194968E7,
+                    3.335727822911561E7,
+                    3.270243115331322E7,
+                    3.3278614886341054E7,
+                    3.302386110789605E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaFunctorBenchmark.anonMapSimpleCCBox",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.736488388910038E8,
+            "scoreError" : 4127627.2952871067,
+            "scoreConfidence" : [
+                2.6952121159571666E8,
+                2.777764661862909E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.570837205688552E8,
+                "50.0" : 2.748881985001795E8,
+                "90.0" : 2.784146320796984E8,
+                "95.0" : 2.7861500769580925E8,
+                "99.0" : 2.7862051156071126E8,
+                "99.9" : 2.7862051156071126E8,
+                "99.99" : 2.7862051156071126E8,
+                "99.999" : 2.7862051156071126E8,
+                "99.9999" : 2.7862051156071126E8,
+                "100.0" : 2.7862051156071126E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.7558129535803777E8,
+                    2.727506291543403E8,
+                    2.7755241243294674E8,
+                    2.774282603764573E8,
+                    2.7862051156071126E8,
+                    2.7851043426267076E8,
+                    2.7308708465523165E8,
+                    2.757082383012193E8,
+                    2.7557849074856937E8,
+                    2.749155813475632E8
+                ],
+                [
+                    2.754787893350805E8,
+                    2.7328767797693235E8,
+                    2.720336527447015E8,
+                    2.748608156527959E8,
+                    2.716449160382697E8,
+                    2.7415647406826633E8,
+                    2.570837205688552E8,
+                    2.763218095188689E8,
+                    2.705702026268112E8,
+                    2.6780578109174588E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaFunctorBenchmark.factoryMapSimpleCCBox",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.733404125390938E8,
+            "scoreError" : 4265049.252584907,
+            "scoreConfidence" : [
+                2.6907536328650886E8,
+                2.776054617916787E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.5943066622933108E8,
+                "50.0" : 2.737654077890747E8,
+                "90.0" : 2.7859916756975275E8,
+                "95.0" : 2.789761586847985E8,
+                "99.0" : 2.789914867885607E8,
+                "99.9" : 2.789914867885607E8,
+                "99.99" : 2.789914867885607E8,
+                "99.999" : 2.789914867885607E8,
+                "99.9999" : 2.789914867885607E8,
+                "100.0" : 2.789914867885607E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.6820724754808626E8,
+                    2.7690171098733956E8,
+                    2.766148104758228E8,
+                    2.7868492471331656E8,
+                    2.789914867885607E8,
+                    2.7782345079932046E8,
+                    2.7775544957744044E8,
+                    2.766605214522308E8,
+                    2.7782735327767843E8,
+                    2.7689002778132534E8
+                ],
+                [
+                    2.5943066622933108E8,
+                    2.67843436950517E8,
+                    2.6928131252172333E8,
+                    2.7221016571302664E8,
+                    2.706077161941459E8,
+                    2.711318969114557E8,
+                    2.738511005105792E8,
+                    2.736797150675702E8,
+                    2.7207109608704644E8,
+                    2.7034416119535893E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.anonEqvPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.718923345280351E9,
+            "scoreError" : 1.6435684289819455E8,
+            "scoreConfidence" : [
+                3.5545665023821564E9,
+                3.883280188178546E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9225276898300924E9,
+                "50.0" : 3.7592524276718206E9,
+                "90.0" : 3.8014551845317364E9,
+                "95.0" : 3.8035308260712876E9,
+                "99.0" : 3.803579682050447E9,
+                "99.9" : 3.803579682050447E9,
+                "99.99" : 3.803579682050447E9,
+                "99.999" : 3.803579682050447E9,
+                "99.9999" : 3.803579682050447E9,
+                "100.0" : 3.803579682050447E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.748733907414034E9,
+                    3.7124853454515476E9,
+                    3.727071996721579E9,
+                    3.743790813520878E9,
+                    3.7585946101724663E9,
+                    3.7197375697556725E9,
+                    3.7440704019154916E9,
+                    3.784318085110614E9,
+                    3.77013044209115E9,
+                    3.7745217753337164E9
+                ],
+                [
+                    3.7814445363939843E9,
+                    3.736846053042338E9,
+                    3.775063968933138E9,
+                    3.7787045513468585E9,
+                    3.802602562467257E9,
+                    2.9225276898300924E9,
+                    3.803579682050447E9,
+                    3.7599102451711755E9,
+                    3.7432038857725563E9,
+                    3.791128783112048E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.anonEqvSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3204077479869664E9,
+            "scoreError" : 4.3441926893429935E7,
+            "scoreConfidence" : [
+                1.2769658210935364E9,
+                1.3638496748803964E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.188217026071233E9,
+                "50.0" : 1.3460693098694873E9,
+                "90.0" : 1.3584911750966349E9,
+                "95.0" : 1.359842735349569E9,
+                "99.0" : 1.3599113574344301E9,
+                "99.9" : 1.3599113574344301E9,
+                "99.99" : 1.3599113574344301E9,
+                "99.999" : 1.3599113574344301E9,
+                "99.9999" : 1.3599113574344301E9,
+                "100.0" : 1.3599113574344301E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3585389157372093E9,
+                    1.3599113574344301E9,
+                    1.358061509331464E9,
+                    1.3486910592698996E9,
+                    1.3533766837448282E9,
+                    1.3520218435677354E9,
+                    1.354785532754881E9,
+                    1.3521236735875158E9,
+                    1.3526775517642984E9,
+                    1.356142130666526E9
+                ],
+                [
+                    1.3390264470002115E9,
+                    1.2822243843889713E9,
+                    1.2622287255354538E9,
+                    1.3087850950154214E9,
+                    1.188217026071233E9,
+                    1.3434475604690752E9,
+                    1.3414016588351004E9,
+                    1.281497169915128E9,
+                    1.2930540362861934E9,
+                    1.2219425983637495E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.anonHashPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6511785134513324E7,
+            "scoreError" : 49495.66903448408,
+            "scoreConfidence" : [
+                1.646228946547884E7,
+                1.6561280803547809E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6387951599582972E7,
+                "50.0" : 1.6530938093796888E7,
+                "90.0" : 1.6572752633564752E7,
+                "95.0" : 1.6573668723751456E7,
+                "99.0" : 1.6573670942419605E7,
+                "99.9" : 1.6573670942419605E7,
+                "99.99" : 1.6573670942419605E7,
+                "99.999" : 1.6573670942419605E7,
+                "99.9999" : 1.6573670942419605E7,
+                "100.0" : 1.6573670942419605E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6548487452754276E7,
+                    1.653234437138722E7,
+                    1.6564700614832977E7,
+                    1.6564887214138055E7,
+                    1.6491405260582317E7,
+                    1.6547622510717269E7,
+                    1.6573670942419605E7,
+                    1.6573626569056606E7,
+                    1.6482348311593853E7,
+                    1.6544629943779308E7
+                ],
+                [
+                    1.6396838182512866E7,
+                    1.6445083715595907E7,
+                    1.651718765513756E7,
+                    1.6519123552405432E7,
+                    1.6529531816206556E7,
+                    1.6564068798981978E7,
+                    1.6387951599582972E7,
+                    1.6437135523238648E7,
+                    1.6533060403628744E7,
+                    1.648199825171427E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.anonHashSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.743991373074946E9,
+            "scoreError" : 1.760853268389452E8,
+            "scoreConfidence" : [
+                3.5679060462360005E9,
+                3.9200766999138913E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.890423988986897E9,
+                "50.0" : 3.796541261177267E9,
+                "90.0" : 3.8105821105070004E9,
+                "95.0" : 3.832732226770321E9,
+                "99.0" : 3.8338764042190843E9,
+                "99.9" : 3.8338764042190843E9,
+                "99.99" : 3.8338764042190843E9,
+                "99.999" : 3.8338764042190843E9,
+                "99.9999" : 3.8338764042190843E9,
+                "100.0" : 3.8338764042190843E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.80075361397431E9,
+                    3.8109928552438216E9,
+                    3.8057869310856967E9,
+                    3.8338764042190843E9,
+                    3.7648973526276283E9,
+                    3.8016415674541826E9,
+                    3.80201055523871E9,
+                    3.785995386505504E9,
+                    3.796936586674057E9,
+                    3.8068854078756094E9
+                ],
+                [
+                    3.770483948824663E9,
+                    3.795897300044252E9,
+                    3.801597108334997E9,
+                    3.804634624903763E9,
+                    3.7961459356804767E9,
+                    2.890423988986897E9,
+                    3.7406586462044873E9,
+                    3.706555988439207E9,
+                    3.776747194296535E9,
+                    3.786906064885026E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.factoryEqvPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7888016723013673E9,
+            "scoreError" : 2.919148544697279E7,
+            "scoreConfidence" : [
+                3.7596101868543944E9,
+                3.81799315774834E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.7268124876676345E9,
+                "50.0" : 3.7969371898986864E9,
+                "90.0" : 3.8303467683806033E9,
+                "95.0" : 3.8472729311536527E9,
+                "99.0" : 3.8481512226569905E9,
+                "99.9" : 3.8481512226569905E9,
+                "99.99" : 3.8481512226569905E9,
+                "99.999" : 3.8481512226569905E9,
+                "99.9999" : 3.8481512226569905E9,
+                "100.0" : 3.8481512226569905E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.767123324022559E9,
+                    3.768681808141172E9,
+                    3.7436884468259573E9,
+                    3.802184387930238E9,
+                    3.8122117971385765E9,
+                    3.795862808113432E9,
+                    3.8239631594447246E9,
+                    3.828199150493909E9,
+                    3.8481512226569905E9,
+                    3.830585392590236E9
+                ],
+                [
+                    3.7268124876676345E9,
+                    3.750284518450577E9,
+                    3.7555166312224517E9,
+                    3.7980115716839414E9,
+                    3.8083329374542074E9,
+                    3.766591700035905E9,
+                    3.7513726402090635E9,
+                    3.8093817864370856E9,
+                    3.779635802538139E9,
+                    3.8094418729705486E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.factoryEqvSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.310290180285474E9,
+            "scoreError" : 3.928195453900176E7,
+            "scoreConfidence" : [
+                1.2710082257464724E9,
+                1.3495721348244758E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.2386708737078362E9,
+                "50.0" : 1.3179075963705978E9,
+                "90.0" : 1.3621773929735885E9,
+                "95.0" : 1.3645371963534226E9,
+                "99.0" : 1.3646459685914664E9,
+                "99.9" : 1.3646459685914664E9,
+                "99.99" : 1.3646459685914664E9,
+                "99.999" : 1.3646459685914664E9,
+                "99.9999" : 1.3646459685914664E9,
+                "100.0" : 1.3646459685914664E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3558615991115906E9,
+                    1.3497460703061619E9,
+                    1.3595392152605746E9,
+                    1.36247052383059E9,
+                    1.3646459685914664E9,
+                    1.3486111308864868E9,
+                    1.3295405419136028E9,
+                    1.3452884624850419E9,
+                    1.3524734845639412E9,
+                    1.3556141586548984E9
+                ],
+                [
+                    1.2710662740819812E9,
+                    1.265003271705834E9,
+                    1.271106168147118E9,
+                    1.2746660964715312E9,
+                    1.2625364121312265E9,
+                    1.267173351823959E9,
+                    1.2386708737078362E9,
+                    1.2577506223919933E9,
+                    1.3062746508275926E9,
+                    1.2677647288160534E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.factoryHashPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6248900536690224E7,
+            "scoreError" : 314217.1398276966,
+            "scoreConfidence" : [
+                1.5934683396862527E7,
+                1.656311767651792E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.5745532591734495E7,
+                "50.0" : 1.6234632951076292E7,
+                "90.0" : 1.6648160480699686E7,
+                "95.0" : 1.6690048989542553E7,
+                "99.0" : 1.6692215320289426E7,
+                "99.9" : 1.6692215320289426E7,
+                "99.99" : 1.6692215320289426E7,
+                "99.999" : 1.6692215320289426E7,
+                "99.9999" : 1.6692215320289426E7,
+                "100.0" : 1.6692215320289426E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.659368929047762E7,
+                    1.6648888705351992E7,
+                    1.6594622896195525E7,
+                    1.6692215320289426E7,
+                    1.6617170915657796E7,
+                    1.6586228523527004E7,
+                    1.6625936786627332E7,
+                    1.6641606458828934E7,
+                    1.6463418750712834E7,
+                    1.6476584836256197E7
+                ],
+                [
+                    1.6005847151439749E7,
+                    1.590171265044896E7,
+                    1.5863384388282876E7,
+                    1.5989120784986563E7,
+                    1.5873386906455044E7,
+                    1.592734868932779E7,
+                    1.5974245545640437E7,
+                    1.5933127985987725E7,
+                    1.5745532591734495E7,
+                    1.5823941555576183E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.factoryHashSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7675400955597444E9,
+            "scoreError" : 3.770341898035951E7,
+            "scoreConfidence" : [
+                3.729836676579385E9,
+                3.805243514540104E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6786267212406416E9,
+                "50.0" : 3.7798125590575275E9,
+                "90.0" : 3.8229043252700267E9,
+                "95.0" : 3.828925805027784E9,
+                "99.0" : 3.8291912981432533E9,
+                "99.9" : 3.8291912981432533E9,
+                "99.99" : 3.8291912981432533E9,
+                "99.999" : 3.8291912981432533E9,
+                "99.9999" : 3.8291912981432533E9,
+                "100.0" : 3.8291912981432533E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.7486817511594806E9,
+                    3.680823596023441E9,
+                    3.738471933094999E9,
+                    3.742210567936665E9,
+                    3.7538180653873506E9,
+                    3.7905729725951595E9,
+                    3.787314191332943E9,
+                    3.797456920860251E9,
+                    3.729907309401764E9,
+                    3.788654216350048E9
+                ],
+                [
+                    3.823881435833864E9,
+                    3.8037675810661707E9,
+                    3.814110330195488E9,
+                    3.6786267212406416E9,
+                    3.7145961326823564E9,
+                    3.7686913051203504E9,
+                    3.7909998885504956E9,
+                    3.8291912981432533E9,
+                    3.7967147674380426E9,
+                    3.772310926782112E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.anonEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2701628.57181502,
+            "scoreError" : 24189.58872501001,
+            "scoreConfidence" : [
+                2677438.98309001,
+                2725818.16054003
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2643958.864578388,
+                "50.0" : 2696915.1973848147,
+                "90.0" : 2737278.522480951,
+                "95.0" : 2760882.93991255,
+                "99.0" : 2762097.6881480585,
+                "99.9" : 2762097.6881480585,
+                "99.99" : 2762097.6881480585,
+                "99.999" : 2762097.6881480585,
+                "99.9999" : 2762097.6881480585,
+                "100.0" : 2762097.6881480585
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2683235.523254501,
+                    2643958.864578388,
+                    2653583.6094331634,
+                    2687970.774282704,
+                    2762097.6881480585,
+                    2737802.723437896,
+                    2700423.825430417,
+                    2695899.8385628466,
+                    2693690.2528669373,
+                    2732560.7138684494
+                ],
+                [
+                    2694570.4584511095,
+                    2708324.3629939705,
+                    2729496.9838802144,
+                    2708438.6377414223,
+                    2691354.60837192,
+                    2697930.556206783,
+                    2715814.0627596946,
+                    2694341.9834224894,
+                    2725759.618749936,
+                    2675316.3498594873
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.anonPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2983574.079573099,
+            "scoreError" : 34953.99294388939,
+            "scoreConfidence" : [
+                2948620.0866292096,
+                3018528.0725169885
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2868072.0820340393,
+                "50.0" : 2997697.8660550322,
+                "90.0" : 3023563.325792609,
+                "95.0" : 3026809.3922264925,
+                "99.0" : 3026978.227952676,
+                "99.9" : 3026978.227952676,
+                "99.99" : 3026978.227952676,
+                "99.999" : 3026978.227952676,
+                "99.9999" : 3026978.227952676,
+                "100.0" : 3026978.227952676
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2982718.3613532796,
+                    2950102.6580830016,
+                    2868072.0820340393,
+                    2910647.5272772154,
+                    2953148.0514609036,
+                    2961713.0023908988,
+                    3004089.7689029546,
+                    3004239.586261575,
+                    3023219.6370650297,
+                    2956534.803648193
+                ],
+                [
+                    3001493.9503220473,
+                    3023601.5134290066,
+                    3021918.945499365,
+                    3000847.8879093435,
+                    2995739.6491137426,
+                    2999327.5816988237,
+                    2991142.090950088,
+                    2996068.1504112403,
+                    3026978.227952676,
+                    2999878.115698549
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.anonSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.2467777217388077E8,
+            "scoreError" : 1602160.5310731546,
+            "scoreConfidence" : [
+                1.2307561164280762E8,
+                1.2627993270495392E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.2039609037405485E8,
+                "50.0" : 1.2509858279589158E8,
+                "90.0" : 1.2714611429022664E8,
+                "95.0" : 1.2722632795980947E8,
+                "99.0" : 1.272299209967582E8,
+                "99.9" : 1.272299209967582E8,
+                "99.99" : 1.272299209967582E8,
+                "99.999" : 1.272299209967582E8,
+                "99.9999" : 1.272299209967582E8,
+                "100.0" : 1.272299209967582E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2302513552207519E8,
+                    1.2405947966103001E8,
+                    1.2196829002368362E8,
+                    1.2442657563126527E8,
+                    1.2510315934555689E8,
+                    1.2458146506701869E8,
+                    1.2487931932627192E8,
+                    1.252343879085325E8,
+                    1.261655632093669E8,
+                    1.272299209967582E8
+                ],
+                [
+                    1.2335851728318089E8,
+                    1.2579485120371673E8,
+                    1.2039609037405485E8,
+                    1.2509400624622627E8,
+                    1.2703860058221425E8,
+                    1.2553594583300167E8,
+                    1.2556087406659631E8,
+                    1.253770125399163E8,
+                    1.2715806025778358E8,
+                    1.2156818839936556E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.factoryEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2757355.7541901963,
+            "scoreError" : 33493.74140893853,
+            "scoreConfidence" : [
+                2723862.0127812577,
+                2790849.495599135
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2625515.690608285,
+                "50.0" : 2761601.5629871227,
+                "90.0" : 2795539.2876278525,
+                "95.0" : 2802035.095845322,
+                "99.0" : 2802373.37257922,
+                "99.9" : 2802373.37257922,
+                "99.99" : 2802373.37257922,
+                "99.999" : 2802373.37257922,
+                "99.9999" : 2802373.37257922,
+                "100.0" : 2802373.37257922
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2625515.690608285,
+                    2760393.766750027,
+                    2731693.127593615,
+                    2762809.359224219,
+                    2772601.3154670824,
+                    2794922.335167218,
+                    2788437.1770213735,
+                    2795607.8379012565,
+                    2788102.082640484,
+                    2791193.047683188
+                ],
+                [
+                    2752568.3432046873,
+                    2767205.1238507964,
+                    2733970.435889006,
+                    2744339.832902551,
+                    2802373.37257922,
+                    2765396.259831908,
+                    2755157.9545659474,
+                    2738183.319690592,
+                    2738750.263267009,
+                    2737894.4379654652
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.factoryPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3050310.548467633,
+            "scoreError" : 14255.483963101582,
+            "scoreConfidence" : [
+                3036055.064504531,
+                3064566.0324307345
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3007378.17894124,
+                "50.0" : 3050877.4622187554,
+                "90.0" : 3070173.5808370337,
+                "95.0" : 3076322.691907283,
+                "99.0" : 3076626.1630532835,
+                "99.9" : 3076626.1630532835,
+                "99.99" : 3076626.1630532835,
+                "99.999" : 3076626.1630532835,
+                "99.9999" : 3076626.1630532835,
+                "100.0" : 3076626.1630532835
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3070556.7401332725,
+                    3051250.874213208,
+                    3064068.3074232037,
+                    3036551.546054633,
+                    3059413.7941647596,
+                    3076626.1630532835,
+                    3052662.580593807,
+                    3049578.342722442,
+                    3036354.4285991746,
+                    3057761.163515459
+                ],
+                [
+                    3062050.373245474,
+                    3030449.2377655418,
+                    3007378.17894124,
+                    3047598.1825679713,
+                    3047275.7446522214,
+                    3043099.5646486008,
+                    3031172.8759555942,
+                    3050504.050224303,
+                    3065133.6737075807,
+                    3066725.147170882
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.factorySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.2560724623622319E8,
+            "scoreError" : 1741543.5933410632,
+            "scoreConfidence" : [
+                1.2386570264288212E8,
+                1.2734878982956426E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.2158307980865733E8,
+                "50.0" : 1.262021368262718E8,
+                "90.0" : 1.2824205419506933E8,
+                "95.0" : 1.2829346030449441E8,
+                "99.0" : 1.2829367447463813E8,
+                "99.9" : 1.2829367447463813E8,
+                "99.99" : 1.2829367447463813E8,
+                "99.999" : 1.2829367447463813E8,
+                "99.9999" : 1.2829367447463813E8,
+                "100.0" : 1.2829367447463813E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2781602230482036E8,
+                    1.2742782470674436E8,
+                    1.2639938985885915E8,
+                    1.266405852871401E8,
+                    1.2723189035405467E8,
+                    1.2667580455309272E8,
+                    1.2829367447463813E8,
+                    1.2648369475993612E8,
+                    1.2754258340999852E8,
+                    1.2828939107176366E8
+                ],
+                [
+                    1.2482408223732167E8,
+                    1.2474402349146147E8,
+                    1.2311230493647131E8,
+                    1.2158307980865733E8,
+                    1.223831847783263E8,
+                    1.2338871319145253E8,
+                    1.2477152189464661E8,
+                    1.2600488379368444E8,
+                    1.2464156467139426E8,
+                    1.2389070514000037E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8508127.499026142,
+            "scoreError" : 414245.5534060466,
+            "scoreConfidence" : [
+                8093881.945620095,
+                8922373.052432189
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7972996.774890301,
+                "50.0" : 8496288.7832437,
+                "90.0" : 9047078.35384249,
+                "95.0" : 9071543.544570556,
+                "99.0" : 9072684.875984782,
+                "99.9" : 9072684.875984782,
+                "99.99" : 9072684.875984782,
+                "99.999" : 9072684.875984782,
+                "99.9999" : 9072684.875984782,
+                "100.0" : 9072684.875984782
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8931842.86923719,
+                    8851911.927961955,
+                    8908983.208095388,
+                    9049858.247700254,
+                    9022059.309122616,
+                    8965313.132514147,
+                    8993090.131145302,
+                    8962352.708258314,
+                    9072684.875984782,
+                    8935613.197453193
+                ],
+                [
+                    7972996.774890301,
+                    8045054.029065077,
+                    8127120.012747609,
+                    7976046.897867616,
+                    8053972.151014054,
+                    8007279.3515773015,
+                    8055577.015134771,
+                    8022608.015249929,
+                    8140665.638525447,
+                    8067520.486977537
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9791047.347474009,
+            "scoreError" : 530841.8596004908,
+            "scoreConfidence" : [
+                9260205.487873519,
+                1.0321889207074499E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9094531.980367033,
+                "50.0" : 9822844.187382491,
+                "90.0" : 1.0461426568718258E7,
+                "95.0" : 1.0473999051972631E7,
+                "99.0" : 1.04745165852325E7,
+                "99.9" : 1.04745165852325E7,
+                "99.99" : 1.04745165852325E7,
+                "99.999" : 1.04745165852325E7,
+                "99.9999" : 1.04745165852325E7,
+                "100.0" : 1.04745165852325E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9240107.530957542,
+                    9364138.380778622,
+                    9202910.350529669,
+                    9172538.247869885,
+                    9206070.998052947,
+                    9189098.346187007,
+                    9094531.980367033,
+                    9141380.18472957,
+                    9176592.03906542,
+                    9199237.052123826
+                ],
+                [
+                    1.04745165852325E7,
+                    1.046416592003514E7,
+                    1.0436772406866318E7,
+                    1.0330403077371966E7,
+                    1.0353288151745386E7,
+                    1.0357469486511137E7,
+                    1.0426473364255404E7,
+                    1.0382852450250871E7,
+                    1.0326850402563572E7,
+                    1.028154999398636E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6799514981160912E8,
+            "scoreError" : 3373631.606683123,
+            "scoreConfidence" : [
+                1.6462151820492598E8,
+                1.7136878141829225E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6190372795542586E8,
+                "50.0" : 1.6889729975728044E8,
+                "90.0" : 1.7177429262855798E8,
+                "95.0" : 1.7249252044144094E8,
+                "99.0" : 1.7253000662906185E8,
+                "99.9" : 1.7253000662906185E8,
+                "99.99" : 1.7253000662906185E8,
+                "99.999" : 1.7253000662906185E8,
+                "99.9999" : 1.7253000662906185E8,
+                "100.0" : 1.7253000662906185E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7253000662906185E8,
+                    1.715026381412241E8,
+                    1.7178028287664363E8,
+                    1.71720380395787E8,
+                    1.7166356208825156E8,
+                    1.717161388266651E8,
+                    1.7145150184911925E8,
+                    1.7102103122815523E8,
+                    1.713916303037969E8,
+                    1.713110907195472E8
+                ],
+                [
+                    1.63972452757046E8,
+                    1.6190372795542586E8,
+                    1.6395043548442507E8,
+                    1.6209554011715567E8,
+                    1.6565190831191608E8,
+                    1.6575097332297736E8,
+                    1.6437476341004133E8,
+                    1.6677356828640565E8,
+                    1.6591381176980284E8,
+                    1.634275517587345E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1917560481188676E8,
+            "scoreError" : 1069415.771338823,
+            "scoreConfidence" : [
+                1.1810618904054794E8,
+                1.2024502058322558E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.168510309071278E8,
+                "50.0" : 1.1975663856639734E8,
+                "90.0" : 1.2021429811125433E8,
+                "95.0" : 1.2046167984125032E8,
+                "99.0" : 1.204746298235374E8,
+                "99.9" : 1.204746298235374E8,
+                "99.99" : 1.204746298235374E8,
+                "99.999" : 1.204746298235374E8,
+                "99.9999" : 1.204746298235374E8,
+                "100.0" : 1.204746298235374E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2002426726815489E8,
+                    1.1685769373859695E8,
+                    1.168510309071278E8,
+                    1.1887338127778766E8,
+                    1.1961534022134626E8,
+                    1.1742809869710898E8,
+                    1.1706512699366626E8,
+                    1.2020230951238166E8,
+                    1.1988102872486575E8,
+                    1.1780960117234354E8
+                ],
+                [
+                    1.197709800868437E8,
+                    1.1974229704595098E8,
+                    1.1931001886520329E8,
+                    1.2021563017779574E8,
+                    1.204746298235374E8,
+                    1.2011585217884745E8,
+                    1.198278615692526E8,
+                    1.2002513447639973E8,
+                    1.1985782106498586E8,
+                    1.1956399243553887E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3734646.081797889,
+            "scoreError" : 43604.73787197137,
+            "scoreConfidence" : [
+                3691041.3439259175,
+                3778250.8196698604
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3623451.138238501,
+                "50.0" : 3749231.9940793784,
+                "90.0" : 3784928.4978900123,
+                "95.0" : 3792729.9959183284,
+                "99.0" : 3793139.9453877117,
+                "99.9" : 3793139.9453877117,
+                "99.99" : 3793139.9453877117,
+                "99.999" : 3793139.9453877117,
+                "99.9999" : 3793139.9453877117,
+                "100.0" : 3793139.9453877117
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3762310.4842466414,
+                    3699497.9623869723,
+                    3753268.3946678173,
+                    3629957.4987584683,
+                    3677271.345402944,
+                    3766250.168156601,
+                    3767328.5750681567,
+                    3684404.4182485957,
+                    3741736.5375586487,
+                    3623451.138238501
+                ],
+                [
+                    3707849.7043844284,
+                    3771957.6475005816,
+                    3724146.235212334,
+                    3784816.374899708,
+                    3784940.9560000463,
+                    3793139.9453877117,
+                    3725566.318656683,
+                    3765445.9055108735,
+                    3745195.593490939,
+                    3784386.432181125
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.76756086688221E7,
+            "scoreError" : 1719472.9012563366,
+            "scoreConfidence" : [
+                1.5956135767565763E7,
+                1.9395081570078436E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.4996680995739028E7,
+                "50.0" : 1.777557288874591E7,
+                "90.0" : 1.972231809996578E7,
+                "95.0" : 1.974354039880808E7,
+                "99.0" : 1.9744224133470774E7,
+                "99.9" : 1.9744224133470774E7,
+                "99.99" : 1.9744224133470774E7,
+                "99.999" : 1.9744224133470774E7,
+                "99.9999" : 1.9744224133470774E7,
+                "100.0" : 1.9744224133470774E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.559040226057421E7,
+                    1.5536880307088904E7,
+                    1.568116242823181E7,
+                    1.587230794697498E7,
+                    1.4996680995739028E7,
+                    1.546028902175113E7,
+                    1.607802349110631E7,
+                    1.610359792567276E7,
+                    1.6189340498510059E7,
+                    1.6134793120209731E7
+                ],
+                [
+                    1.9461046856859583E7,
+                    1.950262276552516E7,
+                    1.961535766783753E7,
+                    1.9648236037705284E7,
+                    1.9361805278981764E7,
+                    1.9631415647513267E7,
+                    1.961039896253647E7,
+                    1.9744224133470774E7,
+                    1.956303858993628E7,
+                    1.9730549440216947E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.742337665910038E7,
+            "scoreError" : 1494770.4569867514,
+            "scoreConfidence" : [
+                1.5928606202113628E7,
+                1.891814711608713E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.070784389480445E7,
+                "50.0" : 1.7942412388327096E7,
+                "90.0" : 1.8184171972954486E7,
+                "95.0" : 1.8197459179698315E7,
+                "99.0" : 1.8197956412444644E7,
+                "99.9" : 1.8197956412444644E7,
+                "99.99" : 1.8197956412444644E7,
+                "99.999" : 1.8197956412444644E7,
+                "99.9999" : 1.8197956412444644E7,
+                "100.0" : 1.8197956412444644E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.786365003439411E7,
+                    1.7920587283310756E7,
+                    1.7964237493343435E7,
+                    1.7888518381641243E7,
+                    1.7647140037197158E7,
+                    1.758518257425496E7,
+                    1.7910645865517203E7,
+                    1.797061144269506E7,
+                    1.7459607787760496E7,
+                    1.7767223840299398E7
+                ],
+                [
+                    1.8197956412444644E7,
+                    1.814961391188208E7,
+                    1.8136077119897224E7,
+                    1.070784389480445E7,
+                    1.5007108066360934E7,
+                    1.8188011757518087E7,
+                    1.809038382433946E7,
+                    1.804093570606085E7,
+                    1.800682648592147E7,
+                    1.796537126236466E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.9481974691449165E7,
+            "scoreError" : 401317.6845103662,
+            "scoreConfidence" : [
+                1.90806570069388E7,
+                1.988329237595953E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.8855272601422656E7,
+                "50.0" : 1.9380319157600485E7,
+                "90.0" : 2.017723171692711E7,
+                "95.0" : 2.02453532430385E7,
+                "99.0" : 2.0248791330302477E7,
+                "99.9" : 2.0248791330302477E7,
+                "99.99" : 2.0248791330302477E7,
+                "99.999" : 2.0248791330302477E7,
+                "99.9999" : 2.0248791330302477E7,
+                "100.0" : 2.0248791330302477E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.8948272718973573E7,
+                    1.904826649214803E7,
+                    1.9043503847486142E7,
+                    1.921251523568344E7,
+                    1.8855272601422656E7,
+                    1.89266868318281E7,
+                    1.9234524843741354E7,
+                    1.9232429232376497E7,
+                    1.9156016299550336E7,
+                    1.935212356016796E7
+                ],
+                [
+                    2.006666567112173E7,
+                    2.0248791330302477E7,
+                    2.0180029585022975E7,
+                    1.980966493514359E7,
+                    1.9690082478016E7,
+                    1.940851475503301E7,
+                    1.952571411289773E7,
+                    1.9476052834933747E7,
+                    2.0072315559069503E7,
+                    2.015205090406433E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.642869109993888E8,
+            "scoreError" : 5458660.205713657,
+            "scoreConfidence" : [
+                3.588282507936752E8,
+                3.6974557120510244E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.468809322884238E8,
+                "50.0" : 3.651806033193079E8,
+                "90.0" : 3.720519356935478E8,
+                "95.0" : 3.739341816135672E8,
+                "99.0" : 3.7402530814730227E8,
+                "99.9" : 3.7402530814730227E8,
+                "99.99" : 3.7402530814730227E8,
+                "99.999" : 3.7402530814730227E8,
+                "99.9999" : 3.7402530814730227E8,
+                "100.0" : 3.7402530814730227E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.694001503698659E8,
+                    3.662119109044543E8,
+                    3.654168193850033E8,
+                    3.5895959812526894E8,
+                    3.524728589580397E8,
+                    3.610011750039245E8,
+                    3.633418008434646E8,
+                    3.6568326615693235E8,
+                    3.6849201533050543E8,
+                    3.7402530814730227E8
+                ],
+                [
+                    3.468809322884238E8,
+                    3.649443872536125E8,
+                    3.667644536416726E8,
+                    3.722027774726004E8,
+                    3.6284062990548867E8,
+                    3.663169650777398E8,
+                    3.620167632888679E8,
+                    3.646782646129866E8,
+                    3.6339378353954905E8,
+                    3.7069435968207425E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7251628680042785E8,
+            "scoreError" : 1.0892541074033964E7,
+            "scoreConfidence" : [
+                2.6162374572639388E8,
+                2.834088278744618E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.528481216537736E8,
+                "50.0" : 2.714774360046332E8,
+                "90.0" : 2.909677995809131E8,
+                "95.0" : 2.915862559675558E8,
+                "99.0" : 2.9158790141972655E8,
+                "99.9" : 2.9158790141972655E8,
+                "99.99" : 2.9158790141972655E8,
+                "99.999" : 2.9158790141972655E8,
+                "99.9999" : 2.9158790141972655E8,
+                "100.0" : 2.9158790141972655E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.8454878772253317E8,
+                    2.814689383346121E8,
+                    2.8080851033617723E8,
+                    2.7733128059568673E8,
+                    2.808596774013842E8,
+                    2.856830644223226E8,
+                    2.915549923763121E8,
+                    2.9158790141972655E8,
+                    2.8263716631081104E8,
+                    2.834200216058356E8
+                ],
+                [
+                    2.639438070483465E8,
+                    2.643343337126642E8,
+                    2.6110186095722497E8,
+                    2.656235914135797E8,
+                    2.528481216537736E8,
+                    2.559958227165658E8,
+                    2.5940193728661722E8,
+                    2.6478116713978353E8,
+                    2.583511457923052E8,
+                    2.640436077622958E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4524803.983685267,
+            "scoreError" : 69094.22074143743,
+            "scoreConfidence" : [
+                4455709.762943829,
+                4593898.204426705
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4267110.302860397,
+                "50.0" : 4515039.708726857,
+                "90.0" : 4608826.76817402,
+                "95.0" : 4632748.006842309,
+                "99.0" : 4633937.1450287085,
+                "99.9" : 4633937.1450287085,
+                "99.99" : 4633937.1450287085,
+                "99.999" : 4633937.1450287085,
+                "99.9999" : 4633937.1450287085,
+                "100.0" : 4633937.1450287085
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4610154.381300719,
+                    4517120.581342703,
+                    4549395.870607395,
+                    4592300.176906508,
+                    4633937.1450287085,
+                    4267110.302860397,
+                    4509422.794334845,
+                    4577954.054467508,
+                    4583626.04862545,
+                    4596878.250033725
+                ],
+                [
+                    4588089.029143375,
+                    4490186.567923106,
+                    4512958.836111012,
+                    4511440.191938889,
+                    4485987.510762884,
+                    4529889.068003305,
+                    4498538.567596584,
+                    4502644.431321649,
+                    4510103.866878835,
+                    4428341.998517742
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.46084655979577E7,
+            "scoreError" : 393410.27488806786,
+            "scoreConfidence" : [
+                4.421505532306963E7,
+                4.500187587284577E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.385364224976002E7,
+                "50.0" : 4.4747517080093905E7,
+                "90.0" : 4.5154977222046606E7,
+                "95.0" : 4.5192472518235184E7,
+                "99.0" : 4.519425897090231E7,
+                "99.9" : 4.519425897090231E7,
+                "99.99" : 4.519425897090231E7,
+                "99.999" : 4.519425897090231E7,
+                "99.9999" : 4.519425897090231E7,
+                "100.0" : 4.519425897090231E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.462414448305997E7,
+                    4.4205952948220246E7,
+                    4.420574368687704E7,
+                    4.385364224976002E7,
+                    4.395599458138228E7,
+                    4.465369049793525E7,
+                    4.474026650359047E7,
+                    4.4322804441369414E7,
+                    4.3926024121179305E7,
+                    4.39335910001995E7
+                ],
+                [
+                    4.515852991755975E7,
+                    4.475476765659733E7,
+                    4.480372994400812E7,
+                    4.492567996007802E7,
+                    4.502253547013286E7,
+                    4.483147182384199E7,
+                    4.489891464977786E7,
+                    4.512300296242827E7,
+                    4.519425897090231E7,
+                    4.503456609025406E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEmptyBenchmark.kindlingsEmpty",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6265512442925935E9,
+            "scoreError" : 4.091485449619559E7,
+            "scoreConfidence" : [
+                1.585636389796398E9,
+                1.667466098788789E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.497585385100851E9,
+                "50.0" : 1.6198735699091344E9,
+                "90.0" : 1.6851179144291644E9,
+                "95.0" : 1.6920966913655996E9,
+                "99.0" : 1.6924192104054286E9,
+                "99.9" : 1.6924192104054286E9,
+                "99.99" : 1.6924192104054286E9,
+                "99.999" : 1.6924192104054286E9,
+                "99.9999" : 1.6924192104054286E9,
+                "100.0" : 1.6924192104054286E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.597253714877793E9,
+                    1.5819326754362788E9,
+                    1.5971752020781865E9,
+                    1.5817098789326692E9,
+                    1.6051179344300358E9,
+                    1.6105802936826403E9,
+                    1.497585385100851E9,
+                    1.6132146198862138E9,
+                    1.60812309633871E9,
+                    1.597302682782475E9
+                ],
+                [
+                    1.643717259176656E9,
+                    1.6516130125586927E9,
+                    1.6859688296088507E9,
+                    1.6924192104054286E9,
+                    1.6685143051447773E9,
+                    1.6619204655393775E9,
+                    1.6574712832482498E9,
+                    1.6754128388799334E9,
+                    1.6774596778119874E9,
+                    1.626532519932055E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEmptyBenchmark.originalSemiAutoEmpty",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5715003631585345E9,
+            "scoreError" : 2.5301658024560656E7,
+            "scoreConfidence" : [
+                1.5461987051339738E9,
+                1.5968020211830952E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.497065059759899E9,
+                "50.0" : 1.571748997389854E9,
+                "90.0" : 1.6048901698495712E9,
+                "95.0" : 1.618976733214773E9,
+                "99.0" : 1.6197010269633217E9,
+                "99.9" : 1.6197010269633217E9,
+                "99.99" : 1.6197010269633217E9,
+                "99.999" : 1.6197010269633217E9,
+                "99.9999" : 1.6197010269633217E9,
+                "100.0" : 1.6197010269633217E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.574153846155683E9,
+                    1.5937773826619031E9,
+                    1.601965330564585E9,
+                    1.5614657463769317E9,
+                    1.6052151519923475E9,
+                    1.6197010269633217E9,
+                    1.5934705943654084E9,
+                    1.569344148624025E9,
+                    1.5828888552438338E9,
+                    1.5946477461349397E9
+                ],
+                [
+                    1.532594387403558E9,
+                    1.583391129280686E9,
+                    1.5883107036340747E9,
+                    1.497065059759899E9,
+                    1.5320647348382666E9,
+                    1.5682452177893322E9,
+                    1.5679481037586703E9,
+                    1.5588467174338698E9,
+                    1.547781598305792E9,
+                    1.5571297818835628E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEqBenchmark.kindlingsSimpleCCEqual",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0015750902928142E8,
+            "scoreError" : 791075.3027973941,
+            "scoreConfidence" : [
+                9.936643372648403E7,
+                1.0094858433207881E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.816114995132935E7,
+                "50.0" : 1.0020322904101394E8,
+                "90.0" : 1.0140942372133078E8,
+                "95.0" : 1.0156379504519157E8,
+                "99.0" : 1.015712868037417E8,
+                "99.9" : 1.015712868037417E8,
+                "99.99" : 1.015712868037417E8,
+                "99.999" : 1.015712868037417E8,
+                "99.9999" : 1.015712868037417E8,
+                "100.0" : 1.015712868037417E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0020876072293214E8,
+                    1.0101841681627789E8,
+                    1.0142145163273916E8,
+                    1.0019769735909574E8,
+                    9.961640315605862E7,
+                    9.922185253599867E7,
+                    1.0030733703215282E8,
+                    1.0072100545066012E8,
+                    9.999280234814188E7,
+                    1.011412133739001E8
+                ],
+                [
+                    1.0130117251865537E8,
+                    1.002259163252417E8,
+                    1.0036319488687839E8,
+                    9.816114995132935E7,
+                    1.015712868037417E8,
+                    9.993129290146486E7,
+                    9.851466344313498E7,
+                    9.93484765142217E7,
+                    9.97346835316697E7,
+                    1.0015140328133357E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEqBenchmark.kindlingsSimpleCCNotEqual",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.498450149565053E8,
+            "scoreError" : 1.1019392029160077E7,
+            "scoreConfidence" : [
+                5.388256229273453E8,
+                5.608644069856653E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.2099863489916617E8,
+                "50.0" : 5.52765199528108E8,
+                "90.0" : 5.62591340641288E8,
+                "95.0" : 5.693090185663118E8,
+                "99.0" : 5.696510390740696E8,
+                "99.9" : 5.696510390740696E8,
+                "99.99" : 5.696510390740696E8,
+                "99.999" : 5.696510390740696E8,
+                "99.9999" : 5.696510390740696E8,
+                "100.0" : 5.696510390740696E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.544866188360298E8,
+                    5.520793182300513E8,
+                    5.606177461426499E8,
+                    5.604229334389812E8,
+                    5.573719114276304E8,
+                    5.579296090993291E8,
+                    5.500031452958761E8,
+                    5.534510808261647E8,
+                    5.467313776517519E8,
+                    5.499301915703568E8
+                ],
+                [
+                    5.248286364183275E8,
+                    5.427242508027447E8,
+                    5.696510390740696E8,
+                    5.2099863489916617E8,
+                    5.604349375006728E8,
+                    5.628106289189146E8,
+                    5.470292925742259E8,
+                    5.413945884747763E8,
+                    5.537687893546932E8,
+                    5.302355685936933E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEqBenchmark.originalAutoSimpleCCEqual",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.5512787285385326E7,
+            "scoreError" : 484008.29211197514,
+            "scoreConfidence" : [
+                4.502877899327335E7,
+                4.59967955774973E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.4352778155980565E7,
+                "50.0" : 4.554429459415744E7,
+                "90.0" : 4.635258909605368E7,
+                "95.0" : 4.6391158556386925E7,
+                "99.0" : 4.6392829431811586E7,
+                "99.9" : 4.6392829431811586E7,
+                "99.99" : 4.6392829431811586E7,
+                "99.999" : 4.6392829431811586E7,
+                "99.9999" : 4.6392829431811586E7,
+                "100.0" : 4.6392829431811586E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.563748362382615E7,
+                    4.598028499500464E7,
+                    4.595094997624635E7,
+                    4.573038647186781E7,
+                    4.5685922147104725E7,
+                    4.575125474951832E7,
+                    4.5463492739810504E7,
+                    4.63594119233184E7,
+                    4.6392829431811586E7,
+                    4.629118365067121E7
+                ],
+                [
+                    4.496181576448974E7,
+                    4.5440419781034194E7,
+                    4.549695872270842E7,
+                    4.5591630465606466E7,
+                    4.510591542040638E7,
+                    4.523503812909013E7,
+                    4.4819204882560164E7,
+                    4.4352778155980565E7,
+                    4.459120690047589E7,
+                    4.541757777617476E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEqBenchmark.originalSemiAutoSimpleCCEqual",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.611506537687406E7,
+            "scoreError" : 580018.3308718222,
+            "scoreConfidence" : [
+                4.553504704600224E7,
+                4.669508370774588E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.37546770436107E7,
+                "50.0" : 4.6241895345191725E7,
+                "90.0" : 4.672660287818433E7,
+                "95.0" : 4.67456612687574E7,
+                "99.0" : 4.674641080485977E7,
+                "99.9" : 4.674641080485977E7,
+                "99.99" : 4.674641080485977E7,
+                "99.999" : 4.674641080485977E7,
+                "99.9999" : 4.674641080485977E7,
+                "100.0" : 4.674641080485977E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.639125152118029E7,
+                    4.6536930551569514E7,
+                    4.673142008281234E7,
+                    4.5987310472027816E7,
+                    4.6595167735303156E7,
+                    4.674641080485977E7,
+                    4.5347752521706514E7,
+                    4.584450271703847E7,
+                    4.37546770436107E7,
+                    4.5664878756289385E7
+                ],
+                [
+                    4.637487837513671E7,
+                    4.626992806534736E7,
+                    4.6353945631961815E7,
+                    4.614467788074507E7,
+                    4.593026772052315E7,
+                    4.607172836311202E7,
+                    4.605394371519667E7,
+                    4.621386262503609E7,
+                    4.660452491749224E7,
+                    4.668324803653225E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsFoldableBenchmark.kindlingsSimpleCCBoxFoldLeft",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6040957079321294E9,
+            "scoreError" : 3.775271756820907E7,
+            "scoreConfidence" : [
+                1.5663429903639202E9,
+                1.6418484255003386E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.497788502031414E9,
+                "50.0" : 1.6152304768722754E9,
+                "90.0" : 1.6459632240241807E9,
+                "95.0" : 1.6684578244590454E9,
+                "99.0" : 1.6696417071249938E9,
+                "99.9" : 1.6696417071249938E9,
+                "99.99" : 1.6696417071249938E9,
+                "99.999" : 1.6696417071249938E9,
+                "99.9999" : 1.6696417071249938E9,
+                "100.0" : 1.6696417071249938E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6459640538060265E9,
+                    1.497788502031414E9,
+                    1.5867944961168175E9,
+                    1.645955755987568E9,
+                    1.573717639393278E9,
+                    1.6113118660012631E9,
+                    1.592865672964692E9,
+                    1.5400360956474192E9,
+                    1.6696417071249938E9,
+                    1.6141662989288323E9
+                ],
+                [
+                    1.6399951585226877E9,
+                    1.5521108448659832E9,
+                    1.6379565694482253E9,
+                    1.6341025433069487E9,
+                    1.6291796694654548E9,
+                    1.6235270604040768E9,
+                    1.6190967031134455E9,
+                    1.6162946548157182E9,
+                    1.542733295974323E9,
+                    1.6086755707234175E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsFunctorBenchmark.kindlingsSimpleCCBoxMap",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.772604133311529E8,
+            "scoreError" : 9391508.463498846,
+            "scoreConfidence" : [
+                2.678689048676541E8,
+                2.8665192179465175E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.514293059109314E8,
+                "50.0" : 2.7753581709544814E8,
+                "90.0" : 2.892769149133371E8,
+                "95.0" : 2.895534644687873E8,
+                "99.0" : 2.8956773170665556E8,
+                "99.9" : 2.8956773170665556E8,
+                "99.99" : 2.8956773170665556E8,
+                "99.999" : 2.8956773170665556E8,
+                "99.9999" : 2.8956773170665556E8,
+                "100.0" : 2.8956773170665556E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.849819542431692E8,
+                    2.8922766658975565E8,
+                    2.869341139893615E8,
+                    2.871313290493657E8,
+                    2.8693909610725886E8,
+                    2.892823869492906E8,
+                    2.8956773170665556E8,
+                    2.889332681316792E8,
+                    2.7907191953493196E8,
+                    2.810121352221132E8
+                ],
+                [
+                    2.749756294615849E8,
+                    2.75284221755024E8,
+                    2.6919300398064953E8,
+                    2.7019613713431615E8,
+                    2.759997146559644E8,
+                    2.6506945175841773E8,
+                    2.655777856023143E8,
+                    2.6875736282802826E8,
+                    2.514293059109314E8,
+                    2.656440520122459E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsFunctorBenchmark.originalSemiAutoSimpleCCBoxMap",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5701491.884358095,
+            "scoreError" : 65949.94777698736,
+            "scoreConfidence" : [
+                5635541.936581108,
+                5767441.832135082
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5608308.609031837,
+                "50.0" : 5685919.8031171635,
+                "90.0" : 5836056.955150815,
+                "95.0" : 5840967.573562407,
+                "99.0" : 5841143.744681637,
+                "99.9" : 5841143.744681637,
+                "99.99" : 5841143.744681637,
+                "99.999" : 5841143.744681637,
+                "99.9999" : 5841143.744681637,
+                "100.0" : 5841143.744681637
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5627791.125039193,
+                    5620727.081959081,
+                    5612353.560642246,
+                    5646199.159936219,
+                    5652487.716876634,
+                    5646756.371318571,
+                    5664002.033779875,
+                    5608308.609031837,
+                    5630484.287941762,
+                    5719921.46072993
+                ],
+                [
+                    5775716.773980064,
+                    5837620.322297033,
+                    5841143.744681637,
+                    5821986.650834849,
+                    5756052.944962487,
+                    5740650.345885076,
+                    5752659.746296963,
+                    5703136.1447341135,
+                    5692650.048985237,
+                    5679189.557249091
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsHashBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.248658310899457E8,
+            "scoreError" : 7054082.411115492,
+            "scoreConfidence" : [
+                8.178117486788301E8,
+                8.319199135010612E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.085080744339585E8,
+                "50.0" : 8.262035305314695E8,
+                "90.0" : 8.353209628327883E8,
+                "95.0" : 8.366981515082339E8,
+                "99.0" : 8.367704557231339E8,
+                "99.9" : 8.367704557231339E8,
+                "99.99" : 8.367704557231339E8,
+                "99.999" : 8.367704557231339E8,
+                "99.9999" : 8.367704557231339E8,
+                "100.0" : 8.367704557231339E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.236885213599089E8,
+                    8.239705299881688E8,
+                    8.085080744339585E8,
+                    8.173081995933427E8,
+                    8.164560344325714E8,
+                    8.26926592141469E8,
+                    8.254804689214699E8,
+                    8.124794425343653E8,
+                    8.121018060864815E8,
+                    8.215996371298182E8
+                ],
+                [
+                    8.353243714251331E8,
+                    8.278371931252443E8,
+                    8.227154576779925E8,
+                    8.300559147668095E8,
+                    8.281583157912366E8,
+                    8.291670165866437E8,
+                    8.352902855016849E8,
+                    8.367704557231339E8,
+                    8.322883588850535E8,
+                    8.311899456944305E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsHashBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.744384958111673E7,
+            "scoreError" : 293708.422340005,
+            "scoreConfidence" : [
+                2.7150141158776723E7,
+                2.7737558003456734E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6625154211914103E7,
+                "50.0" : 2.7421318124523614E7,
+                "90.0" : 2.78420049432105E7,
+                "95.0" : 2.8158652970999576E7,
+                "99.0" : 2.8174776597767882E7,
+                "99.9" : 2.8174776597767882E7,
+                "99.99" : 2.8174776597767882E7,
+                "99.999" : 2.8174776597767882E7,
+                "99.9999" : 2.8174776597767882E7,
+                "100.0" : 2.8174776597767882E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.774931287048939E7,
+                    2.761058311504318E7,
+                    2.7575263184669137E7,
+                    2.7483078835970912E7,
+                    2.8174776597767882E7,
+                    2.7741056338538375E7,
+                    2.7313570958327107E7,
+                    2.7352319780941594E7,
+                    2.721219148972349E7,
+                    2.7016123107128404E7
+                ],
+                [
+                    2.6625154211914103E7,
+                    2.715802622289467E7,
+                    2.7328790439571727E7,
+                    2.7387012238328155E7,
+                    2.759082873631536E7,
+                    2.7454054534681626E7,
+                    2.773929531822883E7,
+                    2.73885817143656E7,
+                    2.7852304062401734E7,
+                    2.7124667865033377E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsHashBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7156574818841517E7,
+            "scoreError" : 358848.4662619039,
+            "scoreConfidence" : [
+                2.6797726352579612E7,
+                2.751542328510342E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6426309976759493E7,
+                "50.0" : 2.724466603356759E7,
+                "90.0" : 2.772287178303769E7,
+                "95.0" : 2.775288462477837E7,
+                "99.0" : 2.7754443062534202E7,
+                "99.9" : 2.7754443062534202E7,
+                "99.99" : 2.7754443062534202E7,
+                "99.999" : 2.7754443062534202E7,
+                "99.9999" : 2.7754443062534202E7,
+                "100.0" : 2.7754443062534202E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.7719249063618757E7,
+                    2.7525204756554328E7,
+                    2.7287192723601002E7,
+                    2.7332625791240577E7,
+                    2.723870977052176E7,
+                    2.744884132425654E7,
+                    2.772327430741757E7,
+                    2.7754443062534202E7,
+                    2.7609595238925915E7,
+                    2.713324567361598E7
+                ],
+                [
+                    2.6646104473482672E7,
+                    2.69953090332894E7,
+                    2.7250622296613418E7,
+                    2.662426979669065E7,
+                    2.674731107277272E7,
+                    2.7021003343384366E7,
+                    2.6783691977146246E7,
+                    2.6593105364151448E7,
+                    2.7271387330253262E7,
+                    2.6426309976759493E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsMonoidBenchmark.kindlingsCombine",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.927878867189573E8,
+            "scoreError" : 2060077.500175328,
+            "scoreConfidence" : [
+                1.9072780921878198E8,
+                1.9484796421913263E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.8743804549806958E8,
+                "50.0" : 1.9332434765960473E8,
+                "90.0" : 1.9533450943863013E8,
+                "95.0" : 1.9599663286814415E8,
+                "99.0" : 1.9603026477319527E8,
+                "99.9" : 1.9603026477319527E8,
+                "99.99" : 1.9603026477319527E8,
+                "99.999" : 1.9603026477319527E8,
+                "99.9999" : 1.9603026477319527E8,
+                "100.0" : 1.9603026477319527E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9460303403260517E8,
+                    1.9535762667217284E8,
+                    1.9400039619870603E8,
+                    1.925096044714043E8,
+                    1.9244932452895004E8,
+                    1.9441080977952573E8,
+                    1.938766327512547E8,
+                    1.9173989561013624E8,
+                    1.9323137616180652E8,
+                    1.8989056725836107E8
+                ],
+                [
+                    1.9131241623142806E8,
+                    1.9603026477319527E8,
+                    1.8743804549806958E8,
+                    1.8801232799116656E8,
+                    1.934173191574029E8,
+                    1.9512645433674583E8,
+                    1.9427912750606012E8,
+                    1.9043291720896336E8,
+                    1.928233475554491E8,
+                    1.9481624665574196E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsMonoidBenchmark.kindlingsEmpty",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.627297469847869E9,
+            "scoreError" : 2.3392802664315322E8,
+            "scoreConfidence" : [
+                3.3933694432047157E9,
+                3.861225496491022E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.823269060543338E9,
+                "50.0" : 3.7248497071237936E9,
+                "90.0" : 3.7620271210920525E9,
+                "95.0" : 3.7643210574471397E9,
+                "99.0" : 3.764425738171967E9,
+                "99.9" : 3.764425738171967E9,
+                "99.99" : 3.764425738171967E9,
+                "99.999" : 3.764425738171967E9,
+                "99.9999" : 3.764425738171967E9,
+                "100.0" : 3.764425738171967E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.6362051280129895E9,
+                    3.6566703299673877E9,
+                    3.6652483405915556E9,
+                    3.6582418042186193E9,
+                    3.646970507092069E9,
+                    3.7532323881071343E9,
+                    3.764425738171967E9,
+                    2.823269060543338E9,
+                    3.7412069734821715E9,
+                    3.7623321236754246E9
+                ],
+                [
+                    2.874916113415294E9,
+                    3.759282097841704E9,
+                    3.724436951385253E9,
+                    3.736247751476176E9,
+                    3.740049876371922E9,
+                    3.7372664446500297E9,
+                    3.725262462862334E9,
+                    3.693726525541682E9,
+                    3.7049949387624755E9,
+                    3.7419638407878633E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsMonoidBenchmark.originalSemiAutoCombine",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.896138445259923E7,
+            "scoreError" : 259697.1085294696,
+            "scoreConfidence" : [
+                4.870168734406976E7,
+                4.92210815611287E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.840470416393293E7,
+                "50.0" : 4.9020335860562295E7,
+                "90.0" : 4.934166954861442E7,
+                "95.0" : 4.94421509613315E7,
+                "99.0" : 4.944703629796422E7,
+                "99.9" : 4.944703629796422E7,
+                "99.99" : 4.944703629796422E7,
+                "99.999" : 4.944703629796422E7,
+                "99.9999" : 4.944703629796422E7,
+                "100.0" : 4.944703629796422E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.840470416393293E7,
+                    4.872575118443793E7,
+                    4.879737915090674E7,
+                    4.883213739200124E7,
+                    4.902799698638205E7,
+                    4.912205427677696E7,
+                    4.92579630041901E7,
+                    4.865105137554158E7,
+                    4.901267473474254E7,
+                    4.909915233702006E7
+                ],
+                [
+                    4.927272939835595E7,
+                    4.944703629796422E7,
+                    4.9163958429380774E7,
+                    4.934932956530981E7,
+                    4.904815472860984E7,
+                    4.8600895273512505E7,
+                    4.8966739307961695E7,
+                    4.8781300137156606E7,
+                    4.842887916224857E7,
+                    4.923780214555266E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsMonoidBenchmark.originalSemiAutoEmpty",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6742937502592318E9,
+            "scoreError" : 1.7765196264150303E7,
+            "scoreConfidence" : [
+                1.6565285539950814E9,
+                1.6920589465233822E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6380302534131126E9,
+                "50.0" : 1.671711647251264E9,
+                "90.0" : 1.7039018955467935E9,
+                "95.0" : 1.7056336482564814E9,
+                "99.0" : 1.705700084622361E9,
+                "99.9" : 1.705700084622361E9,
+                "99.99" : 1.705700084622361E9,
+                "99.999" : 1.705700084622361E9,
+                "99.9999" : 1.705700084622361E9,
+                "100.0" : 1.705700084622361E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6380302534131126E9,
+                    1.665751702096326E9,
+                    1.6486961396701024E9,
+                    1.6640707366590068E9,
+                    1.6710496886926992E9,
+                    1.6502593873936865E9,
+                    1.6971278533798168E9,
+                    1.6723736058098292E9,
+                    1.6548952840363588E9,
+                    1.6566103614404333E9
+                ],
+                [
+                    1.6994988857421114E9,
+                    1.6750571861577456E9,
+                    1.6610951630178628E9,
+                    1.6811976180425572E9,
+                    1.6996767397250137E9,
+                    1.704371357304769E9,
+                    1.705700084622361E9,
+                    1.6921125266916397E9,
+                    1.6620719942969568E9,
+                    1.686228436992248E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsOrderBenchmark.kindlingsSimpleCCCompare",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.2478465968734956E8,
+            "scoreError" : 3.607858692035642E7,
+            "scoreConfidence" : [
+                3.8870607276699317E8,
+                4.6086324660770595E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.744651690571537E8,
+                "50.0" : 4.267435468947258E8,
+                "90.0" : 4.691171552213376E8,
+                "95.0" : 4.692518910369781E8,
+                "99.0" : 4.692556130064274E8,
+                "99.9" : 4.692556130064274E8,
+                "99.99" : 4.692556130064274E8,
+                "99.999" : 4.692556130064274E8,
+                "99.9999" : 4.692556130064274E8,
+                "100.0" : 4.692556130064274E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.623365872668444E8,
+                    4.667987981614905E8,
+                    4.668929422577993E8,
+                    4.6854098965639985E8,
+                    4.692556130064274E8,
+                    4.644783258116004E8,
+                    4.6918117361744183E8,
+                    4.6291509333217424E8,
+                    4.601494991919787E8,
+                    4.5907407517959124E8
+                ],
+                [
+                    3.862631828592485E8,
+                    3.8634123635003704E8,
+                    3.802949148503404E8,
+                    3.8308395338501155E8,
+                    3.944130186098603E8,
+                    3.874614783013963E8,
+                    3.863681094832272E8,
+                    3.744651690571537E8,
+                    3.9234854729947484E8,
+                    3.75030486069494E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsOrderBenchmark.originalAutoSimpleCCCompare",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8778153952570105E8,
+            "scoreError" : 6473213.976369709,
+            "scoreConfidence" : [
+                3.813083255493313E8,
+                3.942547535020708E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.7367571623800427E8,
+                "50.0" : 3.8869237980714375E8,
+                "90.0" : 3.9608458824964887E8,
+                "95.0" : 3.983227833937349E8,
+                "99.0" : 3.984372045776802E8,
+                "99.9" : 3.984372045776802E8,
+                "99.99" : 3.984372045776802E8,
+                "99.999" : 3.984372045776802E8,
+                "99.9999" : 3.984372045776802E8,
+                "100.0" : 3.984372045776802E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.7813526693947744E8,
+                    3.941571058223895E8,
+                    3.7367571623800427E8,
+                    3.748800639237238E8,
+                    3.8582223138795954E8,
+                    3.8847382406264794E8,
+                    3.7935751764397085E8,
+                    3.9010417906088185E8,
+                    3.8809271768000364E8,
+                    3.7731702014327955E8
+                ],
+                [
+                    3.887416795938338E8,
+                    3.9399342394673884E8,
+                    3.9168686336262935E8,
+                    3.955068544075156E8,
+                    3.9096468819568986E8,
+                    3.8627473916471267E8,
+                    3.961487808987748E8,
+                    3.886430800204537E8,
+                    3.984372045776802E8,
+                    3.9521783344365346E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsOrderBenchmark.originalSemiAutoSimpleCCCompare",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.897478937812959E8,
+            "scoreError" : 5967220.975785131,
+            "scoreConfidence" : [
+                3.8378067280551076E8,
+                3.9571511475708103E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.7668427208804643E8,
+                "50.0" : 3.902731683624637E8,
+                "90.0" : 3.993758868959032E8,
+                "95.0" : 4.0215121879264915E8,
+                "99.0" : 4.0228419908274114E8,
+                "99.9" : 4.0228419908274114E8,
+                "99.99" : 4.0228419908274114E8,
+                "99.999" : 4.0228419908274114E8,
+                "99.9999" : 4.0228419908274114E8,
+                "100.0" : 4.0228419908274114E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.916113829039473E8,
+                    3.9661472666913605E8,
+                    4.0228419908274114E8,
+                    3.9025599985796416E8,
+                    3.7668427208804643E8,
+                    3.847725329246117E8,
+                    3.8090071974412256E8,
+                    3.88404277581836E8,
+                    3.902903368669632E8,
+                    3.916103619398808E8
+                ],
+                [
+                    3.9501620325469255E8,
+                    3.833778597975531E8,
+                    3.971375294309179E8,
+                    3.888055141118267E8,
+                    3.924452174928477E8,
+                    3.871581398584117E8,
+                    3.845804182879789E8,
+                    3.947288797388295E8,
+                    3.7865471071270776E8,
+                    3.996245932809016E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsSemigroupBenchmark.kindlingsCombine",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.940826261180778E8,
+            "scoreError" : 1994481.6410918308,
+            "scoreConfidence" : [
+                1.92088144476986E8,
+                1.9607710775916964E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.8979114549053612E8,
+                "50.0" : 1.94377553036385E8,
+                "90.0" : 1.970911885423586E8,
+                "95.0" : 1.975924218638662E8,
+                "99.0" : 1.9761499283474097E8,
+                "99.9" : 1.9761499283474097E8,
+                "99.99" : 1.9761499283474097E8,
+                "99.999" : 1.9761499283474097E8,
+                "99.9999" : 1.9761499283474097E8,
+                "100.0" : 1.9761499283474097E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9505981915764058E8,
+                    1.9429177974891397E8,
+                    1.9575241192894343E8,
+                    1.962712452756488E8,
+                    1.9543492921319157E8,
+                    1.902335889540275E8,
+                    1.9199925556567702E8,
+                    1.9217116561267006E8,
+                    1.94463326323856E8,
+                    1.9058060838463905E8
+                ],
+                [
+                    1.9761499283474097E8,
+                    1.9629218757106203E8,
+                    1.933518348657514E8,
+                    1.9407295490366107E8,
+                    1.9341835751546648E8,
+                    1.964397246683731E8,
+                    1.971635734172459E8,
+                    1.8979114549053612E8,
+                    1.9253130563479978E8,
+                    1.947183152947111E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsSemigroupBenchmark.originalSemiAutoCombine",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.427311231801411E7,
+            "scoreError" : 835662.8367317247,
+            "scoreConfidence" : [
+                5.343744948128238E7,
+                5.510877515474583E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.145195471237052E7,
+                "50.0" : 5.438421131249192E7,
+                "90.0" : 5.5440771708625086E7,
+                "95.0" : 5.5648918687508985E7,
+                "99.0" : 5.565925609441198E7,
+                "99.9" : 5.565925609441198E7,
+                "99.99" : 5.565925609441198E7,
+                "99.999" : 5.565925609441198E7,
+                "99.9999" : 5.565925609441198E7,
+                "100.0" : 5.565925609441198E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.4104286070875965E7,
+                    5.488168498717814E7,
+                    5.508094509762008E7,
+                    5.565925609441198E7,
+                    5.545250795635209E7,
+                    5.5335145479082055E7,
+                    5.443429659231686E7,
+                    5.350271794898355E7,
+                    5.353841209743795E7,
+                    5.145195471237052E7
+                ],
+                [
+                    5.433412603266698E7,
+                    5.4783721023730926E7,
+                    5.490343329862507E7,
+                    5.447935848758969E7,
+                    5.35522752599927E7,
+                    5.313502681017834E7,
+                    5.430282472031318E7,
+                    5.4188578846810624E7,
+                    5.37027471929989E7,
+                    5.463894765074674E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1854015.5115567339,
+            "scoreError" : 21788.05627767669,
+            "scoreConfidence" : [
+                1832227.4552790571,
+                1875803.5678344106
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1791229.496737595,
+                "50.0" : 1852931.0165162147,
+                "90.0" : 1885698.1278479868,
+                "95.0" : 1894191.5579512212,
+                "99.0" : 1894635.8537994884,
+                "99.9" : 1894635.8537994884,
+                "99.99" : 1894635.8537994884,
+                "99.999" : 1894635.8537994884,
+                "99.9999" : 1894635.8537994884,
+                "100.0" : 1894635.8537994884
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1852090.247280887,
+                    1847250.6821187676,
+                    1857056.3830188212,
+                    1791229.496737595,
+                    1816112.7591591375,
+                    1824112.8442926721,
+                    1839523.7761158475,
+                    1871368.2046710253,
+                    1852380.514051154,
+                    1881067.635819908
+                ],
+                [
+                    1870056.2586000771,
+                    1885231.8469725484,
+                    1894635.8537994884,
+                    1853481.5189812754,
+                    1858832.1757157983,
+                    1865869.5944610331,
+                    1885749.9368341465,
+                    1850059.4678353197,
+                    1846107.541133382,
+                    1838093.493535795
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1962559.8767803903,
+            "scoreError" : 45796.05443488595,
+            "scoreConfidence" : [
+                1916763.8223455043,
+                2008355.9312152762
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1874184.138073118,
+                "50.0" : 1958753.3683225983,
+                "90.0" : 2044260.6821389263,
+                "95.0" : 2045335.2349899171,
+                "99.0" : 2045340.5867128335,
+                "99.9" : 2045340.5867128335,
+                "99.99" : 2045340.5867128335,
+                "99.999" : 2045340.5867128335,
+                "99.9999" : 2045340.5867128335,
+                "100.0" : 2045340.5867128335
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1946066.740774342,
+                    1902954.251352453,
+                    1891291.9461973824,
+                    1940843.5125732424,
+                    1921374.2174534253,
+                    1874184.138073118,
+                    1928594.8096747368,
+                    1971439.9958708547,
+                    1942276.3794606256,
+                    1920445.8740564745
+                ],
+                [
+                    1994371.1158398492,
+                    1981907.051103576,
+                    1994547.74232778,
+                    1996516.1641602851,
+                    1994823.4317902057,
+                    1902862.3151652717,
+                    2045233.5522545062,
+                    2020618.8596681391,
+                    2045340.5867128335,
+                    2035504.8510987088
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.601989454742533E7,
+            "scoreError" : 1406166.7916985075,
+            "scoreConfidence" : [
+                8.461372775572683E7,
+                8.742606133912383E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.196837260615239E7,
+                "50.0" : 8.659519701294768E7,
+                "90.0" : 8.760788288382228E7,
+                "95.0" : 8.817796929039048E7,
+                "99.0" : 8.820661462523492E7,
+                "99.9" : 8.820661462523492E7,
+                "99.99" : 8.820661462523492E7,
+                "99.999" : 8.820661462523492E7,
+                "99.9999" : 8.820661462523492E7,
+                "100.0" : 8.820661462523492E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.574436759753916E7,
+                    8.594315017821896E7,
+                    8.671633964410639E7,
+                    8.593650631233972E7,
+                    8.388389091316658E7,
+                    8.196837260615239E7,
+                    8.555307150600818E7,
+                    8.404818856351818E7,
+                    8.422443467286918E7,
+                    8.399604649927759E7
+                ],
+                [
+                    8.703379183932006E7,
+                    8.820661462523492E7,
+                    8.763370792834619E7,
+                    8.733955955447015E7,
+                    8.707561707892835E7,
+                    8.73484723133666E7,
+                    8.737545748310708E7,
+                    8.679887831951089E7,
+                    8.709736893123701E7,
+                    8.647405438178895E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.822361563572931E7,
+            "scoreError" : 442380.7447289461,
+            "scoreConfidence" : [
+                3.778123489100037E7,
+                3.866599638045826E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.727725818515635E7,
+                "50.0" : 3.818997536367959E7,
+                "90.0" : 3.8907238018540055E7,
+                "95.0" : 3.9055043961242415E7,
+                "99.0" : 3.906266680148036E7,
+                "99.9" : 3.906266680148036E7,
+                "99.99" : 3.906266680148036E7,
+                "99.999" : 3.906266680148036E7,
+                "99.9999" : 3.906266680148036E7,
+                "100.0" : 3.906266680148036E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.790562846638947E7,
+                    3.880890532847134E7,
+                    3.7809275209069334E7,
+                    3.744903265424472E7,
+                    3.7782065432583295E7,
+                    3.727725818515635E7,
+                    3.826887772086959E7,
+                    3.803685291500338E7,
+                    3.777538593484014E7,
+                    3.817355696970477E7
+                ],
+                [
+                    3.868848881017036E7,
+                    3.773915630013383E7,
+                    3.82063937576544E7,
+                    3.813898491235781E7,
+                    3.867996263834942E7,
+                    3.8535081782019526E7,
+                    3.891020999672152E7,
+                    3.888049021490686E7,
+                    3.906266680148036E7,
+                    3.834403868445985E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 619871.1477753011,
+            "scoreError" : 5990.590947969303,
+            "scoreConfidence" : [
+                613880.5568273318,
+                625861.7387232705
+            ],
+            "scorePercentiles" : {
+                "0.0" : 606852.4674040177,
+                "50.0" : 618961.7129567186,
+                "90.0" : 630454.0673180603,
+                "95.0" : 631496.3992254803,
+                "99.0" : 631547.4452944815,
+                "99.9" : 631547.4452944815,
+                "99.99" : 631547.4452944815,
+                "99.999" : 631547.4452944815,
+                "99.9999" : 631547.4452944815,
+                "100.0" : 631547.4452944815
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    615792.7483062234,
+                    606852.4674040177,
+                    618431.8109870618,
+                    616885.240960041,
+                    625407.8567765773,
+                    621753.6074898728,
+                    624009.7010400634,
+                    630526.5239144574,
+                    615974.7615169302,
+                    608426.6540372116
+                ],
+                [
+                    609849.9910685659,
+                    619201.8325244484,
+                    631547.4452944815,
+                    629801.9579504862,
+                    624293.9531191268,
+                    619772.2767520299,
+                    616616.3795783845,
+                    618721.5933889888,
+                    625060.8178092455,
+                    618495.3355878063
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 804398.1720001022,
+            "scoreError" : 7867.412214879509,
+            "scoreConfidence" : [
+                796530.7597852227,
+                812265.5842149818
+            ],
+            "scorePercentiles" : {
+                "0.0" : 784920.7875206175,
+                "50.0" : 803960.2981697303,
+                "90.0" : 814411.1708431897,
+                "95.0" : 815629.3725986154,
+                "99.0" : 815684.4659994723,
+                "99.9" : 815684.4659994723,
+                "99.99" : 815684.4659994723,
+                "99.999" : 815684.4659994723,
+                "99.9999" : 815684.4659994723,
+                "100.0" : 815684.4659994723
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    810327.6042879288,
+                    815684.4659994723,
+                    802134.9297209383,
+                    811270.7701919759,
+                    812868.3265908941,
+                    784920.7875206175,
+                    810948.6117854245,
+                    802179.6392739868,
+                    803752.1858104859,
+                    802662.515590166
+                ],
+                [
+                    803904.3135404049,
+                    803120.7206266245,
+                    801825.124174522,
+                    804016.2827990558,
+                    806081.1810032174,
+                    788974.400618596,
+                    814582.5979823336,
+                    812376.388964549,
+                    811356.2751019025,
+                    784976.3184189495
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.044914077861705E7,
+            "scoreError" : 1099238.7286555555,
+            "scoreConfidence" : [
+                9349902.049961494,
+                1.1548379507272607E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9120413.196045743,
+                "50.0" : 1.0230809959443325E7,
+                "90.0" : 1.1913389791945536E7,
+                "95.0" : 1.1932372569797093E7,
+                "99.0" : 1.1933127987520358E7,
+                "99.9" : 1.1933127987520358E7,
+                "99.99" : 1.1933127987520358E7,
+                "99.999" : 1.1933127987520358E7,
+                "99.9999" : 1.1933127987520358E7,
+                "100.0" : 1.1933127987520358E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1690331153643712E7,
+                    1.1825936032533381E7,
+                    1.1559705321104905E7,
+                    1.183546488676669E7,
+                    1.1933127987520358E7,
+                    1.1528909271565432E7,
+                    1.191801963305507E7,
+                    1.1871721221959714E7,
+                    1.1391336343124505E7,
+                    1.1139065363176676E7
+                ],
+                [
+                    9314545.874305084,
+                    9151411.483484909,
+                    9120413.196045743,
+                    9293013.735665467,
+                    9161313.705268875,
+                    9199883.252784321,
+                    9213636.415075185,
+                    9322554.555709975,
+                    9318498.571089923,
+                    9193927.568461083
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6984905.422867162,
+            "scoreError" : 801440.2049610029,
+            "scoreConfidence" : [
+                6183465.217906159,
+                7786345.627828165
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4272759.205751727,
+                "50.0" : 7341897.079766454,
+                "90.0" : 7477630.456973019,
+                "95.0" : 7506417.290774736,
+                "99.0" : 7507740.051286095,
+                "99.9" : 7507740.051286095,
+                "99.99" : 7507740.051286095,
+                "99.999" : 7507740.051286095,
+                "99.9999" : 7507740.051286095,
+                "100.0" : 7507740.051286095
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7444741.000199923,
+                    7507740.051286095,
+                    7443316.953710689,
+                    7442663.044290721,
+                    7253633.858130013,
+                    6859744.836800928,
+                    7129209.786861733,
+                    4272759.205751727,
+                    7481284.841058918,
+                    7430694.9009689735
+                ],
+                [
+                    7341878.396389244,
+                    7299232.664603821,
+                    7356575.124064518,
+                    7237744.94159659,
+                    7341915.763143665,
+                    7248663.525771957,
+                    7431202.513874816,
+                    7364024.592823473,
+                    4564865.821492169,
+                    6246216.634523292
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 602373.7192066305,
+            "scoreError" : 5870.866996800651,
+            "scoreConfidence" : [
+                596502.8522098298,
+                608244.5862034311
+            ],
+            "scorePercentiles" : {
+                "0.0" : 590193.1889097664,
+                "50.0" : 602494.1019198857,
+                "90.0" : 611987.5921212196,
+                "95.0" : 613329.1317935417,
+                "99.0" : 613396.6946113717,
+                "99.9" : 613396.6946113717,
+                "99.99" : 613396.6946113717,
+                "99.999" : 613396.6946113717,
+                "99.9999" : 613396.6946113717,
+                "100.0" : 613396.6946113717
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    606107.741638127,
+                    603151.0215246581,
+                    605583.042237274,
+                    607772.3581503022,
+                    601837.1823151135,
+                    596082.2228522699,
+                    598648.8775594726,
+                    599068.2309715548,
+                    597800.9151363766,
+                    591744.650351837
+                ],
+                [
+                    597685.983715106,
+                    607642.2941185615,
+                    612045.4382547721,
+                    611466.9769192477,
+                    593362.207212071,
+                    590193.1889097664,
+                    601311.9547697917,
+                    613396.6946113717,
+                    608176.5410840993,
+                    604396.8618008328
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6172453163335074E7,
+            "scoreError" : 381245.32341136335,
+            "scoreConfidence" : [
+                1.579120783992371E7,
+                1.6553698486746438E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.4874014432010865E7,
+                "50.0" : 1.6157607765298478E7,
+                "90.0" : 1.6614078422452101E7,
+                "95.0" : 1.668696863306256E7,
+                "99.0" : 1.6690708905813744E7,
+                "99.9" : 1.6690708905813744E7,
+                "99.99" : 1.6690708905813744E7,
+                "99.999" : 1.6690708905813744E7,
+                "99.9999" : 1.6690708905813744E7,
+                "100.0" : 1.6690708905813744E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6374897782093748E7,
+                    1.6433196693154167E7,
+                    1.6565183957880732E7,
+                    1.6615903450790046E7,
+                    1.6593929846826894E7,
+                    1.65976531674106E7,
+                    1.6545468849991E7,
+                    1.6690708905813744E7,
+                    1.6400174812440818E7,
+                    1.605284816959173E7
+                ],
+                [
+                    1.4874014432010865E7,
+                    1.5874181067098483E7,
+                    1.5761699655160416E7,
+                    1.559225435290984E7,
+                    1.5985571669920148E7,
+                    1.613798088642797E7,
+                    1.6074593006942911E7,
+                    1.5963587029640365E7,
+                    1.6147346687924558E7,
+                    1.6167868842672398E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 7473320.170749614,
+            "scoreError" : 55675.58320272934,
+            "scoreConfidence" : [
+                7417644.587546885,
+                7528995.753952343
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7326271.104169597,
+                "50.0" : 7474942.470088432,
+                "90.0" : 7547603.437450816,
+                "95.0" : 7596219.861864683,
+                "99.0" : 7598669.152315296,
+                "99.9" : 7598669.152315296,
+                "99.99" : 7598669.152315296,
+                "99.999" : 7598669.152315296,
+                "99.9999" : 7598669.152315296,
+                "100.0" : 7598669.152315296
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7528405.741067172,
+                    7520006.726036876,
+                    7445106.89232264,
+                    7451525.767925916,
+                    7444276.878024378,
+                    7495982.160189881,
+                    7496573.809382083,
+                    7426163.911502631,
+                    7326271.104169597,
+                    7454770.153399213
+                ],
+                [
+                    7452873.850983903,
+                    7437243.387084757,
+                    7598669.152315296,
+                    7522809.171887874,
+                    7549683.343303034,
+                    7409536.644601892,
+                    7528884.2847808525,
+                    7512431.07631025,
+                    7495114.78677765,
+                    7370074.572926365
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsFastShowPrettyPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1185356.1523531124,
+            "scoreError" : 12311.29470281006,
+            "scoreConfidence" : [
+                1173044.8576503024,
+                1197667.4470559224
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1164874.1137717736,
+                "50.0" : 1182256.8259935416,
+                "90.0" : 1209220.5851645123,
+                "95.0" : 1213717.0972983283,
+                "99.0" : 1213925.0980165454,
+                "99.9" : 1213925.0980165454,
+                "99.99" : 1213925.0980165454,
+                "99.999" : 1213925.0980165454,
+                "99.9999" : 1213925.0980165454,
+                "100.0" : 1213925.0980165454
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1188008.329884577,
+                    1204320.0987753037,
+                    1184231.4609413506,
+                    1179720.070346211,
+                    1202776.3037485825,
+                    1213925.0980165454,
+                    1209765.083652202,
+                    1198784.3803082313,
+                    1192646.5716050894,
+                    1188314.97166461
+                ],
+                [
+                    1169483.6316140536,
+                    1178988.6686040428,
+                    1173716.4817000441,
+                    1180821.170081184,
+                    1175178.1117215937,
+                    1173500.8577311793,
+                    1172139.5591897687,
+                    1164874.1137717736,
+                    1172235.6018000063,
+                    1183692.4819058992
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsFastShowPrettySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3542692872132096E7,
+            "scoreError" : 146283.03993801732,
+            "scoreConfidence" : [
+                1.3396409832194079E7,
+                1.3688975912070114E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.3023040332687829E7,
+                "50.0" : 1.360202260227156E7,
+                "90.0" : 1.366371149583693E7,
+                "95.0" : 1.3701382996831534E7,
+                "99.0" : 1.37033445577199E7,
+                "99.9" : 1.37033445577199E7,
+                "99.99" : 1.37033445577199E7,
+                "99.999" : 1.37033445577199E7,
+                "99.9999" : 1.37033445577199E7,
+                "100.0" : 1.37033445577199E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3552331389150934E7,
+                    1.3660094898795791E7,
+                    1.3648532290553456E7,
+                    1.3654754627603905E7,
+                    1.3643899079789251E7,
+                    1.3664113339952612E7,
+                    1.3647700489333956E7,
+                    1.3549409554785559E7,
+                    1.37033445577199E7,
+                    1.3630116682498384E7
+                ],
+                [
+                    1.362708735288488E7,
+                    1.35104783882116E7,
+                    1.3491860289604587E7,
+                    1.3635894639508242E7,
+                    1.3544125098409405E7,
+                    1.357695785165824E7,
+                    1.353634179023106E7,
+                    1.3271459805173963E7,
+                    1.3023040332687829E7,
+                    1.3282314984088378E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsShowPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1950597.242791038,
+            "scoreError" : 12993.776115191697,
+            "scoreConfidence" : [
+                1937603.4666758464,
+                1963591.0189062296
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1913491.8371647398,
+                "50.0" : 1953355.8109605066,
+                "90.0" : 1967582.3876870153,
+                "95.0" : 1975793.4588404763,
+                "99.0" : 1976206.5623421622,
+                "99.9" : 1976206.5623421622,
+                "99.99" : 1976206.5623421622,
+                "99.999" : 1976206.5623421622,
+                "99.9999" : 1976206.5623421622,
+                "100.0" : 1976206.5623421622
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1964323.4460941684,
+                    1939330.8639696692,
+                    1957608.6012501947,
+                    1950832.585943592,
+                    1963682.6743489655,
+                    1953693.7434258105,
+                    1947657.9768625905,
+                    1925452.5910938345,
+                    1934080.4455723495,
+                    1967944.4923084427
+                ],
+                [
+                    1959292.9993228521,
+                    1953017.8784952026,
+                    1954811.6855068428,
+                    1949500.3342746943,
+                    1913491.8371647398,
+                    1936384.4353529608,
+                    1960150.2679185763,
+                    1976206.5623421622,
+                    1957833.3886789074,
+                    1946648.0458942056
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsShowPrettyPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1919267.2450168065,
+            "scoreError" : 25658.591046964673,
+            "scoreConfidence" : [
+                1893608.6539698418,
+                1944925.8360637713
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1888989.3938333024,
+                "50.0" : 1907372.294684074,
+                "90.0" : 1985281.8472279203,
+                "95.0" : 1986325.6226487192,
+                "99.0" : 1986336.2312719617,
+                "99.9" : 1986336.2312719617,
+                "99.99" : 1986336.2312719617,
+                "99.999" : 1986336.2312719617,
+                "99.9999" : 1986336.2312719617,
+                "100.0" : 1986336.2312719617
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1913795.0992286762,
+                    1898247.1141513467,
+                    1901988.34537718,
+                    1906935.5232583464,
+                    1907809.0661098014,
+                    1918831.3656914693,
+                    1896460.4955761053,
+                    1898521.084349403,
+                    1906356.3055496898,
+                    1917045.70840235
+                ],
+                [
+                    1923167.7340302165,
+                    1903679.7267721633,
+                    1926257.027164175,
+                    1888989.3938333024,
+                    1896224.1354051786,
+                    1904341.2742989438,
+                    1926533.2680435346,
+                    1986336.2312719617,
+                    1986124.0588071144,
+                    1977701.9430151726
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsShowPrettySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.444370558758696E7,
+            "scoreError" : 462957.2570312857,
+            "scoreConfidence" : [
+                3.398074833055568E7,
+                3.4906662844618246E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.3485513656910352E7,
+                "50.0" : 3.451539297906169E7,
+                "90.0" : 3.525435366939385E7,
+                "95.0" : 3.5357518723720275E7,
+                "99.0" : 3.536201016499934E7,
+                "99.9" : 3.536201016499934E7,
+                "99.99" : 3.536201016499934E7,
+                "99.999" : 3.536201016499934E7,
+                "99.9999" : 3.536201016499934E7,
+                "100.0" : 3.536201016499934E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.4774903599541314E7,
+                    3.4832172642155394E7,
+                    3.536201016499934E7,
+                    3.49311354080397E7,
+                    3.509390463917617E7,
+                    3.450795234769696E7,
+                    3.360956474907349E7,
+                    3.452283361042643E7,
+                    3.527218133941804E7,
+                    3.417808047440898E7
+                ],
+                [
+                    3.431113888659766E7,
+                    3.4575206201748356E7,
+                    3.387951726187908E7,
+                    3.3812345819438085E7,
+                    3.3485513656910352E7,
+                    3.461954594247088E7,
+                    3.468674230230126E7,
+                    3.423337148654367E7,
+                    3.434107996568386E7,
+                    3.384491125323026E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsShowSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.9109227919228256E7,
+            "scoreError" : 195003.25374604273,
+            "scoreConfidence" : [
+                3.8914224665482216E7,
+                3.9304231172974296E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.857219590511188E7,
+                "50.0" : 3.911740858052204E7,
+                "90.0" : 3.947760059876394E7,
+                "95.0" : 3.953301680583017E7,
+                "99.0" : 3.9534643690884106E7,
+                "99.9" : 3.9534643690884106E7,
+                "99.99" : 3.9534643690884106E7,
+                "99.999" : 3.9534643690884106E7,
+                "99.9999" : 3.9534643690884106E7,
+                "100.0" : 3.9534643690884106E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.910451488690084E7,
+                    3.911084722359894E7,
+                    3.910942726512754E7,
+                    3.925705207939098E7,
+                    3.8918896410814114E7,
+                    3.857219590511188E7,
+                    3.875888668384749E7,
+                    3.915966179478226E7,
+                    3.915263615165901E7,
+                    3.919344471952943E7
+                ],
+                [
+                    3.920660134645033E7,
+                    3.9250213517169744E7,
+                    3.9102008082792014E7,
+                    3.885446919899937E7,
+                    3.908302242963992E7,
+                    3.9123969937445134E7,
+                    3.894258610169399E7,
+                    3.9534643690884106E7,
+                    3.9502105989805385E7,
+                    3.9247374968922496E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsTraverseBenchmark.kindlingsSimpleCCBoxTraverse",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.7083865715234655E8,
+            "scoreError" : 5791315.363685121,
+            "scoreConfidence" : [
+                1.6504734178866142E8,
+                1.7662997251603168E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6165782514780462E8,
+                "50.0" : 1.6891765618919635E8,
+                "90.0" : 1.7972647752554137E8,
+                "95.0" : 1.797710630689981E8,
+                "99.0" : 1.797723590825621E8,
+                "99.9" : 1.797723590825621E8,
+                "99.99" : 1.797723590825621E8,
+                "99.999" : 1.797723590825621E8,
+                "99.9999" : 1.797723590825621E8,
+                "100.0" : 1.797723590825621E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7954682595387113E8,
+                    1.7905289594084734E8,
+                    1.7974643881128252E8,
+                    1.797723590825621E8,
+                    1.7104513012565467E8,
+                    1.7376695902493125E8,
+                    1.7471211223854995E8,
+                    1.7495016768878826E8,
+                    1.7682957269968712E8,
+                    1.793417155579828E8
+                ],
+                [
+                    1.6309798616330075E8,
+                    1.6317411229706225E8,
+                    1.6165782514780462E8,
+                    1.643602759258892E8,
+                    1.6466342453083485E8,
+                    1.6663511181128237E8,
+                    1.6679018225273803E8,
+                    1.6642738756172344E8,
+                    1.6671754520929596E8,
+                    1.6448511502284294E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1014054.1832142038,
+            "scoreError" : 28102.919591208483,
+            "scoreConfidence" : [
+                985951.2636229953,
+                1042157.1028054123
+            ],
+            "scorePercentiles" : {
+                "0.0" : 968289.5931413537,
+                "50.0" : 1006030.0640446122,
+                "90.0" : 1051290.3957850125,
+                "95.0" : 1051796.9728563891,
+                "99.0" : 1051821.161376899,
+                "99.9" : 1051821.161376899,
+                "99.99" : 1051821.161376899,
+                "99.999" : 1051821.161376899,
+                "99.9999" : 1051821.161376899,
+                "100.0" : 1051821.161376899
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1051821.161376899,
+                    1051337.3909667018,
+                    1045850.823995593,
+                    1049498.983066278,
+                    1023411.4857035219,
+                    1036579.8887283251,
+                    1042758.4851091648,
+                    1045355.4217228704,
+                    1050867.4391498093,
+                    1050134.145747136
+                ],
+                [
+                    983984.5799544349,
+                    968289.5931413537,
+                    980720.9594764743,
+                    982231.8495099369,
+                    988648.6423857025,
+                    980851.8926159247,
+                    986247.9042379006,
+                    986696.7780499861,
+                    987229.8542714802,
+                    988566.3850745821
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1250413.23204098,
+            "scoreError" : 10065.165306507295,
+            "scoreConfidence" : [
+                1240348.0667344725,
+                1260478.3973474873
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1227257.6835245367,
+                "50.0" : 1250727.73679785,
+                "90.0" : 1265833.1040659605,
+                "95.0" : 1266885.3045326408,
+                "99.0" : 1266940.0788542384,
+                "99.9" : 1266940.0788542384,
+                "99.99" : 1266940.0788542384,
+                "99.999" : 1266940.0788542384,
+                "99.9999" : 1266940.0788542384,
+                "100.0" : 1266940.0788542384
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1266940.0788542384,
+                    1265844.5924222858,
+                    1265729.7088590336,
+                    1243869.9324789704,
+                    1256977.370058339,
+                    1250908.1103965738,
+                    1253529.008544507,
+                    1263219.3382856702,
+                    1263606.7339878716,
+                    1257950.2485003145
+                ],
+                [
+                    1235982.3256140444,
+                    1243866.0345288224,
+                    1235700.7405986935,
+                    1238505.784295094,
+                    1243368.5206338782,
+                    1241816.9442382911,
+                    1227257.6835245367,
+                    1256085.4786533455,
+                    1250547.3631991264,
+                    1246558.6431459647
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1216635072458718E7,
+            "scoreError" : 105388.45352394285,
+            "scoreConfidence" : [
+                1.1111246618934775E7,
+                1.1322023525982661E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1004379080810385E7,
+                "50.0" : 1.1203788926677736E7,
+                "90.0" : 1.1360540819174841E7,
+                "95.0" : 1.1363101006847315E7,
+                "99.0" : 1.1363163772745807E7,
+                "99.9" : 1.1363163772745807E7,
+                "99.99" : 1.1363163772745807E7,
+                "99.999" : 1.1363163772745807E7,
+                "99.9999" : 1.1363163772745807E7,
+                "100.0" : 1.1363163772745807E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1148971332989454E7,
+                    1.1164610051259058E7,
+                    1.1089297487254111E7,
+                    1.1011607125311831E7,
+                    1.1077232161649274E7,
+                    1.1160116085870128E7,
+                    1.1146884602014476E7,
+                    1.1165238110666135E7,
+                    1.1121894675388848E7,
+                    1.1004379080810385E7
+                ],
+                [
+                    1.1272217283448422E7,
+                    1.1242339742689336E7,
+                    1.130164524667677E7,
+                    1.1336345593555802E7,
+                    1.1348232098764818E7,
+                    1.1344129106214559E7,
+                    1.1361908454775956E7,
+                    1.1363163772745807E7,
+                    1.1329345341522153E7,
+                    1.1343144095567033E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9267765.839208579,
+            "scoreError" : 418293.58451034344,
+            "scoreConfidence" : [
+                8849472.254698236,
+                9686059.423718922
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8476787.07468407,
+                "50.0" : 9462188.174476843,
+                "90.0" : 9844283.117457034,
+                "95.0" : 9934369.445507424,
+                "99.0" : 9939070.716591557,
+                "99.9" : 9939070.716591557,
+                "99.99" : 9939070.716591557,
+                "99.999" : 9939070.716591557,
+                "99.9999" : 9939070.716591557,
+                "100.0" : 9939070.716591557
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9728281.301886862,
+                    9666945.688138595,
+                    9463115.562101135,
+                    9508227.498470817,
+                    8505822.554991841,
+                    9691694.138289826,
+                    8766258.53974976,
+                    8716610.339857195,
+                    9461260.786852553,
+                    8476787.07468407
+                ],
+                [
+                    8886506.094036298,
+                    9068520.237126278,
+                    9028575.643602213,
+                    9939070.716591557,
+                    8833714.236126779,
+                    9545047.87736921,
+                    8783528.49551024,
+                    9845045.294908877,
+                    9602881.183487028,
+                    9837423.520390447
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsNoBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 736441.748527491,
+            "scoreError" : 11458.823676263743,
+            "scoreConfidence" : [
+                724982.9248512272,
+                747900.5722037548
+            ],
+            "scorePercentiles" : {
+                "0.0" : 695337.5370631876,
+                "50.0" : 739567.1236057249,
+                "90.0" : 749053.9097668981,
+                "95.0" : 749217.7641491946,
+                "99.0" : 749224.9230069775,
+                "99.9" : 749224.9230069775,
+                "99.99" : 749224.9230069775,
+                "99.999" : 749224.9230069775,
+                "99.9999" : 749224.9230069775,
+                "100.0" : 749224.9230069775
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    741012.4705979169,
+                    734323.8367542999,
+                    737120.6301470354,
+                    738915.1474764699,
+                    748803.3850071044,
+                    749224.9230069775,
+                    749081.7458513196,
+                    738863.6388722403,
+                    708821.0650410762,
+                    695337.5370631876
+                ],
+                [
+                    731281.0112024061,
+                    728816.7529499556,
+                    733773.7656114043,
+                    738185.025095289,
+                    740687.2453868884,
+                    740219.0997349799,
+                    744233.8668025249,
+                    745956.9397393425,
+                    742219.9852211319,
+                    741956.8989882661
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsNoBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 917735.7802182309,
+            "scoreError" : 12948.012399622097,
+            "scoreConfidence" : [
+                904787.7678186088,
+                930683.792617853
+            ],
+            "scorePercentiles" : {
+                "0.0" : 892997.6251389241,
+                "50.0" : 919197.7984254777,
+                "90.0" : 934046.637250981,
+                "95.0" : 938557.9407039519,
+                "99.0" : 938788.2100301352,
+                "99.9" : 938788.2100301352,
+                "99.99" : 938788.2100301352,
+                "99.999" : 938788.2100301352,
+                "99.9999" : 938788.2100301352,
+                "100.0" : 938788.2100301352
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    918853.541295467,
+                    912083.5503515456,
+                    894802.0320659583,
+                    907572.6344496174,
+                    906064.8730371149,
+                    892997.6251389241,
+                    926662.0836671038,
+                    897397.3682372117,
+                    899552.7634708183,
+                    903619.9026373661
+                ],
+                [
+                    916209.175822073,
+                    932820.9609515977,
+                    930604.0866941761,
+                    931823.5536630547,
+                    930511.1979034846,
+                    930398.6413450832,
+                    930228.5245419316,
+                    938788.2100301352,
+                    934182.823506468,
+                    919542.0555554883
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsNoBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8725200.364597466,
+            "scoreError" : 131557.46950641726,
+            "scoreConfidence" : [
+                8593642.89509105,
+                8856757.834103882
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8357535.630351477,
+                "50.0" : 8733164.407425381,
+                "90.0" : 8871483.426263884,
+                "95.0" : 9028161.809284015,
+                "99.0" : 9036325.7842641,
+                "99.9" : 9036325.7842641,
+                "99.99" : 9036325.7842641,
+                "99.999" : 9036325.7842641,
+                "99.9999" : 9036325.7842641,
+                "100.0" : 9036325.7842641
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8688304.222901063,
+                    8669714.688817274,
+                    8849043.419847015,
+                    9036325.7842641,
+                    8857417.700677346,
+                    8791304.70086122,
+                    8676517.87118413,
+                    8357535.630351477,
+                    8470737.401355477,
+                    8762555.992234379
+                ],
+                [
+                    8632747.343621787,
+                    8809960.085618693,
+                    8835265.574727962,
+                    8873046.284662388,
+                    8832049.84973646,
+                    8773287.282040564,
+                    8640233.304138638,
+                    8593745.373363553,
+                    8650441.958929429,
+                    8703772.822616382
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsNoBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6052494.434628375,
+            "scoreError" : 92263.95760950331,
+            "scoreConfidence" : [
+                5960230.477018871,
+                6144758.392237878
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5876760.533790078,
+                "50.0" : 6043173.424715588,
+                "90.0" : 6192056.940709778,
+                "95.0" : 6192966.83648349,
+                "99.0" : 6193012.379132472,
+                "99.9" : 6193012.379132472,
+                "99.99" : 6193012.379132472,
+                "99.999" : 6193012.379132472,
+                "99.9999" : 6193012.379132472,
+                "100.0" : 6193012.379132472
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6057045.349677442,
+                    6179123.451075177,
+                    6193012.379132472,
+                    6170117.526143825,
+                    6143699.451957648,
+                    6102484.672029622,
+                    6057659.290610758,
+                    6191655.671722304,
+                    6159175.402978065,
+                    6192101.526152831
+                ],
+                [
+                    6029301.499753735,
+                    5942988.916820505,
+                    5930237.979372155,
+                    5965011.476501708,
+                    5992787.137883419,
+                    5980260.285176899,
+                    5911307.41688855,
+                    6005248.247220492,
+                    5969910.477679809,
+                    5876760.533790078
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 905642.6701195516,
+            "scoreError" : 7222.326649626099,
+            "scoreConfidence" : [
+                898420.3434699255,
+                912864.9967691777
+            ],
+            "scorePercentiles" : {
+                "0.0" : 883332.2673765494,
+                "50.0" : 907764.2321067445,
+                "90.0" : 914018.1425531933,
+                "95.0" : 919432.474188292,
+                "99.0" : 919713.7448727548,
+                "99.9" : 919713.7448727548,
+                "99.99" : 919713.7448727548,
+                "99.999" : 919713.7448727548,
+                "99.9999" : 919713.7448727548,
+                "100.0" : 919713.7448727548
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    896119.673956711,
+                    883332.2673765494,
+                    895601.6744486392,
+                    901461.9038719648,
+                    908420.0778232326,
+                    897536.8942903057,
+                    909656.6402585524,
+                    913386.4448804413,
+                    919713.7448727548,
+                    898567.4779546434
+                ],
+                [
+                    907108.3863902566,
+                    910052.4163733267,
+                    914088.3311834991,
+                    911874.1306851885,
+                    908705.4307659181,
+                    905651.4416577516,
+                    902799.4592720865,
+                    909737.1106336172,
+                    906872.9796410376,
+                    912166.9160545563
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1124901.1813059219,
+            "scoreError" : 6069.180487551383,
+            "scoreConfidence" : [
+                1118832.0008183704,
+                1130970.3617934734
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1115242.7227617954,
+                "50.0" : 1124959.1054313455,
+                "90.0" : 1134676.2399989872,
+                "95.0" : 1135947.0945111972,
+                "99.0" : 1136011.2967247344,
+                "99.9" : 1136011.2967247344,
+                "99.99" : 1136011.2967247344,
+                "99.999" : 1136011.2967247344,
+                "99.9999" : 1136011.2967247344,
+                "100.0" : 1136011.2967247344
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1131606.33956498,
+                    1128164.8969817162,
+                    1132076.4009346177,
+                    1136011.2967247344,
+                    1115242.7227617954,
+                    1117057.9151112896,
+                    1119193.9939597421,
+                    1133274.4858481644,
+                    1134727.2524539907,
+                    1134217.1279039541
+                ],
+                [
+                    1117663.3605957506,
+                    1126198.4514396684,
+                    1116199.9155537686,
+                    1124260.6729499206,
+                    1125657.5379127704,
+                    1115703.0246128389,
+                    1122180.9582431144,
+                    1119294.2511009395,
+                    1125755.2763764728,
+                    1123537.745088212
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9080848.275506053,
+            "scoreError" : 96516.16571679653,
+            "scoreConfidence" : [
+                8984332.109789256,
+                9177364.44122285
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8894299.473599799,
+                "50.0" : 9063289.353773616,
+                "90.0" : 9244707.910054967,
+                "95.0" : 9328375.367095431,
+                "99.0" : 9332731.323272474,
+                "99.9" : 9332731.323272474,
+                "99.99" : 9332731.323272474,
+                "99.999" : 9332731.323272474,
+                "99.9999" : 9332731.323272474,
+                "100.0" : 9332731.323272474
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9080060.854261525,
+                    9067304.800823346,
+                    9041919.182371477,
+                    8894900.945082558,
+                    8990536.361025864,
+                    9042943.580267286,
+                    9096365.537356699,
+                    9027292.12626638,
+                    9009292.926678292,
+                    9040723.660741562
+                ],
+                [
+                    9245612.199731603,
+                    9332731.323272474,
+                    9166835.25816114,
+                    8894299.473599799,
+                    9104343.453301474,
+                    9114209.921178514,
+                    9185373.399560027,
+                    8986377.2967519,
+                    9059273.906723887,
+                    9236569.302965235
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8075228.823521616,
+            "scoreError" : 470001.27693402563,
+            "scoreConfidence" : [
+                7605227.54658759,
+                8545230.100455642
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7422695.764675894,
+                "50.0" : 7994910.89542583,
+                "90.0" : 8910084.188566329,
+                "95.0" : 8929195.571844736,
+                "99.0" : 8930135.466786198,
+                "99.9" : 8930135.466786198,
+                "99.99" : 8930135.466786198,
+                "99.999" : 8930135.466786198,
+                "99.9999" : 8930135.466786198,
+                "100.0" : 8930135.466786198
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7460915.477258121,
+                    7422695.764675894,
+                    7515242.604018519,
+                    8443368.218567751,
+                    8595382.880111592,
+                    7485579.806874916,
+                    8556112.179541446,
+                    7587307.455725912,
+                    7645081.683536455,
+                    7586650.139857397
+                ],
+                [
+                    8930135.466786198,
+                    7738059.173137001,
+                    8806170.293115415,
+                    8911337.567956952,
+                    7921293.477775549,
+                    8898803.774050709,
+                    8005969.18683581,
+                    8004649.529754988,
+                    7991597.825870892,
+                    7998223.964980768
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalNoBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 723555.7964119541,
+            "scoreError" : 21649.029679356383,
+            "scoreConfidence" : [
+                701906.7667325977,
+                745204.8260913105
+            ],
+            "scorePercentiles" : {
+                "0.0" : 688443.7685221529,
+                "50.0" : 724588.7678427151,
+                "90.0" : 751687.0215021342,
+                "95.0" : 752960.5954826768,
+                "99.0" : 753016.6312556566,
+                "99.9" : 753016.6312556566,
+                "99.99" : 753016.6312556566,
+                "99.999" : 753016.6312556566,
+                "99.9999" : 753016.6312556566,
+                "100.0" : 753016.6312556566
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    701545.8471228017,
+                    709490.4037555415,
+                    696263.8899366125,
+                    704658.2736609072,
+                    709196.1303775659,
+                    708846.7630107907,
+                    692423.7690379063,
+                    695148.9469751943,
+                    693752.3889783128,
+                    688443.7685221529
+                ],
+                [
+                    753016.6312556566,
+                    746480.4627327163,
+                    744201.009202107,
+                    744195.0382446737,
+                    739687.1319298889,
+                    748264.4046952387,
+                    748773.1639544677,
+                    749806.9728568017,
+                    751895.91579606,
+                    745025.0161936849
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalNoBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 878855.7307403445,
+            "scoreError" : 22279.934702095707,
+            "scoreConfidence" : [
+                856575.7960382488,
+                901135.6654424402
+            ],
+            "scorePercentiles" : {
+                "0.0" : 839683.8588030778,
+                "50.0" : 877489.540366621,
+                "90.0" : 906308.2773852181,
+                "95.0" : 910212.6059825029,
+                "99.0" : 910416.5475639489,
+                "99.9" : 910416.5475639489,
+                "99.99" : 910416.5475639489,
+                "99.999" : 910416.5475639489,
+                "99.9999" : 910416.5475639489,
+                "100.0" : 910416.5475639489
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    864150.6988507115,
+                    850550.5931282197,
+                    839683.8588030778,
+                    848729.050483135,
+                    854661.8957313126,
+                    856070.9807594512,
+                    859847.4244283036,
+                    863189.4032809347,
+                    861267.0537506144,
+                    848658.3870339162
+                ],
+                [
+                    905919.089707352,
+                    906337.7159350294,
+                    904485.3268146624,
+                    899231.9165397162,
+                    905854.8862886975,
+                    899254.9467106629,
+                    906043.3304369159,
+                    910416.5475639489,
+                    901933.1266776989,
+                    890828.3818825304
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalNoBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 7385653.847082272,
+            "scoreError" : 183801.06884329862,
+            "scoreConfidence" : [
+                7201852.778238974,
+                7569454.915925571
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6990881.344242874,
+                "50.0" : 7364422.582234915,
+                "90.0" : 7734778.967535931,
+                "95.0" : 7801835.412751997,
+                "99.0" : 7805194.771274671,
+                "99.9" : 7805194.771274671,
+                "99.99" : 7805194.771274671,
+                "99.999" : 7805194.771274671,
+                "99.9999" : 7805194.771274671,
+                "100.0" : 7805194.771274671
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7738007.600821198,
+                    7502568.02122075,
+                    6990881.344242874,
+                    7437856.522793848,
+                    7705721.2679685205,
+                    7414777.453079293,
+                    7577247.783750732,
+                    7365502.027594455,
+                    7437629.569550662,
+                    7805194.771274671
+                ],
+                [
+                    7359560.860123452,
+                    7363343.136875377,
+                    7332347.004298606,
+                    7262939.060611622,
+                    7265549.387320591,
+                    7022856.783895282,
+                    7185036.922541751,
+                    7362425.6706663435,
+                    7369937.6696089925,
+                    7213694.083406427
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalNoBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5899862.040405666,
+            "scoreError" : 246904.3113480341,
+            "scoreConfidence" : [
+                5652957.729057632,
+                6146766.3517537005
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5514416.320342932,
+                "50.0" : 5905287.30417938,
+                "90.0" : 6233990.493682745,
+                "95.0" : 6262910.28677111,
+                "99.0" : 6264239.574875124,
+                "99.9" : 6264239.574875124,
+                "99.99" : 6264239.574875124,
+                "99.999" : 6264239.574875124,
+                "99.9999" : 6264239.574875124,
+                "100.0" : 6264239.574875124
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5569161.289376467,
+                    5616274.532653119,
+                    5703027.981330405,
+                    5614677.116441955,
+                    5685916.338648369,
+                    5526143.569518901,
+                    5514416.320342932,
+                    5663951.341796171,
+                    5752479.952738523,
+                    5658580.600370835
+                ],
+                [
+                    6126749.704886487,
+                    6140159.177289133,
+                    6145047.519931884,
+                    6154937.262270165,
+                    6058094.655620237,
+                    6179595.127600107,
+                    6185114.3079539165,
+                    6237653.812794853,
+                    6201020.621673771,
+                    6264239.574875124
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1291418.2285654508,
+            "scoreError" : 15299.050711480642,
+            "scoreConfidence" : [
+                1276119.17785397,
+                1306717.2792769314
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1247939.8265404215,
+                "50.0" : 1292745.2515412732,
+                "90.0" : 1312445.5116647442,
+                "95.0" : 1317866.500492261,
+                "99.0" : 1318141.0692752043,
+                "99.9" : 1318141.0692752043,
+                "99.99" : 1318141.0692752043,
+                "99.999" : 1318141.0692752043,
+                "99.9999" : 1318141.0692752043,
+                "100.0" : 1318141.0692752043
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1290700.5733296194,
+                    1312649.693616339,
+                    1294110.0632259422,
+                    1295202.9907336656,
+                    1291380.4398566042,
+                    1318141.0692752043,
+                    1299674.3886286202,
+                    1286808.910773855,
+                    1306240.5664178904,
+                    1300478.947597392
+                ],
+                [
+                    1284835.7792224286,
+                    1287370.7668467553,
+                    1298810.8764572914,
+                    1307254.9467617457,
+                    1247939.8265404215,
+                    1310607.8741003918,
+                    1284131.650009466,
+                    1281443.465387356,
+                    1255858.6628096593,
+                    1274723.0797183684
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1579366.803791438,
+            "scoreError" : 20698.1521239351,
+            "scoreConfidence" : [
+                1558668.651667503,
+                1600064.955915373
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1523753.6642240589,
+                "50.0" : 1576617.8715067818,
+                "90.0" : 1619006.1987767827,
+                "95.0" : 1621723.2831523917,
+                "99.0" : 1621785.377190411,
+                "99.9" : 1621785.377190411,
+                "99.99" : 1621785.377190411,
+                "99.999" : 1621785.377190411,
+                "99.9999" : 1621785.377190411,
+                "100.0" : 1621785.377190411
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1566678.243180729,
+                    1592108.8465537734,
+                    1574917.5792283213,
+                    1539344.0960872797,
+                    1576600.3575513018,
+                    1567152.1187541578,
+                    1572456.1688504377,
+                    1523753.6642240589,
+                    1560436.0452073598,
+                    1566990.272388425
+                ],
+                [
+                    1572764.1069382743,
+                    1594064.6528881823,
+                    1576635.385462262,
+                    1589751.4108870924,
+                    1605170.5198976363,
+                    1599625.3562318052,
+                    1620543.4964300212,
+                    1577605.7014898295,
+                    1588952.6763874055,
+                    1621785.377190411
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.42664483604039E7,
+            "scoreError" : 161491.8606918541,
+            "scoreConfidence" : [
+                1.4104956499712044E7,
+                1.4427940221095754E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.395568566818094E7,
+                "50.0" : 1.4224773111721532E7,
+                "90.0" : 1.46212053048578E7,
+                "95.0" : 1.4648822088028181E7,
+                "99.0" : 1.4649591654122513E7,
+                "99.9" : 1.4649591654122513E7,
+                "99.99" : 1.4649591654122513E7,
+                "99.999" : 1.4649591654122513E7,
+                "99.9999" : 1.4649591654122513E7,
+                "100.0" : 1.4649591654122513E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.4220504027185446E7,
+                    1.4210273706151564E7,
+                    1.4320364359614402E7,
+                    1.4634200332235878E7,
+                    1.4356773269873837E7,
+                    1.4369983539782314E7,
+                    1.4252178128899846E7,
+                    1.4392277970909577E7,
+                    1.4504250058455095E7,
+                    1.4649591654122513E7
+                ],
+                [
+                    1.4121663683807392E7,
+                    1.415980976940423E7,
+                    1.4006186096962607E7,
+                    1.4056590589457301E7,
+                    1.422904219625762E7,
+                    1.4209658494698482E7,
+                    1.4165372106027963E7,
+                    1.4157856069854833E7,
+                    1.395568566818094E7,
+                    1.4356705486196073E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3861412390129497E7,
+            "scoreError" : 1065445.232005551,
+            "scoreConfidence" : [
+                1.2795967158123946E7,
+                1.4926857622135049E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9676387.96512406,
+                "50.0" : 1.430923776488825E7,
+                "90.0" : 1.4501531217061065E7,
+                "95.0" : 1.45063683689244E7,
+                "99.0" : 1.4506544588409374E7,
+                "99.9" : 1.4506544588409374E7,
+                "99.99" : 1.4506544588409374E7,
+                "99.999" : 1.4506544588409374E7,
+                "99.9999" : 1.4506544588409374E7,
+                "100.0" : 1.4506544588409374E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.4323412885176064E7,
+                    1.4333606205669127E7,
+                    1.4386538136946717E7,
+                    1.3824508621428449E7,
+                    1.4503020198709885E7,
+                    1.4506544588409374E7,
+                    1.433697819586716E7,
+                    1.4295062644600436E7,
+                    1.4430238166414563E7,
+                    1.4264379269863851E7
+                ],
+                [
+                    1.4092708882341411E7,
+                    1.437629260381376E7,
+                    1.4013605611679437E7,
+                    1.4488130382221691E7,
+                    1.3925897244910255E7,
+                    1.3855384225537533E7,
+                    9676387.96512406,
+                    1.1104331576020226E7,
+                    1.4167654722677095E7,
+                    1.4323565675178794E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsNoBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 831367.488647984,
+            "scoreError" : 47185.56464874638,
+            "scoreConfidence" : [
+                784181.9239992376,
+                878553.0532967304
+            ],
+            "scorePercentiles" : {
+                "0.0" : 608998.6678913852,
+                "50.0" : 837850.3534411234,
+                "90.0" : 860439.0554140497,
+                "95.0" : 865641.8051328536,
+                "99.0" : 865909.3580288832,
+                "99.9" : 865909.3580288832,
+                "99.99" : 865909.3580288832,
+                "99.999" : 865909.3580288832,
+                "99.9999" : 865909.3580288832,
+                "100.0" : 865909.3580288832
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    856268.8984639817,
+                    608998.6678913852,
+                    843611.2985018194,
+                    856747.1082432722,
+                    856422.9076382968,
+                    859365.8531658776,
+                    858613.1450045819,
+                    853912.4778613413,
+                    860558.300108291,
+                    865909.3580288832
+                ],
+                [
+                    826651.7703129087,
+                    815501.6910783015,
+                    821725.8448022306,
+                    838308.1867658522,
+                    834585.4599158878,
+                    826838.5347218368,
+                    836206.8901186344,
+                    833853.0873437971,
+                    837392.5201163947,
+                    835877.7728761074
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsNoBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 985170.9332921738,
+            "scoreError" : 8880.199911184895,
+            "scoreConfidence" : [
+                976290.7333809889,
+                994051.1332033586
+            ],
+            "scorePercentiles" : {
+                "0.0" : 971381.9332538091,
+                "50.0" : 984609.1612966256,
+                "90.0" : 1000374.5567061832,
+                "95.0" : 1006697.2691696611,
+                "99.0" : 1007011.536244184,
+                "99.9" : 1007011.536244184,
+                "99.99" : 1007011.536244184,
+                "99.999" : 1007011.536244184,
+                "99.9999" : 1007011.536244184,
+                "100.0" : 1007011.536244184
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    975567.8778909828,
+                    982048.2911390908,
+                    971381.9332538091,
+                    976273.0684719597,
+                    972854.9409402778,
+                    989171.4018834786,
+                    992282.5034571617,
+                    982583.9401131563,
+                    973718.4666469253,
+                    977108.6748585547
+                ],
+                [
+                    992778.9352061029,
+                    978560.0310908323,
+                    986634.3824800948,
+                    997209.8142783018,
+                    975545.1200776023,
+                    987755.5878949239,
+                    988131.1502634024,
+                    1000726.1947537257,
+                    1007011.536244184,
+                    996074.8148989094
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsNoBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 7811378.04293188,
+            "scoreError" : 42107.1747855253,
+            "scoreConfidence" : [
+                7769270.868146354,
+                7853485.217717405
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7712325.507989643,
+                "50.0" : 7814329.621249622,
+                "90.0" : 7880931.47534195,
+                "95.0" : 7927306.63405766,
+                "99.0" : 7929525.432221731,
+                "99.9" : 7929525.432221731,
+                "99.99" : 7929525.432221731,
+                "99.999" : 7929525.432221731,
+                "99.9999" : 7929525.432221731,
+                "100.0" : 7929525.432221731
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7842969.532956867,
+                    7885149.4689402925,
+                    7712325.507989643,
+                    7793908.940181759,
+                    7842106.31007959,
+                    7813632.168453874,
+                    7806508.091150972,
+                    7822685.8380946545,
+                    7764750.256497203,
+                    7815027.0740453685
+                ],
+                [
+                    7750525.737792049,
+                    7755589.791827075,
+                    7815698.475018228,
+                    7807691.331196233,
+                    7838114.481397563,
+                    7777328.980281074,
+                    7929525.432221731,
+                    7840225.919373578,
+                    7832172.35532086,
+                    7781625.16581896
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsNoBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6759602.469245188,
+            "scoreError" : 100206.27993951095,
+            "scoreConfidence" : [
+                6659396.189305677,
+                6859808.749184699
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6536415.940511818,
+                "50.0" : 6781870.766791172,
+                "90.0" : 6928728.821649564,
+                "95.0" : 6948582.861920436,
+                "99.0" : 6949559.180107835,
+                "99.9" : 6949559.180107835,
+                "99.99" : 6949559.180107835,
+                "99.999" : 6949559.180107835,
+                "99.9999" : 6949559.180107835,
+                "100.0" : 6949559.180107835
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6598425.7241399195,
+                    6848557.558501856,
+                    6642629.363193995,
+                    6916992.869256982,
+                    6698487.601193048,
+                    6580748.029156548,
+                    6716845.152958101,
+                    6835913.184751687,
+                    6836930.865348543,
+                    6792998.58110658
+                ],
+                [
+                    6822107.651441797,
+                    6692168.869073737,
+                    6690798.267582691,
+                    6949559.180107835,
+                    6748369.554342457,
+                    6790326.642293991,
+                    6783837.231536007,
+                    6536415.940511818,
+                    6930032.8163598515,
+                    6779904.302046339
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1107510.3549362863,
+            "scoreError" : 7575.310285706745,
+            "scoreConfidence" : [
+                1099935.0446505796,
+                1115085.665221993
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1090852.9580560888,
+                "50.0" : 1105634.8307692995,
+                "90.0" : 1118710.676115153,
+                "95.0" : 1120223.372984267,
+                "99.0" : 1120300.1581937755,
+                "99.9" : 1120300.1581937755,
+                "99.99" : 1120300.1581937755,
+                "99.999" : 1120300.1581937755,
+                "99.9999" : 1120300.1581937755,
+                "100.0" : 1120300.1581937755
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1106929.5028000309,
+                    1105678.3679053166,
+                    1105536.0056664168,
+                    1113961.5010391683,
+                    1118764.4540036058,
+                    1117845.9603984163,
+                    1118226.675119078,
+                    1116359.1769691792,
+                    1120300.1581937755,
+                    1114596.6380226212
+                ],
+                [
+                    1109761.6677952397,
+                    1099612.0448790682,
+                    1091017.642288367,
+                    1097842.0377197112,
+                    1105468.7372829784,
+                    1104126.7488204865,
+                    1104092.9427440055,
+                    1105591.2936332827,
+                    1103642.585388891,
+                    1090852.9580560888
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1384992.0615252296,
+            "scoreError" : 9885.719319474229,
+            "scoreConfidence" : [
+                1375106.3422057554,
+                1394877.7808447038
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1362939.7670871557,
+                "50.0" : 1384045.3005774212,
+                "90.0" : 1398313.307545394,
+                "95.0" : 1404746.9462783192,
+                "99.0" : 1405083.291982504,
+                "99.9" : 1405083.291982504,
+                "99.99" : 1405083.291982504,
+                "99.999" : 1405083.291982504,
+                "99.9999" : 1405083.291982504,
+                "100.0" : 1405083.291982504
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1405083.291982504,
+                    1398356.377898809,
+                    1387087.4667415416,
+                    1380208.3754374527,
+                    1384868.1275277785,
+                    1370692.9408264179,
+                    1395479.4572682176,
+                    1395069.66249446,
+                    1381420.6636823346,
+                    1383674.8932864368
+                ],
+                [
+                    1369424.4170534858,
+                    1384396.5266136823,
+                    1376003.8971189936,
+                    1383694.0745411604,
+                    1394145.5974074625,
+                    1396190.1190690498,
+                    1362939.7670871557,
+                    1397925.6743646583,
+                    1383420.2295964293,
+                    1369759.67050656
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8122873.414244209,
+            "scoreError" : 219043.04901715182,
+            "scoreConfidence" : [
+                7903830.365227058,
+                8341916.463261361
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7812183.181068755,
+                "50.0" : 8091190.5280558895,
+                "90.0" : 8420477.157226313,
+                "95.0" : 8434409.026582325,
+                "99.0" : 8435058.691730537,
+                "99.9" : 8435058.691730537,
+                "99.99" : 8435058.691730537,
+                "99.999" : 8435058.691730537,
+                "99.9999" : 8435058.691730537,
+                "100.0" : 8435058.691730537
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7867302.295224233,
+                    7901239.22779346,
+                    7875563.122123455,
+                    7826771.518303643,
+                    7812183.181068755,
+                    7898844.99605248,
+                    7927131.512218128,
+                    7917960.859222789,
+                    7872704.900404477,
+                    7912935.657153216
+                ],
+                [
+                    8390521.852512242,
+                    8255249.54389365,
+                    8313617.02710408,
+                    8373267.183285053,
+                    8422065.388766294,
+                    8406183.07336647,
+                    8365218.781623282,
+                    8435058.691730537,
+                    8310777.012871248,
+                    8372872.460166733
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0468204300136115E7,
+            "scoreError" : 415988.52477083344,
+            "scoreConfidence" : [
+                1.0052215775365282E7,
+                1.0884192824906949E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9814750.539987847,
+                "50.0" : 1.0448218185749259E7,
+                "90.0" : 1.0984906882512793E7,
+                "95.0" : 1.0991477671200434E7,
+                "99.0" : 1.0991822656173717E7,
+                "99.9" : 1.0991822656173717E7,
+                "99.99" : 1.0991822656173717E7,
+                "99.999" : 1.0991822656173717E7,
+                "99.9999" : 1.0991822656173717E7,
+                "100.0" : 1.0991822656173717E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0959462162889125E7,
+                    1.0954028326851431E7,
+                    1.0991822656173717E7,
+                    1.0956727416094769E7,
+                    1.083980286881762E7,
+                    1.098492295670806E7,
+                    1.098476221475539E7,
+                    1.0966884810804982E7,
+                    1.0859968120026635E7,
+                    1.0776732758430354E7
+                ],
+                [
+                    9867792.729578814,
+                    9995311.278655445,
+                    1.0008662715617597E7,
+                    1.0101238665625773E7,
+                    1.0079963809015473E7,
+                    9814750.539987847,
+                    1.0119703613068162E7,
+                    1.001746568582884E7,
+                    9990357.363702979,
+                    1.0093725310089277E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalNoBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 763596.1920752265,
+            "scoreError" : 4661.617335747559,
+            "scoreConfidence" : [
+                758934.5747394789,
+                768257.809410974
+            ],
+            "scorePercentiles" : {
+                "0.0" : 754211.6989550942,
+                "50.0" : 762743.8749012817,
+                "90.0" : 772832.8652645876,
+                "95.0" : 773271.0760888007,
+                "99.0" : 773287.3041887805,
+                "99.9" : 773287.3041887805,
+                "99.99" : 773287.3041887805,
+                "99.999" : 773287.3041887805,
+                "99.9999" : 773287.3041887805,
+                "100.0" : 773287.3041887805
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    766236.5487647661,
+                    772962.7421891845,
+                    765616.4541651953,
+                    764466.3898428227,
+                    767382.5553503726,
+                    771663.9729432146,
+                    768204.332927814,
+                    773287.3041887805,
+                    760306.8765486645,
+                    761871.5002247515
+                ],
+                [
+                    754211.6989550942,
+                    761846.274636982,
+                    762145.3314403412,
+                    763342.4183622223,
+                    757468.4239531334,
+                    760899.3357669275,
+                    759543.571124952,
+                    754502.5030069929,
+                    763891.1769080157,
+                    762074.4302043023
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalNoBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 882466.5378811297,
+            "scoreError" : 5632.189762240244,
+            "scoreConfidence" : [
+                876834.3481188894,
+                888098.7276433699
+            ],
+            "scorePercentiles" : {
+                "0.0" : 868656.4188306871,
+                "50.0" : 882859.4911679552,
+                "90.0" : 889927.7567465856,
+                "95.0" : 894363.8263773017,
+                "99.0" : 894591.2405954854,
+                "99.9" : 894591.2405954854,
+                "99.99" : 894591.2405954854,
+                "99.999" : 894591.2405954854,
+                "99.9999" : 894591.2405954854,
+                "100.0" : 894591.2405954854
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    885567.4924619967,
+                    868656.4188306871,
+                    880957.5065436815,
+                    890042.9562318104,
+                    877694.2295627592,
+                    888842.2352393643,
+                    882266.6193503569,
+                    883452.3629855536,
+                    872751.5503866745,
+                    894591.2405954854
+                ],
+                [
+                    877889.1712419133,
+                    878720.7657263357,
+                    888525.0929110711,
+                    881357.059112145,
+                    886303.0385041027,
+                    888890.961379563,
+                    879422.0539613668,
+                    873528.4148847536,
+                    883671.0010282877,
+                    886200.5866846843
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalNoBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5915442.37838255,
+            "scoreError" : 89763.56698485863,
+            "scoreConfidence" : [
+                5825678.811397691,
+                6005205.945367408
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5775322.046012488,
+                "50.0" : 5910452.3560477905,
+                "90.0" : 6030176.851725483,
+                "95.0" : 6041420.3586083865,
+                "99.0" : 6042008.97170431,
+                "99.9" : 6042008.97170431,
+                "99.99" : 6042008.97170431,
+                "99.999" : 6042008.97170431,
+                "99.9999" : 6042008.97170431,
+                "100.0" : 6042008.97170431
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6004125.807768403,
+                    5988682.79881657,
+                    5987533.015344053,
+                    6029638.129182279,
+                    6022936.3401351655,
+                    6030236.70978584,
+                    6042008.97170431,
+                    5997084.128531058,
+                    6023953.408062369,
+                    6020416.770362388
+                ],
+                [
+                    5775322.046012488,
+                    5831439.15247614,
+                    5829969.697487571,
+                    5822909.591699596,
+                    5814130.079915526,
+                    5808074.695823518,
+                    5809304.606442552,
+                    5831927.33832384,
+                    5833371.6967515275,
+                    5805782.583025767
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalNoBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5395579.141825735,
+            "scoreError" : 51373.423897830646,
+            "scoreConfidence" : [
+                5344205.717927904,
+                5446952.565723565
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5267552.977013258,
+                "50.0" : 5403445.118582161,
+                "90.0" : 5460853.464473197,
+                "95.0" : 5494966.915086535,
+                "99.0" : 5496730.828761742,
+                "99.9" : 5496730.828761742,
+                "99.99" : 5496730.828761742,
+                "99.999" : 5496730.828761742,
+                "99.9999" : 5496730.828761742,
+                "100.0" : 5496730.828761742
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5334929.508884677,
+                    5367100.121264761,
+                    5496730.828761742,
+                    5455461.647413622,
+                    5277915.002100861,
+                    5412801.304875659,
+                    5417184.125832405,
+                    5380119.359552943,
+                    5447159.964378287,
+                    5453478.025241699
+                ],
+                [
+                    5378992.126878542,
+                    5356768.832355058,
+                    5406519.064501456,
+                    5400371.172662866,
+                    5408754.762863026,
+                    5347689.890744189,
+                    5398033.862506592,
+                    5461452.555257594,
+                    5442567.7034254335,
+                    5267552.977013258
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3463320.3845676794,
+            "scoreError" : 157269.3583474458,
+            "scoreConfidence" : [
+                3306051.0262202336,
+                3620589.742915125
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3251756.943886497,
+                "50.0" : 3432951.4934139913,
+                "90.0" : 3675566.8277864866,
+                "95.0" : 3697765.726570107,
+                "99.0" : 3698880.7010719427,
+                "99.9" : 3698880.7010719427,
+                "99.99" : 3698880.7010719427,
+                "99.999" : 3698880.7010719427,
+                "99.9999" : 3698880.7010719427,
+                "100.0" : 3698880.7010719427
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3288269.421539791,
+                    3258140.0788034922,
+                    3311808.7206694838,
+                    3289399.3910248727,
+                    3296947.772046251,
+                    3312345.3989641285,
+                    3251756.943886497,
+                    3302164.350662329,
+                    3298673.6997554037,
+                    3288736.9091892387
+                ],
+                [
+                    3599448.768779169,
+                    3602610.3762162547,
+                    3613641.341368967,
+                    3553557.5878638546,
+                    3636427.3729967535,
+                    3656289.3766461555,
+                    3698880.7010719427,
+                    3664290.890286002,
+                    3676581.211035233,
+                    3666437.3785477676
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5338345.735822449,
+            "scoreError" : 35743.1925462765,
+            "scoreConfidence" : [
+                5302602.543276173,
+                5374088.928368726
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5277375.398553772,
+                "50.0" : 5330014.673427383,
+                "90.0" : 5391309.231261294,
+                "95.0" : 5428319.788752759,
+                "99.0" : 5430238.332924454,
+                "99.9" : 5430238.332924454,
+                "99.99" : 5430238.332924454,
+                "99.999" : 5430238.332924454,
+                "99.9999" : 5430238.332924454,
+                "100.0" : 5430238.332924454
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5330022.02151706,
+                    5277375.398553772,
+                    5299944.15624312,
+                    5295045.134462503,
+                    5330007.325337707,
+                    5307386.754391128,
+                    5301251.187757762,
+                    5290728.614264134,
+                    5323709.284049745,
+                    5307780.695134833
+                ],
+                [
+                    5376369.004906946,
+                    5380721.705770647,
+                    5375823.673457913,
+                    5361869.506439468,
+                    5318895.836294852,
+                    5386285.267197904,
+                    5391867.44949056,
+                    5336389.362026923,
+                    5430238.332924454,
+                    5345204.006227571
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.5884210290218756E7,
+            "scoreError" : 1822537.7777787414,
+            "scoreConfidence" : [
+                5.406167251244001E7,
+                5.77067480679975E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.308505384936582E7,
+                "50.0" : 5.603575442986004E7,
+                "90.0" : 5.806143347698857E7,
+                "95.0" : 5.810933390102749E7,
+                "99.0" : 5.8111402453557834E7,
+                "99.9" : 5.8111402453557834E7,
+                "99.99" : 5.8111402453557834E7,
+                "99.999" : 5.8111402453557834E7,
+                "99.9999" : 5.8111402453557834E7,
+                "100.0" : 5.8111402453557834E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.8070031402950995E7,
+                    5.784592269357187E7,
+                    5.7812291690660305E7,
+                    5.8111402453557834E7,
+                    5.7733677163758E7,
+                    5.797482537475221E7,
+                    5.798405214332675E7,
+                    5.796043189257462E7,
+                    5.796002118655697E7,
+                    5.769985156148496E7
+                ],
+                [
+                    5.389353158216138E7,
+                    5.3910439343969434E7,
+                    5.3694237536543824E7,
+                    5.308505384936582E7,
+                    5.36975825242003E7,
+                    5.3827317489356995E7,
+                    5.407353571756512E7,
+                    5.410267186973332E7,
+                    5.3875671030049086E7,
+                    5.437165729823512E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.324564105569267E7,
+            "scoreError" : 268788.1373798243,
+            "scoreConfidence" : [
+                9.297685291831285E7,
+                9.35144291930725E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.256969572181244E7,
+                "50.0" : 9.329413814535168E7,
+                "90.0" : 9.360443681002563E7,
+                "95.0" : 9.373419641598725E7,
+                "99.0" : 9.374090346334875E7,
+                "99.9" : 9.374090346334875E7,
+                "99.99" : 9.374090346334875E7,
+                "99.999" : 9.374090346334875E7,
+                "99.9999" : 9.374090346334875E7,
+                "100.0" : 9.374090346334875E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.319704336617307E7,
+                    9.34341021805621E7,
+                    9.3297879343303E7,
+                    9.308921352322488E7,
+                    9.321995449738649E7,
+                    9.275624119835785E7,
+                    9.329039694740036E7,
+                    9.349177906690833E7,
+                    9.31564304637806E7,
+                    9.330425890967238E7
+                ],
+                [
+                    9.303859011467923E7,
+                    9.347982437108077E7,
+                    9.256969572181244E7,
+                    9.27182454488176E7,
+                    9.360676251611894E7,
+                    9.349135616956857E7,
+                    9.305414775028147E7,
+                    9.374090346334875E7,
+                    9.339249060619056E7,
+                    9.358350545518586E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3257380.688274453,
+            "scoreError" : 27222.34761707187,
+            "scoreConfidence" : [
+                3230158.340657381,
+                3284603.035891525
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3202458.8529583225,
+                "50.0" : 3255867.82818017,
+                "90.0" : 3293258.712349111,
+                "95.0" : 3295625.3726121876,
+                "99.0" : 3295748.150708771,
+                "99.9" : 3295748.150708771,
+                "99.99" : 3295748.150708771,
+                "99.999" : 3295748.150708771,
+                "99.9999" : 3295748.150708771,
+                "100.0" : 3295748.150708771
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3292734.5328765563,
+                    3277336.271164686,
+                    3287765.2082048226,
+                    3269678.260486038,
+                    3273410.586435142,
+                    3293292.588777103,
+                    3295748.150708771,
+                    3292953.8244971847,
+                    3288975.08869721,
+                    3287928.9171638004
+                ],
+                [
+                    3230260.7161737783,
+                    3208360.9578301017,
+                    3202458.8529583225,
+                    3233834.446745254,
+                    3230594.5385317216,
+                    3234617.955416157,
+                    3242005.51917906,
+                    3234018.327041779,
+                    3242057.3958743024,
+                    3229581.626727265
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5409776.124116065,
+            "scoreError" : 154880.11399968027,
+            "scoreConfidence" : [
+                5254896.010116384,
+                5564656.238115746
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5160612.45547445,
+                "50.0" : 5427286.06433752,
+                "90.0" : 5610744.904845728,
+                "95.0" : 5634235.596915391,
+                "99.0" : 5635433.943659599,
+                "99.9" : 5635433.943659599,
+                "99.99" : 5635433.943659599,
+                "99.999" : 5635433.943659599,
+                "99.9999" : 5635433.943659599,
+                "100.0" : 5635433.943659599
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5276050.428938249,
+                    5348782.384569838,
+                    5286970.5613267515,
+                    5167275.94892595,
+                    5160612.45547445,
+                    5224586.1695096055,
+                    5211405.191101013,
+                    5224332.863917385,
+                    5253700.944140901,
+                    5274237.190552247
+                ],
+                [
+                    5511959.634690586,
+                    5505789.744105203,
+                    5599209.270064392,
+                    5562824.88192559,
+                    5611467.008775447,
+                    5601593.679426803,
+                    5635433.943659599,
+                    5604245.969478252,
+                    5543581.634353596,
+                    5591462.577385441
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.628602100692447E7,
+            "scoreError" : 857038.5726274193,
+            "scoreConfidence" : [
+                5.5428982434297055E7,
+                5.714305957955189E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.433153539488193E7,
+                "50.0" : 5.637173468313415E7,
+                "90.0" : 5.7453497387206525E7,
+                "95.0" : 5.74934943380135E7,
+                "99.0" : 5.74955048829751E7,
+                "99.9" : 5.74955048829751E7,
+                "99.99" : 5.74955048829751E7,
+                "99.999" : 5.74955048829751E7,
+                "99.9999" : 5.74955048829751E7,
+                "100.0" : 5.74955048829751E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.681446001710613E7,
+                    5.72587242020765E7,
+                    5.701907533594563E7,
+                    5.7143855385574006E7,
+                    5.682092487080905E7,
+                    5.7390306119276196E7,
+                    5.743732801837785E7,
+                    5.745529398374304E7,
+                    5.74955048829751E7,
+                    5.678646149566306E7
+                ],
+                [
+                    5.433153539488193E7,
+                    5.505733337212752E7,
+                    5.584312403955509E7,
+                    5.5947562460886E7,
+                    5.595700787060524E7,
+                    5.488299542381284E7,
+                    5.55111695768236E7,
+                    5.546282473885605E7,
+                    5.543763222509103E7,
+                    5.56673007243037E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.833439488787217E7,
+            "scoreError" : 2669052.8726418824,
+            "scoreConfidence" : [
+                8.56653420152303E7,
+                9.100344776051405E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.060694747122405E7,
+                "50.0" : 8.795836479109573E7,
+                "90.0" : 9.273543802242906E7,
+                "95.0" : 9.301464389435345E7,
+                "99.0" : 9.302414546866424E7,
+                "99.9" : 9.302414546866424E7,
+                "99.99" : 9.302414546866424E7,
+                "99.999" : 9.302414546866424E7,
+                "99.9999" : 9.302414546866424E7,
+                "100.0" : 9.302414546866424E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.763871979411875E7,
+                    8.744704870781113E7,
+                    8.77823425382688E7,
+                    8.613507431045936E7,
+                    8.758767345378141E7,
+                    8.759716784674147E7,
+                    8.813438704392268E7,
+                    8.756424398375124E7,
+                    8.519311584948902E7,
+                    8.060694747122405E7
+                ],
+                [
+                    8.889486754211986E7,
+                    8.974415489329122E7,
+                    9.017142831557846E7,
+                    9.283411398244844E7,
+                    9.184735438225463E7,
+                    9.112296003239733E7,
+                    8.873884781539376E7,
+                    8.33439824487869E7,
+                    9.127932187694092E7,
+                    9.302414546866424E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2671370.818434035,
+            "scoreError" : 6690.2317235668,
+            "scoreConfidence" : [
+                2664680.586710468,
+                2678061.050157602
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2654668.9090120825,
+                "50.0" : 2671254.4955438734,
+                "90.0" : 2682039.349287649,
+                "95.0" : 2684703.212284969,
+                "99.0" : 2684835.4874001318,
+                "99.9" : 2684835.4874001318,
+                "99.99" : 2684835.4874001318,
+                "99.999" : 2684835.4874001318,
+                "99.9999" : 2684835.4874001318,
+                "100.0" : 2684835.4874001318
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2657655.355354528,
+                    2654668.9090120825,
+                    2680455.2493606703,
+                    2682189.9850968807,
+                    2669745.686187873,
+                    2684835.4874001318,
+                    2680683.627004563,
+                    2668756.2997446316,
+                    2663895.188314889,
+                    2671213.5366880577
+                ],
+                [
+                    2668334.6526792324,
+                    2671892.6629385385,
+                    2670063.267647848,
+                    2673845.390779046,
+                    2677648.302476184,
+                    2663673.976893443,
+                    2669739.8575125313,
+                    2674040.952276525,
+                    2671295.454399689,
+                    2672782.526913355
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3629504.526953033,
+            "scoreError" : 87824.29356017713,
+            "scoreConfidence" : [
+                3541680.233392856,
+                3717328.8205132103
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3510311.9165547397,
+                "50.0" : 3618848.127559323,
+                "90.0" : 3737298.1882587154,
+                "95.0" : 3741294.741358039,
+                "99.0" : 3741495.325810819,
+                "99.9" : 3741495.325810819,
+                "99.99" : 3741495.325810819,
+                "99.999" : 3741495.325810819,
+                "99.9999" : 3741495.325810819,
+                "100.0" : 3741495.325810819
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3727897.424103101,
+                    3734658.5545870205,
+                    3741495.325810819,
+                    3722634.007021265,
+                    3722796.6081667542,
+                    3730658.575148726,
+                    3730709.8199345972,
+                    3686393.2150208903,
+                    3735629.1517901504,
+                    3737483.6367552225
+                ],
+                [
+                    3550942.672042763,
+                    3542357.8103005528,
+                    3513305.0168569307,
+                    3551303.040097755,
+                    3529161.0373308547,
+                    3533184.1062843716,
+                    3516795.4315486765,
+                    3534784.0420584236,
+                    3537589.14764706,
+                    3510311.9165547397
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.5703375994022284E7,
+            "scoreError" : 746496.1628132033,
+            "scoreConfidence" : [
+                2.4956879831209082E7,
+                2.6449872156835485E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.4467020503243916E7,
+                "50.0" : 2.5713719563454032E7,
+                "90.0" : 2.663897773486174E7,
+                "95.0" : 2.67257788929505E7,
+                "99.0" : 2.673033328889752E7,
+                "99.9" : 2.673033328889752E7,
+                "99.99" : 2.673033328889752E7,
+                "99.999" : 2.673033328889752E7,
+                "99.9999" : 2.673033328889752E7,
+                "100.0" : 2.673033328889752E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.6602481545097735E7,
+                    2.673033328889752E7,
+                    2.6525616155741666E7,
+                    2.6455301558470923E7,
+                    2.6408980428022135E7,
+                    2.663924536995712E7,
+                    2.6376789575118624E7,
+                    2.643053542479998E7,
+                    2.6465965444845676E7,
+                    2.663656901900332E7
+                ],
+                [
+                    2.5049806723542113E7,
+                    2.492183186017166E7,
+                    2.497436226143669E7,
+                    2.5050649551789436E7,
+                    2.5045715287805352E7,
+                    2.4729052560120404E7,
+                    2.5007284098156173E7,
+                    2.4690144788203023E7,
+                    2.4467020503243916E7,
+                    2.4859834436022174E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.259772301131721E7,
+            "scoreError" : 149539.08322141066,
+            "scoreConfidence" : [
+                4.2448183928095795E7,
+                4.274726209453862E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.230841352231974E7,
+                "50.0" : 4.260937591394593E7,
+                "90.0" : 4.2798337393089764E7,
+                "95.0" : 4.282789915303113E7,
+                "99.0" : 4.282944820435308E7,
+                "99.9" : 4.282944820435308E7,
+                "99.99" : 4.282944820435308E7,
+                "99.999" : 4.282944820435308E7,
+                "99.9999" : 4.282944820435308E7,
+                "100.0" : 4.282944820435308E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.2788790108001254E7,
+                    4.262612772671413E7,
+                    4.2458425261293486E7,
+                    4.261042121192491E7,
+                    4.2608330615966946E7,
+                    4.270925553572768E7,
+                    4.234733431512916E7,
+                    4.239703048876424E7,
+                    4.239966429397261E7,
+                    4.279716932967031E7
+                ],
+                [
+                    4.279846717791415E7,
+                    4.245233580573219E7,
+                    4.274531608854602E7,
+                    4.259601723842863E7,
+                    4.282944820435308E7,
+                    4.251985266154438E7,
+                    4.279674716806858E7,
+                    4.243214132920834E7,
+                    4.230841352231974E7,
+                    4.273317214306451E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2736405.7949673296,
+            "scoreError" : 52841.08642832787,
+            "scoreConfidence" : [
+                2683564.7085390016,
+                2789246.8813956575
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2663286.8885128777,
+                "50.0" : 2731342.3941026446,
+                "90.0" : 2807402.3471472096,
+                "95.0" : 2811120.7955831042,
+                "99.0" : 2811292.517984632,
+                "99.9" : 2811292.517984632,
+                "99.99" : 2811292.517984632,
+                "99.999" : 2811292.517984632,
+                "99.9999" : 2811292.517984632,
+                "100.0" : 2811292.517984632
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2803300.8418854303,
+                    2795617.430541371,
+                    2788606.042485374,
+                    2779206.2871621945,
+                    2811292.517984632,
+                    2776027.229350326,
+                    2791626.7369429804,
+                    2802303.755330047,
+                    2794697.3238501344,
+                    2807858.069954074
+                ],
+                [
+                    2677097.630582908,
+                    2680068.9646398043,
+                    2678284.549543332,
+                    2676366.434417071,
+                    2663286.8885128777,
+                    2679856.168687352,
+                    2683967.569903686,
+                    2686657.558854963,
+                    2677374.80609209,
+                    2674619.0926259477
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3538835.893171206,
+            "scoreError" : 27871.973419363665,
+            "scoreConfidence" : [
+                3510963.9197518425,
+                3566707.8665905697
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3421578.069263762,
+                "50.0" : 3547015.359905173,
+                "90.0" : 3565036.4281999436,
+                "95.0" : 3568764.462031803,
+                "99.0" : 3568944.8712661257,
+                "99.9" : 3568944.8712661257,
+                "99.99" : 3568944.8712661257,
+                "99.999" : 3568944.8712661257,
+                "99.9999" : 3568944.8712661257,
+                "100.0" : 3568944.8712661257
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3561895.6928990693,
+                    3553426.0627826694,
+                    3548053.8326885416,
+                    3558043.5620645178,
+                    3519378.0241228146,
+                    3530994.3210719796,
+                    3536230.200548192,
+                    3565336.6865796763,
+                    3568944.8712661257,
+                    3554760.066868773
+                ],
+                [
+                    3562334.102782349,
+                    3552793.769989658,
+                    3555080.9329396193,
+                    3531459.688837812,
+                    3523748.9076670213,
+                    3421578.069263762,
+                    3545976.887121805,
+                    3544290.9404509277,
+                    3508519.6366156624,
+                    3533871.606863149
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.4964151766206928E7,
+            "scoreError" : 178360.12659796193,
+            "scoreConfidence" : [
+                2.4785791639608964E7,
+                2.514251189280489E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.457094662051287E7,
+                "50.0" : 2.4967708840814173E7,
+                "90.0" : 2.522053363302198E7,
+                "95.0" : 2.5255724337686326E7,
+                "99.0" : 2.5257463820128858E7,
+                "99.9" : 2.5257463820128858E7,
+                "99.99" : 2.5257463820128858E7,
+                "99.999" : 2.5257463820128858E7,
+                "99.9999" : 2.5257463820128858E7,
+                "100.0" : 2.5257463820128858E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.480947525116602E7,
+                    2.4718038204607118E7,
+                    2.471411130294443E7,
+                    2.4874611881598014E7,
+                    2.457094662051287E7,
+                    2.4796899168887217E7,
+                    2.4795408786688775E7,
+                    2.4809061412987154E7,
+                    2.4895078006042976E7,
+                    2.480172687075592E7
+                ],
+                [
+                    2.5100936664225675E7,
+                    2.5158773282141376E7,
+                    2.513243408623298E7,
+                    2.5125704099608522E7,
+                    2.5131882971787672E7,
+                    2.512620025824382E7,
+                    2.5201268788715493E7,
+                    2.5257463820128858E7,
+                    2.5222674171278257E7,
+                    2.5040339675585374E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.201506171893262E7,
+            "scoreError" : 240406.15056148442,
+            "scoreConfidence" : [
+                4.177465556837114E7,
+                4.22554678694941E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.132843404656064E7,
+                "50.0" : 4.20141612738644E7,
+                "90.0" : 4.234847781184038E7,
+                "95.0" : 4.235314840944024E7,
+                "99.0" : 4.235328180790308E7,
+                "99.9" : 4.235328180790308E7,
+                "99.99" : 4.235328180790308E7,
+                "99.999" : 4.235328180790308E7,
+                "99.9999" : 4.235328180790308E7,
+                "100.0" : 4.235328180790308E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.1952029065484524E7,
+                    4.180301618300589E7,
+                    4.200687509522314E7,
+                    4.132843404656064E7,
+                    4.16742211570698E7,
+                    4.19549069120671E7,
+                    4.202123828383364E7,
+                    4.190723607229823E7,
+                    4.213736289656524E7,
+                    4.157002978128304E7
+                ],
+                [
+                    4.215924381871549E7,
+                    4.235061383864631E7,
+                    4.200708426389518E7,
+                    4.227359337074463E7,
+                    4.2129823682951435E7,
+                    4.182058871333637E7,
+                    4.235328180790308E7,
+                    4.2329253570587024E7,
+                    4.231511115809635E7,
+                    4.220729066038544E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3417919.6215406097,
+            "scoreError" : 15894.186681011794,
+            "scoreConfidence" : [
+                3402025.434859598,
+                3433813.8082216214
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3395519.9886689903,
+                "50.0" : 3414353.1134872274,
+                "90.0" : 3445956.1862992775,
+                "95.0" : 3458232.1775104254,
+                "99.0" : 3458878.076011822,
+                "99.9" : 3458878.076011822,
+                "99.99" : 3458878.076011822,
+                "99.999" : 3458878.076011822,
+                "99.9999" : 3458878.076011822,
+                "100.0" : 3458878.076011822
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3445920.9091377896,
+                    3445960.1059838873,
+                    3420641.127143721,
+                    3419730.034989073,
+                    3423853.1191891064,
+                    3442875.146564865,
+                    3416986.249849355,
+                    3458878.076011822,
+                    3429044.753827654,
+                    3407107.8891473725
+                ],
+                [
+                    3410150.6609846754,
+                    3404635.8411860447,
+                    3397710.4475727165,
+                    3400318.12228903,
+                    3415540.8043801473,
+                    3413165.4225943075,
+                    3406866.7308852985,
+                    3407942.2610830837,
+                    3395544.739323256,
+                    3395519.9886689903
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4452283.6867117975,
+            "scoreError" : 24557.205983844375,
+            "scoreConfidence" : [
+                4427726.480727953,
+                4476840.892695642
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4386858.786320931,
+                "50.0" : 4462156.96845954,
+                "90.0" : 4483074.563562703,
+                "95.0" : 4486093.320313884,
+                "99.0" : 4486245.714709812,
+                "99.9" : 4486245.714709812,
+                "99.99" : 4486245.714709812,
+                "99.999" : 4486245.714709812,
+                "99.9999" : 4486245.714709812,
+                "100.0" : 4486245.714709812
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4474961.476100788,
+                    4469860.536973156,
+                    4406832.325476616,
+                    4465310.446614227,
+                    4486245.714709812,
+                    4470490.475624786,
+                    4481965.194505794,
+                    4472344.85515435,
+                    4428736.691273041,
+                    4438270.808007125
+                ],
+                [
+                    4469014.707094319,
+                    4420873.693548592,
+                    4426801.135676757,
+                    4386858.786320931,
+                    4432980.845012507,
+                    4483197.826791248,
+                    4479678.687770268,
+                    4459003.490304853,
+                    4456646.468000517,
+                    4435599.56927627
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7106879229128856E7,
+            "scoreError" : 133155.40405083454,
+            "scoreConfidence" : [
+                2.697372382507802E7,
+                2.724003463317969E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6748475034911968E7,
+                "50.0" : 2.7115812290790547E7,
+                "90.0" : 2.7345295303160798E7,
+                "95.0" : 2.7378736461516026E7,
+                "99.0" : 2.738013982135249E7,
+                "99.9" : 2.738013982135249E7,
+                "99.99" : 2.738013982135249E7,
+                "99.999" : 2.738013982135249E7,
+                "99.9999" : 2.738013982135249E7,
+                "100.0" : 2.738013982135249E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.714845953868441E7,
+                    2.6879452635293044E7,
+                    2.703833963526231E7,
+                    2.7207339195218086E7,
+                    2.7284299409998775E7,
+                    2.738013982135249E7,
+                    2.7352072624623243E7,
+                    2.726117049468559E7,
+                    2.6748475034911968E7,
+                    2.700873127344203E7
+                ],
+                [
+                    2.710711221366742E7,
+                    2.7031600601924833E7,
+                    2.7036024422398005E7,
+                    2.7135347510733213E7,
+                    2.7177813642024156E7,
+                    2.7124512367913675E7,
+                    2.708526699199264E7,
+                    2.7075273943167966E7,
+                    2.7127152826701347E7,
+                    2.6929000398581874E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.0854000656529766E7,
+            "scoreError" : 196380.8685834703,
+            "scoreConfidence" : [
+                3.0657619787946295E7,
+                3.1050381525113236E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.034913131478327E7,
+                "50.0" : 3.0968926078279052E7,
+                "90.0" : 3.1091664154839188E7,
+                "95.0" : 3.1097281386627864E7,
+                "99.0" : 3.1097467259111412E7,
+                "99.9" : 3.1097467259111412E7,
+                "99.99" : 3.1097467259111412E7,
+                "99.999" : 3.1097467259111412E7,
+                "99.9999" : 3.1097467259111412E7,
+                "100.0" : 3.1097467259111412E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.0975793140433885E7,
+                    3.034913131478327E7,
+                    3.0757313942558464E7,
+                    3.1008865468072906E7,
+                    3.1097467259111412E7,
+                    3.1072893263427563E7,
+                    3.105695349488146E7,
+                    3.0593381930209108E7,
+                    3.071568360039226E7,
+                    3.109374980944048E7
+                ],
+                [
+                    3.073681479175932E7,
+                    3.0979181755615342E7,
+                    3.049848469860036E7,
+                    3.075671854188603E7,
+                    3.1037212151258226E7,
+                    3.102878713981114E7,
+                    3.097405074409639E7,
+                    3.0963801412461713E7,
+                    3.0508338569863617E7,
+                    3.0875390101932403E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3394707.8617747985,
+            "scoreError" : 26472.7985686967,
+            "scoreConfidence" : [
+                3368235.063206102,
+                3421180.660343495
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3352955.6996214916,
+                "50.0" : 3382123.8374718647,
+                "90.0" : 3434185.339156153,
+                "95.0" : 3436454.0948976385,
+                "99.0" : 3436570.9579101284,
+                "99.9" : 3436570.9579101284,
+                "99.99" : 3436570.9579101284,
+                "99.999" : 3436570.9579101284,
+                "99.9999" : 3436570.9579101284,
+                "100.0" : 3436570.9579101284
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3410819.2386726853,
+                    3409882.3746839315,
+                    3416738.2765210154,
+                    3431145.4608544605,
+                    3429372.1892027073,
+                    3436570.9579101284,
+                    3433750.112618522,
+                    3386149.514825373,
+                    3430715.99531803,
+                    3434233.6976603344
+                ],
+                [
+                    3377368.023303425,
+                    3369409.959315007,
+                    3368141.0444098976,
+                    3372920.914187408,
+                    3366482.651878071,
+                    3378098.1601183563,
+                    3360642.9688980873,
+                    3362337.766325095,
+                    3366422.229171935,
+                    3352955.6996214916
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4461928.096728117,
+            "scoreError" : 21451.08665767756,
+            "scoreConfidence" : [
+                4440477.010070439,
+                4483379.183385795
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4406026.286245354,
+                "50.0" : 4470987.848299084,
+                "90.0" : 4489905.594076758,
+                "95.0" : 4495866.704900816,
+                "99.0" : 4496136.2036835505,
+                "99.9" : 4496136.2036835505,
+                "99.99" : 4496136.2036835505,
+                "99.999" : 4496136.2036835505,
+                "99.9999" : 4496136.2036835505,
+                "100.0" : 4496136.2036835505
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4417393.986908298,
+                    4445164.976243933,
+                    4480864.775901348,
+                    4479286.956061841,
+                    4460427.629394143,
+                    4482339.888507788,
+                    4406026.286245354,
+                    4452470.015694779,
+                    4496136.2036835505,
+                    4490746.2280288655
+                ],
+                [
+                    4479571.856800035,
+                    4442948.09165518,
+                    4426979.749046606,
+                    4470820.3421836635,
+                    4445343.4586572535,
+                    4460732.307840816,
+                    4472031.005037523,
+                    4471155.354414505,
+                    4481666.439971234,
+                    4476456.382285635
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7541871521420322E7,
+            "scoreError" : 319087.3288458567,
+            "scoreConfidence" : [
+                2.7222784192574464E7,
+                2.786095885026618E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.70560865356732E7,
+                "50.0" : 2.737513235141447E7,
+                "90.0" : 2.8029191337939024E7,
+                "95.0" : 2.8052342926388863E7,
+                "99.0" : 2.8053526204553366E7,
+                "99.9" : 2.8053526204553366E7,
+                "99.99" : 2.8053526204553366E7,
+                "99.999" : 2.8053526204553366E7,
+                "99.9999" : 2.8053526204553366E7,
+                "100.0" : 2.8053526204553366E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.7788835784430224E7,
+                    2.772025176687703E7,
+                    2.8029860641263314E7,
+                    2.7984193973593954E7,
+                    2.7929298732078504E7,
+                    2.7777806571366042E7,
+                    2.7467244164656624E7,
+                    2.7965135355029766E7,
+                    2.8023167608020414E7,
+                    2.8053526204553366E7
+                ],
+                [
+                    2.7179149019507583E7,
+                    2.7273513116132915E7,
+                    2.727155834346996E7,
+                    2.727926499922404E7,
+                    2.7283020538172312E7,
+                    2.7162324824815013E7,
+                    2.7190992147359464E7,
+                    2.70560865356732E7,
+                    2.7260198421429195E7,
+                    2.714200168075353E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.0256326310069244E7,
+            "scoreError" : 238577.65055248197,
+            "scoreConfidence" : [
+                3.0017748659516763E7,
+                3.0494903960621726E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9731161896280006E7,
+                "50.0" : 3.0273477881323304E7,
+                "90.0" : 3.059538384270665E7,
+                "95.0" : 3.0603413173283327E7,
+                "99.0" : 3.0603808187594496E7,
+                "99.9" : 3.0603808187594496E7,
+                "99.99" : 3.0603808187594496E7,
+                "99.999" : 3.0603808187594496E7,
+                "99.9999" : 3.0603808187594496E7,
+                "100.0" : 3.0603808187594496E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.998247185301802E7,
+                    3.0142075565039705E7,
+                    3.0155176843367133E7,
+                    3.032694865335308E7,
+                    2.9902082498238616E7,
+                    2.9731161896280006E7,
+                    2.98659763533956E7,
+                    2.9960655878908876E7,
+                    3.0180936283814825E7,
+                    3.0053764534604393E7
+                ],
+                [
+                    3.0220007109293528E7,
+                    3.048960990315774E7,
+                    3.0603808187594496E7,
+                    3.0590667314726118E7,
+                    3.052200590571093E7,
+                    3.0595907901371155E7,
+                    3.039426738763382E7,
+                    3.0506454468610737E7,
+                    3.0375801383991577E7,
+                    3.052674627927455E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2365157.733079274,
+            "scoreError" : 43008.320505971526,
+            "scoreConfidence" : [
+                2322149.4125733026,
+                2408166.0535852457
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2301463.1368776364,
+                "50.0" : 2364005.247485097,
+                "90.0" : 2419733.579013847,
+                "95.0" : 2432370.9974005297,
+                "99.0" : 2433024.9092703573,
+                "99.9" : 2433024.9092703573,
+                "99.99" : 2433024.9092703573,
+                "99.999" : 2433024.9092703573,
+                "99.9999" : 2433024.9092703573,
+                "100.0" : 2433024.9092703573
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2312664.900791802,
+                    2313903.7162770987,
+                    2312866.442633425,
+                    2329578.3879917404,
+                    2310385.3822895964,
+                    2301463.1368776364,
+                    2325506.535933266,
+                    2322245.5955987587,
+                    2325411.8821493243,
+                    2323224.086862024
+                ],
+                [
+                    2411385.0190541637,
+                    2419946.6718738074,
+                    2414106.247566852,
+                    2417815.743274201,
+                    2403132.048804037,
+                    2417116.940412209,
+                    2398432.1069784537,
+                    2406809.5156187825,
+                    2404135.3913279464,
+                    2433024.9092703573
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3051250.1552564157,
+            "scoreError" : 10536.428997150872,
+            "scoreConfidence" : [
+                3040713.7262592646,
+                3061786.584253567
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3034312.459403747,
+                "50.0" : 3050481.897054894,
+                "90.0" : 3066693.762727835,
+                "95.0" : 3072624.1136144907,
+                "99.0" : 3072930.6049143816,
+                "99.9" : 3072930.6049143816,
+                "99.99" : 3072930.6049143816,
+                "99.999" : 3072930.6049143816,
+                "99.9999" : 3072930.6049143816,
+                "100.0" : 3072930.6049143816
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3063840.7581921327,
+                    3066800.7789165624,
+                    3063831.3139632097,
+                    3072930.6049143816,
+                    3042529.0077987015,
+                    3037115.269379191,
+                    3065730.6170292906,
+                    3061371.8018387174,
+                    3043947.1500447365,
+                    3059771.5140316845
+                ],
+                [
+                    3051904.2215302424,
+                    3059900.6107199844,
+                    3051741.6718853163,
+                    3039640.57260475,
+                    3045590.5957535068,
+                    3034312.459403747,
+                    3040465.326378189,
+                    3039308.8391008163,
+                    3035047.869418684,
+                    3049222.122224472
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3860670100150418E7,
+            "scoreError" : 221434.05347899627,
+            "scoreConfidence" : [
+                1.363923604667142E7,
+                1.4082104153629415E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.3483055298746156E7,
+                "50.0" : 1.385278384139065E7,
+                "90.0" : 1.4169630155998757E7,
+                "95.0" : 1.4214295645179033E7,
+                "99.0" : 1.4216522777674895E7,
+                "99.9" : 1.4216522777674895E7,
+                "99.99" : 1.4216522777674895E7,
+                "99.999" : 1.4216522777674895E7,
+                "99.9999" : 1.4216522777674895E7,
+                "100.0" : 1.4216522777674895E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3716973730070386E7,
+                    1.353352133461774E7,
+                    1.3527034566645233E7,
+                    1.3483055298746156E7,
+                    1.3607801725330543E7,
+                    1.3709783681683315E7,
+                    1.3828192558900679E7,
+                    1.3662461563986767E7,
+                    1.3602988811116084E7,
+                    1.3636527582270714E7
+                ],
+                [
+                    1.407253765554962E7,
+                    1.4118860828345532E7,
+                    1.4216522777674895E7,
+                    1.405857962577787E7,
+                    1.4171980127757655E7,
+                    1.414848041016867E7,
+                    1.4122234492392188E7,
+                    1.3877375123880625E7,
+                    1.4006407038678167E7,
+                    1.41120830694155E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.8961478902036473E7,
+            "scoreError" : 565866.1004761049,
+            "scoreConfidence" : [
+                1.839561280156037E7,
+                1.9527345002512578E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6765939771133991E7,
+                "50.0" : 1.9028526276989575E7,
+                "90.0" : 1.9701800652689002E7,
+                "95.0" : 1.981974703398362E7,
+                "99.0" : 1.9825410485997837E7,
+                "99.9" : 1.9825410485997837E7,
+                "99.99" : 1.9825410485997837E7,
+                "99.999" : 1.9825410485997837E7,
+                "99.9999" : 1.9825410485997837E7,
+                "100.0" : 1.9825410485997837E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9048718205800146E7,
+                    1.8629264641517613E7,
+                    1.8604342821597032E7,
+                    1.887835974510762E7,
+                    1.9008334348179005E7,
+                    1.9108157929472584E7,
+                    1.860639570466291E7,
+                    1.850075346173082E7,
+                    1.884809584040629E7,
+                    1.8569431448291305E7
+                ],
+                [
+                    1.6765939771133991E7,
+                    1.8931567719257433E7,
+                    1.944478031658991E7,
+                    1.9825410485997837E7,
+                    1.960873351546838E7,
+                    1.9244741911719862E7,
+                    1.928448404394919E7,
+                    1.9712141445713516E7,
+                    1.950880246819113E7,
+                    1.9101122215942852E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2277905.214801272,
+            "scoreError" : 20947.745401064727,
+            "scoreConfidence" : [
+                2256957.469400207,
+                2298852.960202337
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2237979.3378689936,
+                "50.0" : 2281680.8385423953,
+                "90.0" : 2306833.9781186087,
+                "95.0" : 2307510.624315287,
+                "99.0" : 2307542.869781633,
+                "99.9" : 2307542.869781633,
+                "99.99" : 2307542.869781633,
+                "99.999" : 2307542.869781633,
+                "99.9999" : 2307542.869781633,
+                "100.0" : 2307542.869781633
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2283310.774630721,
+                    2280050.90245407,
+                    2262240.5691272644,
+                    2264559.800315114,
+                    2279458.6446789675,
+                    2260266.413145964,
+                    2242756.804616933,
+                    2239941.05426064,
+                    2237979.3378689936,
+                    2239483.9810277633
+                ],
+                [
+                    2295574.207053686,
+                    2293752.3496204787,
+                    2305762.6859107423,
+                    2291795.9855085406,
+                    2306258.1370936576,
+                    2307542.869781633,
+                    2298675.8058464737,
+                    2306897.9604547145,
+                    2285055.72088153,
+                    2276740.29174755
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2972245.496556293,
+            "scoreError" : 102976.05221526074,
+            "scoreConfidence" : [
+                2869269.4443410323,
+                3075221.548771554
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2800135.989734462,
+                "50.0" : 2961116.0462931064,
+                "90.0" : 3110982.159449808,
+                "95.0" : 3120482.4391971924,
+                "99.0" : 3120917.225032604,
+                "99.9" : 3120917.225032604,
+                "99.99" : 3120917.225032604,
+                "99.999" : 3120917.225032604,
+                "99.9999" : 3120917.225032604,
+                "100.0" : 3120917.225032604
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2864396.864514674,
+                    2881945.3274166333,
+                    2839625.904973854,
+                    2887634.893249517,
+                    2875112.2337814705,
+                    2858326.731281785,
+                    2846931.369358015,
+                    2895427.6149102156,
+                    2849433.2594431406,
+                    2800135.989734462
+                ],
+                [
+                    3091521.765255552,
+                    3099141.7535514883,
+                    3112221.508324372,
+                    3095146.1340667997,
+                    3120917.225032604,
+                    3081887.0427967217,
+                    3073412.443260015,
+                    3026804.477675997,
+                    3045059.372919822,
+                    3099828.019578729
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.337179237993386E7,
+            "scoreError" : 143356.23651329754,
+            "scoreConfidence" : [
+                1.3228436143420562E7,
+                1.3515148616447158E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.2973862307593388E7,
+                "50.0" : 1.336599204183641E7,
+                "90.0" : 1.3631607927448949E7,
+                "95.0" : 1.3683759107856281E7,
+                "99.0" : 1.3686107436608652E7,
+                "99.9" : 1.3686107436608652E7,
+                "99.99" : 1.3686107436608652E7,
+                "99.999" : 1.3686107436608652E7,
+                "99.9999" : 1.3686107436608652E7,
+                "100.0" : 1.3686107436608652E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3505421011607915E7,
+                    1.3367581036217425E7,
+                    1.3507482320033915E7,
+                    1.3362128951456334E7,
+                    1.3333504643372884E7,
+                    1.3639140861561224E7,
+                    1.3686107436608652E7,
+                    1.3364403047455398E7,
+                    1.3563811520438466E7,
+                    1.3368773418493412E7
+                ],
+                [
+                    1.3321029188386163E7,
+                    1.3390583288476214E7,
+                    1.31952685397778E7,
+                    1.3435022000406452E7,
+                    1.3421545558803473E7,
+                    1.3238052523647225E7,
+                    1.3273448704715088E7,
+                    1.2973862307593388E7,
+                    1.3327488102762956E7,
+                    1.3161193136862772E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.884108732540825E7,
+            "scoreError" : 256644.47502475182,
+            "scoreConfidence" : [
+                1.8584442850383498E7,
+                1.9097731800433002E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.8240242887467545E7,
+                "50.0" : 1.8795095803585455E7,
+                "90.0" : 1.9282871712782454E7,
+                "95.0" : 1.939916662968081E7,
+                "99.0" : 1.9405128026617136E7,
+                "99.9" : 1.9405128026617136E7,
+                "99.99" : 1.9405128026617136E7,
+                "99.999" : 1.9405128026617136E7,
+                "99.9999" : 1.9405128026617136E7,
+                "100.0" : 1.9405128026617136E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9142424348062012E7,
+                    1.8604920606727615E7,
+                    1.925561633680933E7,
+                    1.9285900087890577E7,
+                    1.912893643235617E7,
+                    1.859281385812262E7,
+                    1.8240242887467545E7,
+                    1.9119150693630766E7,
+                    1.8811953677838027E7,
+                    1.9405128026617136E7
+                ],
+                [
+                    1.882217759697469E7,
+                    1.8801551381343193E7,
+                    1.8484056010031935E7,
+                    1.8699385453255706E7,
+                    1.873768783683996E7,
+                    1.883115031559326E7,
+                    1.877165251407713E7,
+                    1.878864022582772E7,
+                    1.8642574760125082E7,
+                    1.8655783458574556E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.FastShowPrettyBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 853719.9863297933,
+            "scoreError" : 11560.644665054639,
+            "scoreConfidence" : [
+                842159.3416647387,
+                865280.630994848
+            ],
+            "scorePercentiles" : {
+                "0.0" : 815308.8632940428,
+                "50.0" : 856185.0894223264,
+                "90.0" : 868640.7759486628,
+                "95.0" : 869374.5854278485,
+                "99.0" : 869382.2201136891,
+                "99.9" : 869382.2201136891,
+                "99.99" : 869382.2201136891,
+                "99.999" : 869382.2201136891,
+                "99.9999" : 869382.2201136891,
+                "100.0" : 869382.2201136891
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    856020.2164861006,
+                    833370.3718503714,
+                    843589.4493922455,
+                    815308.8632940428,
+                    832772.4308118485,
+                    862714.5681897919,
+                    859163.8414470447,
+                    854743.950907977,
+                    863342.0219147266,
+                    869229.526396878
+                ],
+                [
+                    858274.5397263174,
+                    861705.6861097025,
+                    862161.0266775882,
+                    852698.3351349784,
+                    854115.386409216,
+                    862514.4157067913,
+                    869382.2201136891,
+                    853504.2382699637,
+                    853438.6753980406,
+                    856349.9623585523
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.FastShowPrettyBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1178151.217785056,
+            "scoreError" : 7087.62425278313,
+            "scoreConfidence" : [
+                1171063.5935322728,
+                1185238.8420378391
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1158723.499360199,
+                "50.0" : 1180443.2577489275,
+                "90.0" : 1187209.6859962202,
+                "95.0" : 1187561.7447424897,
+                "99.0" : 1187574.348702513,
+                "99.9" : 1187574.348702513,
+                "99.99" : 1187574.348702513,
+                "99.999" : 1187574.348702513,
+                "99.9999" : 1187574.348702513,
+                "100.0" : 1187574.348702513
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1162311.1765822987,
+                    1170250.9631169708,
+                    1183846.4275600184,
+                    1181727.7670512102,
+                    1171391.4018989152,
+                    1182504.9291958278,
+                    1180103.688889104,
+                    1180654.474370471,
+                    1178220.283417756,
+                    1158723.499360199
+                ],
+                [
+                    1184203.2640154988,
+                    1178153.23041642,
+                    1187574.348702513,
+                    1181096.1673095298,
+                    1184941.7463025232,
+                    1186196.434443781,
+                    1187322.2695020468,
+                    1180232.041127384,
+                    1167277.26966989,
+                    1176292.9727687617
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.FastShowPrettyBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5623520724151809E7,
+            "scoreError" : 74815.36533361784,
+            "scoreConfidence" : [
+                1.554870535881819E7,
+                1.5698336089485427E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.5439887122446192E7,
+                "50.0" : 1.5640340128470793E7,
+                "90.0" : 1.5724305025943527E7,
+                "95.0" : 1.5739521876164675E7,
+                "99.0" : 1.574026193748508E7,
+                "99.9" : 1.574026193748508E7,
+                "99.99" : 1.574026193748508E7,
+                "99.999" : 1.574026193748508E7,
+                "99.9999" : 1.574026193748508E7,
+                "100.0" : 1.574026193748508E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.5489819447697392E7,
+                    1.5580821619375024E7,
+                    1.5516040022652175E7,
+                    1.556267859151921E7,
+                    1.5713903859742468E7,
+                    1.5650548081169091E7,
+                    1.570494463660595E7,
+                    1.5655773790043931E7,
+                    1.561681427679866E7,
+                    1.5725460711076979E7
+                ],
+                [
+                    1.565494575639408E7,
+                    1.5693318632471617E7,
+                    1.574026193748508E7,
+                    1.559735136974594E7,
+                    1.562306399107642E7,
+                    1.5630132175772494E7,
+                    1.570083738066494E7,
+                    1.5439887122446192E7,
+                    1.5496124129989324E7,
+                    1.567768695030923E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.FastShowPrettyBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3537199077256996E7,
+            "scoreError" : 78071.91301401223,
+            "scoreConfidence" : [
+                1.3459127164242985E7,
+                1.3615270990271008E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.3393787973390331E7,
+                "50.0" : 1.3530162899707379E7,
+                "90.0" : 1.364054511375936E7,
+                "95.0" : 1.369055603102098E7,
+                "99.0" : 1.369314695601806E7,
+                "99.9" : 1.369314695601806E7,
+                "99.99" : 1.369314695601806E7,
+                "99.999" : 1.369314695601806E7,
+                "99.9999" : 1.369314695601806E7,
+                "100.0" : 1.369314695601806E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.356476331066628E7,
+                    1.369314695601806E7,
+                    1.3632927968770612E7,
+                    1.3524097073337816E7,
+                    1.3622609019656468E7,
+                    1.364132845607647E7,
+                    1.3593496948663898E7,
+                    1.363349503290537E7,
+                    1.3627891135557305E7,
+                    1.36150989618258E7
+                ],
+                [
+                    1.3444634513939347E7,
+                    1.345591244474306E7,
+                    1.3426212921525968E7,
+                    1.3484224564777732E7,
+                    1.3482217284354057E7,
+                    1.3536228726076942E7,
+                    1.343980260064754E7,
+                    1.3393787973390331E7,
+                    1.3485996825130623E7,
+                    1.3446108827076228E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3279171.2749737822,
+            "scoreError" : 27310.14422823024,
+            "scoreConfidence" : [
+                3251861.130745552,
+                3306481.4192020125
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3204675.4877706445,
+                "50.0" : 3287157.9977871976,
+                "90.0" : 3311676.525160765,
+                "95.0" : 3311911.0004236344,
+                "99.0" : 3311914.0070778755,
+                "99.9" : 3311914.0070778755,
+                "99.99" : 3311914.0070778755,
+                "99.999" : 3311914.0070778755,
+                "99.9999" : 3311914.0070778755,
+                "100.0" : 3311914.0070778755
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3290039.318567589,
+                    3209054.6681800536,
+                    3287840.2597300825,
+                    3297966.978578677,
+                    3309611.205452582,
+                    3310080.3856701977,
+                    3278321.035413234,
+                    3288590.8060264024,
+                    3272173.93967327,
+                    3311853.87399305
+                ],
+                [
+                    3299552.212540389,
+                    3283729.5102152294,
+                    3273301.2882061526,
+                    3290964.782875544,
+                    3275179.6614721958,
+                    3311914.0070778755,
+                    3204675.4877706445,
+                    3224976.0025033513,
+                    3277124.339684806,
+                    3286475.7358443127
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3594941.730184869,
+            "scoreError" : 26483.841863541784,
+            "scoreConfidence" : [
+                3568457.888321327,
+                3621425.572048411
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3542107.9378744215,
+                "50.0" : 3597149.7768702535,
+                "90.0" : 3628224.6322436905,
+                "95.0" : 3640298.989369743,
+                "99.0" : 3640913.1132076057,
+                "99.9" : 3640913.1132076057,
+                "99.99" : 3640913.1132076057,
+                "99.999" : 3640913.1132076057,
+                "99.9999" : 3640913.1132076057,
+                "100.0" : 3640913.1132076057
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3621027.057293891,
+                    3595583.947431347,
+                    3557200.40361542,
+                    3628630.6364503503,
+                    3616581.6547301086,
+                    3578826.4054299127,
+                    3613747.737398795,
+                    3591841.518878018,
+                    3617715.9831844387,
+                    3620715.0659512896
+                ],
+                [
+                    3560205.1683257683,
+                    3591162.3739621215,
+                    3621096.66286569,
+                    3580314.7353945044,
+                    3640913.1132076057,
+                    3624570.5943837543,
+                    3546630.6497391653,
+                    3542107.9378744215,
+                    3551247.3512716074,
+                    3598715.6063091606
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.680250869137937E7,
+            "scoreError" : 394689.1564377461,
+            "scoreConfidence" : [
+                1.6407819534941623E7,
+                1.7197197847817115E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.5725509400593834E7,
+                "50.0" : 1.694561611563687E7,
+                "90.0" : 1.721376413874829E7,
+                "95.0" : 1.7310353242382552E7,
+                "99.0" : 1.731530677058245E7,
+                "99.9" : 1.731530677058245E7,
+                "99.99" : 1.731530677058245E7,
+                "99.999" : 1.731530677058245E7,
+                "99.9999" : 1.731530677058245E7,
+                "100.0" : 1.731530677058245E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.5725509400593834E7,
+                    1.731530677058245E7,
+                    1.701995758891093E7,
+                    1.640175289368971E7,
+                    1.661638731502561E7,
+                    1.5995552082772287E7,
+                    1.6833325086231366E7,
+                    1.695066230654556E7,
+                    1.5891161400752533E7,
+                    1.721623620658452E7
+                ],
+                [
+                    1.682594468562028E7,
+                    1.7090876049576297E7,
+                    1.7121578048972685E7,
+                    1.6940569924728185E7,
+                    1.717390827017919E7,
+                    1.6823491035697166E7,
+                    1.71915155282222E7,
+                    1.6959878820697803E7,
+                    1.7018316432878543E7,
+                    1.6938243979326237E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.581462771937661E7,
+            "scoreError" : 1273278.064254992,
+            "scoreConfidence" : [
+                3.454134965512162E7,
+                3.70879057836316E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.96866912960629E7,
+                "50.0" : 3.6120355772962525E7,
+                "90.0" : 3.6520346365813196E7,
+                "95.0" : 3.65889634092798E7,
+                "99.0" : 3.659246824967414E7,
+                "99.9" : 3.659246824967414E7,
+                "99.99" : 3.659246824967414E7,
+                "99.999" : 3.659246824967414E7,
+                "99.9999" : 3.659246824967414E7,
+                "100.0" : 3.659246824967414E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.6522371441787384E7,
+                    3.6096254524264984E7,
+                    3.631168714872574E7,
+                    3.6502120682045475E7,
+                    3.619450838118748E7,
+                    3.6163664393383436E7,
+                    3.629914836072745E7,
+                    3.659246824967414E7,
+                    2.96866912960629E7,
+                    3.6439248948098235E7
+                ],
+                [
+                    3.5819071107255526E7,
+                    3.6088089825260594E7,
+                    3.6144457021660075E7,
+                    3.5714118854772516E7,
+                    3.6088296308392175E7,
+                    3.565881186039669E7,
+                    3.5812534740945004E7,
+                    3.6095786863803886E7,
+                    3.589472983351885E7,
+                    3.616849454556975E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3294216.741475178,
+            "scoreError" : 21885.610488352937,
+            "scoreConfidence" : [
+                3272331.130986825,
+                3316102.3519635308
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3240462.4746906497,
+                "50.0" : 3296007.0609260183,
+                "90.0" : 3328260.6784339077,
+                "95.0" : 3331655.169479978,
+                "99.0" : 3331825.427642518,
+                "99.9" : 3331825.427642518,
+                "99.99" : 3331825.427642518,
+                "99.999" : 3331825.427642518,
+                "99.9999" : 3331825.427642518,
+                "100.0" : 3331825.427642518
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3304121.7017328492,
+                    3288804.9587341994,
+                    3295643.7312312033,
+                    3328420.2643917142,
+                    3326824.4048136463,
+                    3317255.363480235,
+                    3299807.556116836,
+                    3314839.3204215495,
+                    3240462.4746906497,
+                    3331825.427642518
+                ],
+                [
+                    3308621.7985088998,
+                    3296370.390620833,
+                    3314443.990226336,
+                    3284415.009705904,
+                    3268873.9057819024,
+                    3252346.471520654,
+                    3268863.960453226,
+                    3286944.7034076336,
+                    3272115.7360122143,
+                    3283333.6600105586
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3599360.4305404485,
+            "scoreError" : 14210.011651425419,
+            "scoreConfidence" : [
+                3585150.418889023,
+                3613570.442191874
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3560753.270283721,
+                "50.0" : 3604480.202761502,
+                "90.0" : 3619256.7497713603,
+                "95.0" : 3621181.1583579504,
+                "99.0" : 3621264.6054366915,
+                "99.9" : 3621264.6054366915,
+                "99.99" : 3621264.6054366915,
+                "99.999" : 3621264.6054366915,
+                "99.9999" : 3621264.6054366915,
+                "100.0" : 3621264.6054366915
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3592417.4177078605,
+                    3604786.5150635806,
+                    3599149.5771761453,
+                    3606858.2257244317,
+                    3568102.927111389,
+                    3576101.024562868,
+                    3616206.522956814,
+                    3611010.8595147156,
+                    3619595.663861865,
+                    3601602.115582494
+                ],
+                [
+                    3601863.6556184697,
+                    3604209.690495747,
+                    3584177.964546342,
+                    3609115.4094879706,
+                    3560753.270283721,
+                    3589830.0423907056,
+                    3604781.957830114,
+                    3621264.6054366915,
+                    3610630.450429788,
+                    3604750.7150272573
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5536969499496156E7,
+            "scoreError" : 872835.8843611452,
+            "scoreConfidence" : [
+                1.466413361513501E7,
+                1.6409805383857302E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.3596395168963738E7,
+                "50.0" : 1.5694121409336478E7,
+                "90.0" : 1.6733385530828556E7,
+                "95.0" : 1.681697968722253E7,
+                "99.0" : 1.6821109838838406E7,
+                "99.9" : 1.6821109838838406E7,
+                "99.99" : 1.6821109838838406E7,
+                "99.999" : 1.6821109838838406E7,
+                "99.9999" : 1.6821109838838406E7,
+                "100.0" : 1.6821109838838406E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6133460819812646E7,
+                    1.4644409775350869E7,
+                    1.5759867863661578E7,
+                    1.5628374955011379E7,
+                    1.6444309598246291E7,
+                    1.524178499805596E7,
+                    1.6269763899165306E7,
+                    1.587254681453591E7,
+                    1.4184866473117938E7,
+                    1.6687294049597427E7
+                ],
+                [
+                    1.660811947945765E7,
+                    1.445232048143075E7,
+                    1.4972012901395803E7,
+                    1.6821109838838406E7,
+                    1.6469975452963063E7,
+                    1.5548367326155724E7,
+                    1.4293375470221514E7,
+                    1.4372527817420308E7,
+                    1.3596395168963738E7,
+                    1.6738506806520903E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.638507697009376E7,
+            "scoreError" : 286762.22156325245,
+            "scoreConfidence" : [
+                3.609831474853051E7,
+                3.667183919165701E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.56267525481201E7,
+                "50.0" : 3.637308235760359E7,
+                "90.0" : 3.6811776003699504E7,
+                "95.0" : 3.6892911814479865E7,
+                "99.0" : 3.6896617957737386E7,
+                "99.9" : 3.6896617957737386E7,
+                "99.99" : 3.6896617957737386E7,
+                "99.999" : 3.6896617957737386E7,
+                "99.9999" : 3.6896617957737386E7,
+                "100.0" : 3.6896617957737386E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.669210136200194E7,
+                    3.662900085589865E7,
+                    3.661086690073582E7,
+                    3.646269052521981E7,
+                    3.664753740051786E7,
+                    3.6896617957737386E7,
+                    3.682249509258704E7,
+                    3.671530420371171E7,
+                    3.667010542502662E7,
+                    3.6537186715062045E7
+                ],
+                [
+                    3.610263784057092E7,
+                    3.620672394766372E7,
+                    3.597868354874441E7,
+                    3.61144952351926E7,
+                    3.607057433132568E7,
+                    3.620078315485107E7,
+                    3.619335327575783E7,
+                    3.628347418998736E7,
+                    3.624015489116258E7,
+                    3.56267525481201E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3750350.2170846188,
+            "scoreError" : 30820.152385891768,
+            "scoreConfidence" : [
+                3719530.064698727,
+                3781170.3694705106
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3675609.204549601,
+                "50.0" : 3760394.115013014,
+                "90.0" : 3790417.0945184776,
+                "95.0" : 3797231.5225335024,
+                "99.0" : 3797582.6566502186,
+                "99.9" : 3797582.6566502186,
+                "99.99" : 3797582.6566502186,
+                "99.999" : 3797582.6566502186,
+                "99.9999" : 3797582.6566502186,
+                "100.0" : 3797582.6566502186
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3761803.6014386015,
+                    3764778.447813586,
+                    3797582.6566502186,
+                    3785254.6145236646,
+                    3773337.799521615,
+                    3782991.821118068,
+                    3789131.1763417553,
+                    3790559.974315891,
+                    3773680.4926114716,
+                    3780710.246342061
+                ],
+                [
+                    3752464.1882432573,
+                    3708108.431206818,
+                    3708368.858103987,
+                    3718507.280626288,
+                    3708454.516066912,
+                    3722920.921814839,
+                    3758984.6285874266,
+                    3718820.637557007,
+                    3675609.204549601,
+                    3734934.844259339
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.552631484823988E7,
+            "scoreError" : 227968.32892110487,
+            "scoreConfidence" : [
+                3.5298346519318774E7,
+                3.575428317716098E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.511242699919187E7,
+                "50.0" : 3.549509661185492E7,
+                "90.0" : 3.596993902916725E7,
+                "95.0" : 3.600228956586237E7,
+                "99.0" : 3.600333040808742E7,
+                "99.9" : 3.600333040808742E7,
+                "99.99" : 3.600333040808742E7,
+                "99.999" : 3.600333040808742E7,
+                "99.9999" : 3.600333040808742E7,
+                "100.0" : 3.600333040808742E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.548412228383533E7,
+                    3.519119277195657E7,
+                    3.51874342396766E7,
+                    3.5218619255895756E7,
+                    3.511242699919187E7,
+                    3.553341742112285E7,
+                    3.554585750377774E7,
+                    3.550607093987451E7,
+                    3.538537357730465E7,
+                    3.534113824836985E7
+                ],
+                [
+                    3.5421080647565894E7,
+                    3.573534213243204E7,
+                    3.545981869571931E7,
+                    3.585676821939342E7,
+                    3.598251356358656E7,
+                    3.5717533647604704E7,
+                    3.575281984355457E7,
+                    3.536278406590417E7,
+                    3.5728652499943644E7,
+                    3.600333040808742E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4480187.173660496,
+            "scoreError" : 153941.84231611073,
+            "scoreConfidence" : [
+                4326245.331344386,
+                4634129.015976607
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4099558.5980334105,
+                "50.0" : 4462855.640927956,
+                "90.0" : 4697505.626802743,
+                "95.0" : 4707364.2236735625,
+                "99.0" : 4707745.677691649,
+                "99.9" : 4707745.677691649,
+                "99.99" : 4707745.677691649,
+                "99.999" : 4707745.677691649,
+                "99.9999" : 4707745.677691649,
+                "100.0" : 4707745.677691649
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4627362.74712059,
+                    4320698.805150879,
+                    4700116.597329932,
+                    4707745.677691649,
+                    4674006.892058045,
+                    4665148.441863047,
+                    4504496.542316441,
+                    4588274.267241933,
+                    4653613.367587927,
+                    4653174.906871416
+                ],
+                [
+                    4259589.533110276,
+                    4279517.0512519535,
+                    4099558.5980334105,
+                    4454116.960154064,
+                    4458501.931589141,
+                    4454552.408153542,
+                    4291444.128407713,
+                    4297651.148935908,
+                    4446964.118075278,
+                    4467209.350266772
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4729993.825474766,
+            "scoreError" : 114209.21493364565,
+            "scoreConfidence" : [
+                4615784.61054112,
+                4844203.040408412
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4460298.183894426,
+                "50.0" : 4733647.569165094,
+                "90.0" : 4892934.950163355,
+                "95.0" : 4896708.754726936,
+                "99.0" : 4896896.361528561,
+                "99.9" : 4896896.361528561,
+                "99.99" : 4896896.361528561,
+                "99.999" : 4896896.361528561,
+                "99.9999" : 4896896.361528561,
+                "100.0" : 4896896.361528561
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4771096.817213174,
+                    4612876.853311513,
+                    4683269.112074245,
+                    4658745.616332633,
+                    4891051.4721690705,
+                    4835449.61802468,
+                    4846742.657459023,
+                    4743040.286258274,
+                    4466386.380959438,
+                    4890656.760120287
+                ],
+                [
+                    4675584.620622999,
+                    4804657.172082643,
+                    4628871.950491793,
+                    4460298.183894426,
+                    4893144.225496054,
+                    4791040.655786233,
+                    4724254.852071914,
+                    4686469.754502937,
+                    4639343.159095418,
+                    4896896.361528561
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.265773346456432E7,
+            "scoreError" : 652727.7794749193,
+            "scoreConfidence" : [
+                6.20050056850894E7,
+                6.3310461244039245E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.052600779485224E7,
+                "50.0" : 6.292698014107706E7,
+                "90.0" : 6.3429427287482366E7,
+                "95.0" : 6.346553893233186E7,
+                "99.0" : 6.346651888546119E7,
+                "99.9" : 6.346651888546119E7,
+                "99.99" : 6.346651888546119E7,
+                "99.999" : 6.346651888546119E7,
+                "99.9999" : 6.346651888546119E7,
+                "100.0" : 6.346651888546119E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.302907317616369E7,
+                    6.3271994468952715E7,
+                    6.299263000214843E7,
+                    6.346651888546119E7,
+                    6.052600779485224E7,
+                    6.2956034453925945E7,
+                    6.3136933703940615E7,
+                    6.293793703655073E7,
+                    6.3446919822874546E7,
+                    6.179626919535626E7
+                ],
+                [
+                    6.263325706561741E7,
+                    6.322460420306415E7,
+                    6.290356823077261E7,
+                    6.199541433839895E7,
+                    6.281334539314096E7,
+                    6.126676947576074E7,
+                    6.247668980180978E7,
+                    6.291602324560339E7,
+                    6.304767417939942E7,
+                    6.231700481749271E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.9266398307395615E7,
+            "scoreError" : 449118.4213850165,
+            "scoreConfidence" : [
+                5.8817279886010595E7,
+                5.9715516728780635E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.797713970210215E7,
+                "50.0" : 5.925608699161227E7,
+                "90.0" : 5.998449378238518E7,
+                "95.0" : 6.000033604241109E7,
+                "99.0" : 6.000061828553481E7,
+                "99.9" : 6.000061828553481E7,
+                "99.99" : 6.000061828553481E7,
+                "99.999" : 6.000061828553481E7,
+                "99.9999" : 6.000061828553481E7,
+                "100.0" : 6.000061828553481E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.937984066232178E7,
+                    5.797713970210215E7,
+                    5.977802192610821E7,
+                    5.92191515116413E7,
+                    5.980736410407963E7,
+                    5.883766656346875E7,
+                    5.849756395464665E7,
+                    5.898434068485992E7,
+                    5.93588917170812E7,
+                    5.9631914917498104E7
+                ],
+                [
+                    5.946692731531317E7,
+                    5.999497342306042E7,
+                    5.889767205742847E7,
+                    5.989017701630805E7,
+                    5.925705123298478E7,
+                    5.8888971998147614E7,
+                    5.925512275023975E7,
+                    5.899621811503963E7,
+                    5.920833821004777E7,
+                    6.000061828553481E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4472222.0150203165,
+            "scoreError" : 149830.9573229448,
+            "scoreConfidence" : [
+                4322391.057697372,
+                4622052.972343261
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4120174.5143555095,
+                "50.0" : 4457770.626118047,
+                "90.0" : 4678947.468784471,
+                "95.0" : 4682600.584730623,
+                "99.0" : 4682773.927953315,
+                "99.9" : 4682773.927953315,
+                "99.99" : 4682773.927953315,
+                "99.999" : 4682773.927953315,
+                "99.9999" : 4682773.927953315,
+                "100.0" : 4682773.927953315
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4447720.611955427,
+                    4439586.958118499,
+                    4444430.363815269,
+                    4367919.165887719,
+                    4120174.5143555095,
+                    4392653.21913006,
+                    4239711.465113505,
+                    4387062.752370985,
+                    4343970.160079879,
+                    4154505.11526101
+                ],
+                [
+                    4586952.217118719,
+                    4679307.063499485,
+                    4670954.555660549,
+                    4675711.116349344,
+                    4520642.088964603,
+                    4467820.640280669,
+                    4660660.187388456,
+                    4682773.927953315,
+                    4563892.22393826,
+                    4597991.953165051
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4757594.461704287,
+            "scoreError" : 150373.5448441227,
+            "scoreConfidence" : [
+                4607220.916860164,
+                4907968.006548409
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4257845.33920532,
+                "50.0" : 4809315.823156681,
+                "90.0" : 4916669.618270785,
+                "95.0" : 4924078.89176447,
+                "99.0" : 4924334.449004899,
+                "99.9" : 4924334.449004899,
+                "99.99" : 4924334.449004899,
+                "99.999" : 4924334.449004899,
+                "99.9999" : 4924334.449004899,
+                "100.0" : 4924334.449004899
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4818809.855754008,
+                    4568507.45985993,
+                    4924334.449004899,
+                    4919223.304196335,
+                    4851079.365240445,
+                    4799821.790559355,
+                    4852122.146412116,
+                    4582186.1372160325,
+                    4549678.65025883,
+                    4794438.298551603
+                ],
+                [
+                    4257845.33920532,
+                    4884538.592298025,
+                    4884873.327298352,
+                    4701502.602385043,
+                    4747459.210575888,
+                    4550542.813904495,
+                    4798631.971257823,
+                    4888676.373991567,
+                    4893686.444940831,
+                    4883931.101174851
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.221949419437959E7,
+            "scoreError" : 745947.7598809918,
+            "scoreConfidence" : [
+                6.14735464344986E7,
+                6.296544195426058E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.051341641783981E7,
+                "50.0" : 6.251077428127283E7,
+                "90.0" : 6.3165442397867136E7,
+                "95.0" : 6.3380363308964126E7,
+                "99.0" : 6.3391488810529225E7,
+                "99.9" : 6.3391488810529225E7,
+                "99.99" : 6.3391488810529225E7,
+                "99.999" : 6.3391488810529225E7,
+                "99.9999" : 6.3391488810529225E7,
+                "100.0" : 6.3391488810529225E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.2748992827212274E7,
+                    6.155027157880068E7,
+                    6.062071046463068E7,
+                    6.28365574376861E7,
+                    6.162563858377345E7,
+                    6.252176798310064E7,
+                    6.274407455971733E7,
+                    6.070670237656529E7,
+                    6.17020804265781E7,
+                    6.2476600177087076E7
+                ],
+                [
+                    6.278517093150645E7,
+                    6.316897877922729E7,
+                    6.249978057944503E7,
+                    6.051341641783981E7,
+                    6.276209589349123E7,
+                    6.260635501839328E7,
+                    6.215879411872106E7,
+                    6.3391488810529225E7,
+                    6.1836791957661346E7,
+                    6.313361496562575E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.106059218920735E7,
+            "scoreError" : 1178159.1966693809,
+            "scoreConfidence" : [
+                5.9882432992537975E7,
+                6.223875138587673E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.906807756529625E7,
+                "50.0" : 6.0707722186345786E7,
+                "90.0" : 6.2744830155069746E7,
+                "95.0" : 6.2832516545402214E7,
+                "99.0" : 6.283713015572765E7,
+                "99.9" : 6.283713015572765E7,
+                "99.99" : 6.283713015572765E7,
+                "99.999" : 6.283713015572765E7,
+                "99.9999" : 6.283713015572765E7,
+                "100.0" : 6.283713015572765E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.988114636037602E7,
+                    5.996017830797692E7,
+                    6.004783546219013E7,
+                    6.0060261508347474E7,
+                    5.906807756529625E7,
+                    5.970460053972399E7,
+                    5.98480547532794E7,
+                    5.984789539640317E7,
+                    5.9657194792696945E7,
+                    6.015950236016069E7
+                ],
+                [
+                    6.1929519001482025E7,
+                    6.272915336571825E7,
+                    6.1255942012530886E7,
+                    6.198636132718595E7,
+                    6.2744857949218936E7,
+                    6.131545149587588E7,
+                    6.270167311594393E7,
+                    6.273242830628532E7,
+                    6.274458000772704E7,
+                    6.283713015572765E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4318929.231084751,
+            "scoreError" : 92868.99364729322,
+            "scoreConfidence" : [
+                4226060.237437458,
+                4411798.224732044
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4035297.426670001,
+                "50.0" : 4355404.238982286,
+                "90.0" : 4418482.365760755,
+                "95.0" : 4419452.781339363,
+                "99.0" : 4419459.418135924,
+                "99.9" : 4419459.418135924,
+                "99.99" : 4419459.418135924,
+                "99.999" : 4419459.418135924,
+                "99.9999" : 4419459.418135924,
+                "100.0" : 4419459.418135924
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4302350.125771604,
+                    4235096.25785201,
+                    4408042.298184084,
+                    4371761.174226813,
+                    4364123.878152335,
+                    4271629.9828572925,
+                    4364191.332989745,
+                    4035297.426670001,
+                    4410883.517765173,
+                    4385687.7512604315
+                ],
+                [
+                    4397914.1941927755,
+                    4346684.599812237,
+                    4178274.4090744606,
+                    4330947.534081918,
+                    4419459.418135924,
+                    4343572.302124131,
+                    4306401.206178062,
+                    4385458.792454236,
+                    4101481.737707085,
+                    4419326.682204708
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4722546.362004924,
+            "scoreError" : 117322.44649004776,
+            "scoreConfidence" : [
+                4605223.915514876,
+                4839868.808494971
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4393024.951067043,
+                "50.0" : 4727440.7330408525,
+                "90.0" : 4850017.920128909,
+                "95.0" : 4864055.240454516,
+                "99.0" : 4864780.87719422,
+                "99.9" : 4864780.87719422,
+                "99.99" : 4864780.87719422,
+                "99.999" : 4864780.87719422,
+                "99.9999" : 4864780.87719422,
+                "100.0" : 4864780.87719422
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4844173.733247922,
+                    4725848.940085664,
+                    4799813.991281477,
+                    4690428.508265123,
+                    4431249.508056975,
+                    4726677.046270502,
+                    4728204.419811202,
+                    4803790.326451795,
+                    4700839.946945863,
+                    4669146.122974665
+                ],
+                [
+                    4535278.41614086,
+                    4780248.93535636,
+                    4693829.350526897,
+                    4681858.938720519,
+                    4836985.959481101,
+                    4393024.951067043,
+                    4847765.919687856,
+                    4846713.206132301,
+                    4864780.87719422,
+                    4850268.142400137
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.originalSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.915434025540188E7,
+            "scoreError" : 1003728.2171146026,
+            "scoreConfidence" : [
+                6.815061203828728E7,
+                7.015806847251648E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.709929591971785E7,
+                "50.0" : 6.910136098008461E7,
+                "90.0" : 7.08580832043088E7,
+                "95.0" : 7.106063701408637E7,
+                "99.0" : 7.107046994650215E7,
+                "99.9" : 7.107046994650215E7,
+                "99.99" : 7.107046994650215E7,
+                "99.999" : 7.107046994650215E7,
+                "99.9999" : 7.107046994650215E7,
+                "100.0" : 7.107046994650215E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.8656020339567E7,
+                    6.728288903055854E7,
+                    6.85582546457919E7,
+                    6.900913008829547E7,
+                    6.88828696203158E7,
+                    6.895930948254877E7,
+                    6.709929591971785E7,
+                    6.719991819145976E7,
+                    6.892575456868476E7,
+                    6.801048012160905E7
+                ],
+                [
+                    6.989881558469655E7,
+                    6.955141960224059E7,
+                    6.919359187187375E7,
+                    7.087381129818648E7,
+                    6.969332635190266E7,
+                    7.023659271429239E7,
+                    6.977393814769787E7,
+                    7.071653035940953E7,
+                    6.949438722268657E7,
+                    7.107046994650215E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.076618426343322E7,
+            "scoreError" : 1344843.2900947346,
+            "scoreConfidence" : [
+                5.9421340973338485E7,
+                6.211102755352795E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.807070536129908E7,
+                "50.0" : 6.086986031906398E7,
+                "90.0" : 6.258777353151638E7,
+                "95.0" : 6.2618401982167564E7,
+                "99.0" : 6.261961507631979E7,
+                "99.9" : 6.261961507631979E7,
+                "99.99" : 6.261961507631979E7,
+                "99.999" : 6.261961507631979E7,
+                "99.9999" : 6.261961507631979E7,
+                "100.0" : 6.261961507631979E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.2519556575686716E7,
+                    6.212125008817644E7,
+                    6.181249828659396E7,
+                    6.1528597000557266E7,
+                    6.214614557780902E7,
+                    6.2595353193275236E7,
+                    6.232141911940563E7,
+                    6.261961507631979E7,
+                    6.185474697698626E7,
+                    6.105990127654702E7
+                ],
+                [
+                    5.8480778427737094E7,
+                    5.915893148978746E7,
+                    5.899622960421154E7,
+                    5.807070536129908E7,
+                    5.809746196589447E7,
+                    6.043767289777996E7,
+                    6.067981936158093E7,
+                    6.0587669228201E7,
+                    5.973343438422115E7,
+                    6.0501899376594424E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.handWrittenDeepName",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.881004425524388E7,
+            "scoreError" : 1384730.3736746714,
+            "scoreConfidence" : [
+                9.74253138815692E7,
+                1.0019477462891856E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.365375947943181E7,
+                "50.0" : 9.91456766162996E7,
+                "90.0" : 1.0044085448967762E8,
+                "95.0" : 1.004809129009361E8,
+                "99.0" : 1.0048294294050498E8,
+                "99.9" : 1.0048294294050498E8,
+                "99.99" : 1.0048294294050498E8,
+                "99.999" : 1.0048294294050498E8,
+                "99.9999" : 1.0048294294050498E8,
+                "100.0" : 1.0048294294050498E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.872889457505381E7,
+                    9.801102854937275E7,
+                    9.916472132146908E7,
+                    9.843340768991682E7,
+                    9.824588639524667E7,
+                    9.711121175231084E7,
+                    9.365375947943181E7,
+                    1.0036851434540729E8,
+                    9.869323603981277E7,
+                    9.768187335532074E7
+                ],
+                [
+                    9.92933207870222E7,
+                    9.756236837587589E7,
+                    1.0042746555463158E8,
+                    9.915867852298625E7,
+                    1.0021537328694148E8,
+                    9.913267470961294E7,
+                    1.0044234214912719E8,
+                    1.0005326242796537E8,
+                    1.0048294294050498E8,
+                    9.933992284686749E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.handWrittenEachSalary",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.14233288063529E7,
+            "scoreError" : 446235.28055961634,
+            "scoreConfidence" : [
+                2.097709352579328E7,
+                2.1869564086912517E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.0750272183548294E7,
+                "50.0" : 2.1353730368914053E7,
+                "90.0" : 2.203754761141437E7,
+                "95.0" : 2.2059373643613376E7,
+                "99.0" : 2.2060115963680957E7,
+                "99.9" : 2.2060115963680957E7,
+                "99.99" : 2.2060115963680957E7,
+                "99.999" : 2.2060115963680957E7,
+                "99.9999" : 2.2060115963680957E7,
+                "100.0" : 2.2060115963680957E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.090042064366192E7,
+                    2.1054113989458814E7,
+                    2.101778422512375E7,
+                    2.0977054817264777E7,
+                    2.0957030127436E7,
+                    2.102242011231879E7,
+                    2.1019400710587196E7,
+                    2.084047822193346E7,
+                    2.0750272183548294E7,
+                    2.0804719727333877E7
+                ],
+                [
+                    2.165334674836929E7,
+                    2.176173399081447E7,
+                    2.1934537223628335E7,
+                    2.193809699989663E7,
+                    2.1892747721824963E7,
+                    2.1968050053179428E7,
+                    2.2060115963680957E7,
+                    2.2045269562329363E7,
+                    2.196347902659866E7,
+                    2.1905504078069042E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.kindlingsDeepName",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.8976054041519E7,
+            "scoreError" : 1561984.5562690573,
+            "scoreConfidence" : [
+                9.741406948524994E7,
+                1.0053803859778807E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.416732599621932E7,
+                "50.0" : 9.918379095896238E7,
+                "90.0" : 1.0070220836641301E8,
+                "95.0" : 1.0085977012609923E8,
+                "99.0" : 1.0086795321400055E8,
+                "99.9" : 1.0086795321400055E8,
+                "99.99" : 1.0086795321400055E8,
+                "99.999" : 1.0086795321400055E8,
+                "99.9999" : 1.0086795321400055E8,
+                "100.0" : 1.0086795321400055E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0026546217154156E8,
+                    1.0070429145597409E8,
+                    1.0086795321400055E8,
+                    1.0065692796229532E8,
+                    1.0068346056036326E8,
+                    1.0066893367500347E8,
+                    1.0033989391591394E8,
+                    9.942538027567297E7,
+                    9.923665537862223E7,
+                    1.0056289019020702E8
+                ],
+                [
+                    9.833051267897137E7,
+                    9.86526540101139E7,
+                    9.585824176653756E7,
+                    9.855301129380965E7,
+                    9.826290655988176E7,
+                    9.416732599621932E7,
+                    9.687470533626467E7,
+                    9.913092653930251E7,
+                    9.791476796709245E7,
+                    9.836417988259189E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.kindlingsEachSalary",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1780918292466134E7,
+            "scoreError" : 55448.54896501389,
+            "scoreConfidence" : [
+                2.172546974350112E7,
+                2.183636684143115E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.165293764597935E7,
+                "50.0" : 2.179311281982295E7,
+                "90.0" : 2.1861176463328857E7,
+                "95.0" : 2.1905160560900792E7,
+                "99.0" : 2.1907363436910074E7,
+                "99.9" : 2.1907363436910074E7,
+                "99.99" : 2.1907363436910074E7,
+                "99.999" : 2.1907363436910074E7,
+                "99.9999" : 2.1907363436910074E7,
+                "100.0" : 2.1907363436910074E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.171079450648814E7,
+                    2.1823129053407416E7,
+                    2.179497538881215E7,
+                    2.1907363436910074E7,
+                    2.171447735827878E7,
+                    2.178364589512846E7,
+                    2.1715284705101587E7,
+                    2.168900317302972E7,
+                    2.165293764597935E7,
+                    2.1797492091239516E7
+                ],
+                [
+                    2.17208529044934E7,
+                    2.175964458548299E7,
+                    2.186330591672447E7,
+                    2.180463395145348E7,
+                    2.1791250250833746E7,
+                    2.1799552369162396E7,
+                    2.1787215356051713E7,
+                    2.1842011382768337E7,
+                    2.1840910348577663E7,
+                    2.18198855293993E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.quicklensDeepName",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.871636074519E7,
+            "scoreError" : 1496440.0072150398,
+            "scoreConfidence" : [
+                9.721992073797496E7,
+                1.0021280075240503E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.490161307692946E7,
+                "50.0" : 9.846710314417672E7,
+                "90.0" : 1.0111295452534115E8,
+                "95.0" : 1.0128059519447024E8,
+                "99.0" : 1.0128824688850477E8,
+                "99.9" : 1.0128824688850477E8,
+                "99.99" : 1.0128824688850477E8,
+                "99.999" : 1.0128824688850477E8,
+                "99.9999" : 1.0128824688850477E8,
+                "100.0" : 1.0128824688850477E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.754778875221309E7,
+                    9.734106982975674E7,
+                    9.763120675475352E7,
+                    9.77951946215671E7,
+                    9.804566110190754E7,
+                    9.744846675323988E7,
+                    9.490161307692946E7,
+                    9.662238499787891E7,
+                    9.770749104321302E7,
+                    9.759359675105113E7
+                ],
+                [
+                    9.88885451864459E7,
+                    9.907485860621324E7,
+                    9.979605293544544E7,
+                    1.0053330039971592E8,
+                    1.0041722986073755E8,
+                    1.0113521300781417E8,
+                    1.0091262818308394E8,
+                    9.92702574939511E7,
+                    1.0037640865937705E8,
+                    1.0128824688850477E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.quicklensEachSalary",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.0129663556468025E7,
+            "scoreError" : 140069.90462712583,
+            "scoreConfidence" : [
+                1.99895936518409E7,
+                2.026973346109515E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.984587882921029E7,
+                "50.0" : 2.014208517058503E7,
+                "90.0" : 2.0332935507384505E7,
+                "95.0" : 2.0342458419209924E7,
+                "99.0" : 2.0342804698663164E7,
+                "99.9" : 2.0342804698663164E7,
+                "99.99" : 2.0342804698663164E7,
+                "99.999" : 2.0342804698663164E7,
+                "99.9999" : 2.0342804698663164E7,
+                "100.0" : 2.0342804698663164E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.0069762240720354E7,
+                    2.0036722059047103E7,
+                    1.9949979015136E7,
+                    2.0053301884480543E7,
+                    2.0135957181795325E7,
+                    1.984587882921029E7,
+                    1.9920245104484312E7,
+                    1.99241750806916E7,
+                    2.002628343512195E7,
+                    1.994497387773077E7
+                ],
+                [
+                    2.0335879109598324E7,
+                    2.0303655300856654E7,
+                    2.0148213159374736E7,
+                    2.026790266764924E7,
+                    2.0300604924789425E7,
+                    2.0277790089007348E7,
+                    2.0342804698663164E7,
+                    2.0168214748789962E7,
+                    2.023448463475323E7,
+                    2.0306443087460123E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigReadBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1026969.1578509102,
+            "scoreError" : 6614.876977211414,
+            "scoreConfidence" : [
+                1020354.2808736988,
+                1033584.0348281217
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1008222.8289372892,
+                "50.0" : 1026779.4507603962,
+                "90.0" : 1037410.0953171103,
+                "95.0" : 1037594.4948168369,
+                "99.0" : 1037595.1313349524,
+                "99.9" : 1037595.1313349524,
+                "99.99" : 1037595.1313349524,
+                "99.999" : 1037595.1313349524,
+                "99.9999" : 1037595.1313349524,
+                "100.0" : 1037595.1313349524
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1032302.3591651268,
+                    1034982.1377867424,
+                    1013485.9989342069,
+                    1008222.8289372892,
+                    1037582.4009726421,
+                    1021890.6061321298,
+                    1028328.1999823832,
+                    1035859.3444173244,
+                    1037595.1313349524,
+                    1034178.7502538577
+                ],
+                [
+                    1018088.273697323,
+                    1026091.0486398608,
+                    1025430.3183706392,
+                    1025663.9663441656,
+                    1027292.9468539972,
+                    1026265.9546667953,
+                    1024868.4875864255,
+                    1027700.3657145734,
+                    1025522.2103064228,
+                    1028031.8269213467
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigReadBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.7175214207778845E7,
+            "scoreError" : 897164.1481984572,
+            "scoreConfidence" : [
+                1.6278050059580388E7,
+                1.80723783559773E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6078798445294265E7,
+                "50.0" : 1.719869213441882E7,
+                "90.0" : 1.820838738065587E7,
+                "95.0" : 1.8215283995887283E7,
+                "99.0" : 1.8215625725433413E7,
+                "99.9" : 1.8215625725433413E7,
+                "99.99" : 1.8215625725433413E7,
+                "99.999" : 1.8215625725433413E7,
+                "99.9999" : 1.8215625725433413E7,
+                "100.0" : 1.8215625725433413E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6177373378564393E7,
+                    1.6175980679716732E7,
+                    1.614882967955912E7,
+                    1.6134339546657877E7,
+                    1.6078798445294265E7,
+                    1.6216143645581E7,
+                    1.6172714601066034E7,
+                    1.6191319350387374E7,
+                    1.6133009986326417E7,
+                    1.6260476411378516E7
+                ],
+                [
+                    1.8150274194647618E7,
+                    1.8208791134510837E7,
+                    1.818958882029816E7,
+                    1.813690785745912E7,
+                    1.8182631949439183E7,
+                    1.8171006584814545E7,
+                    1.8204753595961142E7,
+                    1.8215625725433413E7,
+                    1.818973934698858E7,
+                    1.8165979221492507E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigReadBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 215507.5524073565,
+            "scoreError" : 1416.5733309277648,
+            "scoreConfidence" : [
+                214090.97907642875,
+                216924.12573828426
+            ],
+            "scorePercentiles" : {
+                "0.0" : 212267.24698404074,
+                "50.0" : 215154.57048904715,
+                "90.0" : 217462.25369338001,
+                "95.0" : 217527.33284816222,
+                "99.0" : 217530.14527585142,
+                "99.9" : 217530.14527585142,
+                "99.99" : 217530.14527585142,
+                "99.999" : 217530.14527585142,
+                "99.9999" : 217530.14527585142,
+                "100.0" : 217530.14527585142
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    216542.16485897388,
+                    217357.46643519355,
+                    217230.84051087944,
+                    216738.65921923207,
+                    215199.55509444105,
+                    216421.89172908757,
+                    217268.87263073455,
+                    217333.42557762153,
+                    217473.8967220674,
+                    217530.14527585142
+                ],
+                [
+                    212267.24698404074,
+                    214119.54165376278,
+                    214819.6772634859,
+                    214126.73994794738,
+                    214291.16204713006,
+                    213221.50976665856,
+                    213838.71808003073,
+                    214994.5745911217,
+                    215109.58588365326,
+                    214265.3738752167
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigReadBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1378066.3226710637,
+            "scoreError" : 8278.658898343934,
+            "scoreConfidence" : [
+                1369787.6637727197,
+                1386344.9815694077
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1359417.62043826,
+                "50.0" : 1379864.944539918,
+                "90.0" : 1388184.7888507645,
+                "95.0" : 1389004.4569894655,
+                "99.0" : 1389039.2553075599,
+                "99.9" : 1389039.2553075599,
+                "99.99" : 1389039.2553075599,
+                "99.999" : 1389039.2553075599,
+                "99.9999" : 1389039.2553075599,
+                "100.0" : 1389039.2553075599
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1373145.5568447218,
+                    1373578.9143639682,
+                    1369601.097925532,
+                    1359417.62043826,
+                    1364530.5517108918,
+                    1376384.2639272953,
+                    1377609.5868255557,
+                    1364245.4542342382,
+                    1377993.189422604,
+                    1363819.1406206333
+                ],
+                [
+                    1385788.4946101592,
+                    1389039.2553075599,
+                    1384645.00144853,
+                    1386758.2879966046,
+                    1388343.2889456712,
+                    1384920.361522823,
+                    1386500.1656487447,
+                    1386658.9929596875,
+                    1381736.699657232,
+                    1386610.5290105634
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigWriteBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1183367.4236835088,
+            "scoreError" : 43025.938141085135,
+            "scoreConfidence" : [
+                1140341.4855424236,
+                1226393.361824594
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1116700.9472213965,
+                "50.0" : 1183309.6638597376,
+                "90.0" : 1242683.57069943,
+                "95.0" : 1244158.9991079995,
+                "99.0" : 1244215.3995758612,
+                "99.9" : 1244215.3995758612,
+                "99.99" : 1244215.3995758612,
+                "99.999" : 1244215.3995758612,
+                "99.9999" : 1244215.3995758612,
+                "100.0" : 1244215.3995758612
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1232048.4179784835,
+                    1219812.5412166615,
+                    1231772.7885152327,
+                    1214689.929786122,
+                    1238078.0772456045,
+                    1239049.1950266662,
+                    1243087.390218626,
+                    1244215.3995758612,
+                    1221646.6984937864,
+                    1218602.8746356778
+                ],
+                [
+                    1148471.410016683,
+                    1128688.0304050532,
+                    1145002.7091899451,
+                    1146825.3432450218,
+                    1116700.9472213965,
+                    1129977.136807199,
+                    1148919.6763112913,
+                    1151929.3979333532,
+                    1123247.3942715314,
+                    1124583.115575974
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigWriteBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1007302400452118E7,
+            "scoreError" : 642118.3780401963,
+            "scoreConfidence" : [
+                1.0365184022411922E7,
+                1.1649420778492315E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0156485392516585E7,
+                "50.0" : 1.1061020016539793E7,
+                "90.0" : 1.1779558912099237E7,
+                "95.0" : 1.1856718223771442E7,
+                "99.0" : 1.1860773367349446E7,
+                "99.9" : 1.1860773367349446E7,
+                "99.99" : 1.1860773367349446E7,
+                "99.999" : 1.1860773367349446E7,
+                "99.9999" : 1.1860773367349446E7,
+                "100.0" : 1.1860773367349446E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0298125041590774E7,
+                    1.0331994266997071E7,
+                    1.0156485392516585E7,
+                    1.018587903101251E7,
+                    1.0289567502495551E7,
+                    1.0217805486356258E7,
+                    1.0413656540656796E7,
+                    1.0508209775976382E7,
+                    1.028394447222738E7,
+                    1.023348310385104E7
+                ],
+                [
+                    1.1658203830084058E7,
+                    1.1687484998386899E7,
+                    1.1754020513458071E7,
+                    1.1723077404670993E7,
+                    1.177855465888818E7,
+                    1.1860773367349446E7,
+                    1.1779670495789355E7,
+                    1.173830036913265E7,
+                    1.1632981500499213E7,
+                    1.1613830257103207E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigWriteBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 205443.49678865293,
+            "scoreError" : 4684.232485028895,
+            "scoreConfidence" : [
+                200759.26430362405,
+                210127.72927368182
+            ],
+            "scorePercentiles" : {
+                "0.0" : 198196.46783369323,
+                "50.0" : 205598.19465466007,
+                "90.0" : 211502.98597121026,
+                "95.0" : 211752.56943516663,
+                "99.0" : 211763.6284108954,
+                "99.9" : 211763.6284108954,
+                "99.99" : 211763.6284108954,
+                "99.999" : 211763.6284108954,
+                "99.9999" : 211763.6284108954,
+                "100.0" : 211763.6284108954
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    201699.084239855,
+                    199360.54119110238,
+                    199906.18211160848,
+                    199154.32506448947,
+                    201080.0698925536,
+                    201373.3239526038,
+                    200896.62051937822,
+                    199437.9529607262,
+                    198196.46783369323,
+                    201708.35021180732
+                ],
+                [
+                    210968.5074493562,
+                    210507.8970876759,
+                    209545.62071171607,
+                    209496.242682678,
+                    211147.8196452226,
+                    210883.1166677998,
+                    211542.44889632,
+                    209488.03909751284,
+                    211763.6284108954,
+                    210713.69714606466
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigWriteBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1206961.9963970603,
+            "scoreError" : 18986.841094950614,
+            "scoreConfidence" : [
+                1187975.1553021097,
+                1225948.837492011
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1179280.0760065378,
+                "50.0" : 1203939.139688225,
+                "90.0" : 1237305.284565114,
+                "95.0" : 1242316.8081837457,
+                "99.0" : 1242572.6681911866,
+                "99.9" : 1242572.6681911866,
+                "99.99" : 1242572.6681911866,
+                "99.999" : 1242572.6681911866,
+                "99.9999" : 1242572.6681911866,
+                "100.0" : 1242572.6681911866
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1235953.6332698227,
+                    1213386.3073593113,
+                    1216172.409473922,
+                    1228094.4087817427,
+                    1234243.5649949643,
+                    1237455.4680423685,
+                    1242572.6681911866,
+                    1215504.2444693244,
+                    1219350.143569545,
+                    1225769.7844606065
+                ],
+                [
+                    1187674.737132959,
+                    1189274.914020559,
+                    1188546.2884068578,
+                    1187642.3173728008,
+                    1186146.1746400495,
+                    1192201.6624526463,
+                    1194491.9720171385,
+                    1181245.3839310906,
+                    1179280.0760065378,
+                    1184233.7693477753
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckArbitraryBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3977.8637730087985,
+            "scoreError" : 77.11590772632475,
+            "scoreConfidence" : [
+                3900.747865282474,
+                4054.979680735123
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3836.406527561377,
+                "50.0" : 3957.7036649265406,
+                "90.0" : 4097.378688457808,
+                "95.0" : 4099.911631958669,
+                "99.0" : 4099.951180166773,
+                "99.9" : 4099.951180166773,
+                "99.99" : 4099.951180166773,
+                "99.999" : 4099.951180166773,
+                "99.9999" : 4099.951180166773,
+                "100.0" : 4099.951180166773
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3887.793064863253,
+                    3914.0118394643973,
+                    3904.4158916015035,
+                    3902.584060227856,
+                    3905.1114852385736,
+                    3904.317576286076,
+                    3908.778586747486,
+                    3836.406527561377,
+                    3890.5257248508647,
+                    3897.4953141862015
+                ],
+                [
+                    4081.344940535799,
+                    4099.951180166773,
+                    4001.395490388684,
+                    4038.0889668802365,
+                    4064.063117864596,
+                    4049.7781545682838,
+                    4072.04985541221,
+                    4067.8182541016718,
+                    4032.185213225429,
+                    4099.160216004698
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckArbitraryBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1937920.1410818412,
+            "scoreError" : 46833.6822382967,
+            "scoreConfidence" : [
+                1891086.4588435446,
+                1984753.8233201378
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1878446.78906568,
+                "50.0" : 1934572.3919286497,
+                "90.0" : 1995401.4009834605,
+                "95.0" : 1996335.7527729436,
+                "99.0" : 1996382.5054290951,
+                "99.9" : 1996382.5054290951,
+                "99.99" : 1996382.5054290951,
+                "99.999" : 1996382.5054290951,
+                "99.9999" : 1996382.5054290951,
+                "100.0" : 1996382.5054290951
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1977777.9835034376,
+                    1989202.3476533673,
+                    1994986.9390800218,
+                    1993772.3752228788,
+                    1995447.4523060648,
+                    1996382.5054290951,
+                    1986084.3493669417,
+                    1985643.1360313685,
+                    1993445.6534299445,
+                    1989849.8581116784
+                ],
+                [
+                    1890848.2059965522,
+                    1887932.4916447997,
+                    1889063.1011439208,
+                    1886300.8331894155,
+                    1881268.6676770414,
+                    1878446.78906568,
+                    1886530.3369384299,
+                    1882431.8770695853,
+                    1891366.8003538619,
+                    1881621.11842273
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckArbitraryBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 779120.264099497,
+            "scoreError" : 4000.0189236606016,
+            "scoreConfidence" : [
+                775120.2451758364,
+                783120.2830231576
+            ],
+            "scorePercentiles" : {
+                "0.0" : 761877.2665610329,
+                "50.0" : 779682.880333097,
+                "90.0" : 784093.435607404,
+                "95.0" : 784324.5882971549,
+                "99.0" : 784329.2739027672,
+                "99.9" : 784329.2739027672,
+                "99.99" : 784329.2739027672,
+                "99.999" : 784329.2739027672,
+                "99.9999" : 784329.2739027672,
+                "100.0" : 784329.2739027672
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    777996.0354877902,
+                    782169.9887548584,
+                    782814.2999593471,
+                    784329.2739027672,
+                    781639.7224180688,
+                    780273.6167284229,
+                    777066.2043777192,
+                    784235.5617905214,
+                    781166.408536576,
+                    761877.2665610329
+                ],
+                [
+                    779449.1953670745,
+                    776992.8990536587,
+                    780550.7335230354,
+                    780037.8351071479,
+                    779028.0341634895,
+                    777784.0988482344,
+                    778181.2656244494,
+                    779916.5652991196,
+                    778954.96316079,
+                    777941.3133258345
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckShrinkBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5848931.530262377,
+            "scoreError" : 28505.593951761286,
+            "scoreConfidence" : [
+                5820425.936310615,
+                5877437.124214139
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5799597.020491659,
+                "50.0" : 5845106.192105208,
+                "90.0" : 5902394.845151049,
+                "95.0" : 5909237.406195164,
+                "99.0" : 5909549.456422137,
+                "99.9" : 5909549.456422137,
+                "99.99" : 5909549.456422137,
+                "99.999" : 5909549.456422137,
+                "99.9999" : 5909549.456422137,
+                "100.0" : 5909549.456422137
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5799597.020491659,
+                    5832701.984520767,
+                    5870866.741992132,
+                    5890104.751302219,
+                    5903308.451882678,
+                    5807099.743514694,
+                    5809489.73451155,
+                    5838288.075497986,
+                    5894172.38456639,
+                    5909549.456422137
+                ],
+                [
+                    5825767.882460662,
+                    5863535.583760208,
+                    5850100.406813252,
+                    5853161.730873173,
+                    5823126.985330374,
+                    5834594.194397859,
+                    5842325.83696766,
+                    5870697.17018259,
+                    5812255.922516819,
+                    5847886.547242755
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckShrinkBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5772105.8206309555,
+            "scoreError" : 44301.33625670741,
+            "scoreConfidence" : [
+                5727804.484374248,
+                5816407.156887663
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5681391.884888532,
+                "50.0" : 5767852.916330735,
+                "90.0" : 5834828.7567546815,
+                "95.0" : 5838060.307256119,
+                "99.0" : 5838205.1236577155,
+                "99.9" : 5838205.1236577155,
+                "99.99" : 5838205.1236577155,
+                "99.999" : 5838205.1236577155,
+                "99.9999" : 5838205.1236577155,
+                "100.0" : 5838205.1236577155
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5733115.11075827,
+                    5751786.326975614,
+                    5749354.782003782,
+                    5746906.234324301,
+                    5684856.205310767,
+                    5697276.846030392,
+                    5737554.959407702,
+                    5758129.911051497,
+                    5681391.884888532,
+                    5741442.400579345
+                ],
+                [
+                    5777575.921609974,
+                    5790768.238866227,
+                    5813517.712845905,
+                    5830508.406914654,
+                    5818810.306076418,
+                    5820410.735830852,
+                    5811460.786412617,
+                    5835308.795625796,
+                    5838205.1236577155,
+                    5823735.723448737
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigReadBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2642577.475492385,
+            "scoreError" : 62286.27033578182,
+            "scoreConfidence" : [
+                2580291.2051566034,
+                2704863.745828167
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2563611.8124368917,
+                "50.0" : 2622981.65346836,
+                "90.0" : 2725357.0499920137,
+                "95.0" : 2726442.8093157485,
+                "99.0" : 2726470.672759146,
+                "99.9" : 2726470.672759146,
+                "99.99" : 2726470.672759146,
+                "99.999" : 2726470.672759146,
+                "99.9999" : 2726470.672759146,
+                "100.0" : 2726470.672759146
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2716010.3770703347,
+                    2709755.266577174,
+                    2718647.787439748,
+                    2718054.5425833864,
+                    2661560.665242154,
+                    2707229.796876605,
+                    2707757.7976663387,
+                    2720349.8648993494,
+                    2725913.403891199,
+                    2726470.672759146
+                ],
+                [
+                    2578569.7039046227,
+                    2575274.343066815,
+                    2578467.418013451,
+                    2573455.142766562,
+                    2583129.204192392,
+                    2563801.7823808272,
+                    2571073.53545939,
+                    2563611.8124368917,
+                    2568013.750926739,
+                    2584402.6416945667
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigReadBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5016194.728255201,
+            "scoreError" : 164611.84229632842,
+            "scoreConfidence" : [
+                4851582.885958873,
+                5180806.5705515295
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4771069.162338677,
+                "50.0" : 5027673.556973336,
+                "90.0" : 5219151.467259804,
+                "95.0" : 5224526.66337637,
+                "99.0" : 5224769.300341819,
+                "99.9" : 5224769.300341819,
+                "99.99" : 5224769.300341819,
+                "99.999" : 5224769.300341819,
+                "99.9999" : 5224769.300341819,
+                "100.0" : 5224769.300341819
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4850786.868845892,
+                    4885658.345215353,
+                    4870989.410343016,
+                    4801499.339185451,
+                    4800063.960142109,
+                    4841061.902077737,
+                    4867495.71029634,
+                    4771069.162338677,
+                    4827415.6312216,
+                    4819533.853233181
+                ],
+                [
+                    5169688.76873132,
+                    5212265.623302501,
+                    5189730.348441589,
+                    5174217.8111199215,
+                    5174039.204669562,
+                    5202471.283953524,
+                    5211234.219143651,
+                    5209987.261467944,
+                    5224769.300341819,
+                    5219916.561032837
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigReadBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1980814432587845E7,
+            "scoreError" : 158708.5302835765,
+            "scoreConfidence" : [
+                1.182210590230427E7,
+                1.2139522962871421E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1656865156106872E7,
+                "50.0" : 1.199221618536529E7,
+                "90.0" : 1.2177406602659402E7,
+                "95.0" : 1.2199583069223356E7,
+                "99.0" : 1.220070311519954E7,
+                "99.9" : 1.220070311519954E7,
+                "99.99" : 1.220070311519954E7,
+                "99.999" : 1.220070311519954E7,
+                "99.9999" : 1.220070311519954E7,
+                "100.0" : 1.220070311519954E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1881783734560981E7,
+                    1.1814005975677252E7,
+                    1.1656865156106872E7,
+                    1.1744394838541953E7,
+                    1.179975977532737E7,
+                    1.1791777742513487E7,
+                    1.18320320469193E7,
+                    1.1797163709615529E7,
+                    1.1886359624024548E7,
+                    1.1912692311309803E7
+                ],
+                [
+                    1.2130983900501452E7,
+                    1.2164427133556956E7,
+                    1.2071740059420774E7,
+                    1.211104277939235E7,
+                    1.2150015419827446E7,
+                    1.216063439330806E7,
+                    1.2162258474766143E7,
+                    1.2178302195675869E7,
+                    1.2169346265511211E7,
+                    1.220070311519954E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigReadBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 7.24135393760343E7,
+            "scoreError" : 438457.4815727434,
+            "scoreConfidence" : [
+                7.197508189446156E7,
+                7.285199685760705E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7.115541944879344E7,
+                "50.0" : 7.245776234527996E7,
+                "90.0" : 7.294120904426186E7,
+                "95.0" : 7.299513001495138E7,
+                "99.0" : 7.299782059043308E7,
+                "99.9" : 7.299782059043308E7,
+                "99.99" : 7.299782059043308E7,
+                "99.999" : 7.299782059043308E7,
+                "99.9999" : 7.299782059043308E7,
+                "100.0" : 7.299782059043308E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7.192328287370846E7,
+                    7.218508842560716E7,
+                    7.141789580116872E7,
+                    7.245825716574313E7,
+                    7.201322864475523E7,
+                    7.115541944879344E7,
+                    7.24572675248168E7,
+                    7.224572480993691E7,
+                    7.235450027353203E7,
+                    7.223166857538745E7
+                ],
+                [
+                    7.280769000414138E7,
+                    7.294400908079927E7,
+                    7.299782059043308E7,
+                    7.232427625349626E7,
+                    7.284283839282987E7,
+                    7.291448971559273E7,
+                    7.27417865906255E7,
+                    7.280322067662562E7,
+                    7.253631395726776E7,
+                    7.291600871542522E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigWriteBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 629654.0362264251,
+            "scoreError" : 5342.189085394543,
+            "scoreConfidence" : [
+                624311.8471410306,
+                634996.2253118196
+            ],
+            "scorePercentiles" : {
+                "0.0" : 614359.3933070904,
+                "50.0" : 631262.1675139988,
+                "90.0" : 636766.0031205782,
+                "95.0" : 639053.3979778651,
+                "99.0" : 639168.9908113369,
+                "99.9" : 639168.9908113369,
+                "99.99" : 639168.9908113369,
+                "99.999" : 639168.9908113369,
+                "99.9999" : 639168.9908113369,
+                "100.0" : 639168.9908113369
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    626423.3491006773,
+                    614359.3933070904,
+                    618557.9991568675,
+                    625431.3663087244,
+                    622459.4630110249,
+                    632847.3727682612,
+                    632321.0999911006,
+                    629844.9338025814,
+                    627693.1458049333,
+                    625410.0135492483
+                ],
+                [
+                    631791.5112542486,
+                    634113.7241979216,
+                    633500.0373125508,
+                    633232.7235154833,
+                    630732.823773749,
+                    632389.8035934141,
+                    635945.8239286788,
+                    636857.1341419003,
+                    639168.9908113369,
+                    630000.0151987099
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigWriteBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1219975.5454187146,
+            "scoreError" : 7774.3660723309395,
+            "scoreConfidence" : [
+                1212201.1793463838,
+                1227749.9114910455
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1196839.8261149202,
+                "50.0" : 1222354.94703587,
+                "90.0" : 1230290.2658709788,
+                "95.0" : 1237926.8670781709,
+                "99.0" : 1238312.148174639,
+                "99.9" : 1238312.148174639,
+                "99.99" : 1238312.148174639,
+                "99.999" : 1238312.148174639,
+                "99.9999" : 1238312.148174639,
+                "100.0" : 1238312.148174639
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1223282.7878597742,
+                    1214868.912509724,
+                    1226792.1238724536,
+                    1225143.773645149,
+                    1210953.0321732452,
+                    1222868.7561567475,
+                    1224322.034246415,
+                    1230606.5262452736,
+                    1238312.148174639,
+                    1227443.9225023258
+                ],
+                [
+                    1217314.5536652405,
+                    1210838.3482584364,
+                    1208424.8911291119,
+                    1223580.0075243856,
+                    1217515.8124634228,
+                    1217403.3087597855,
+                    1222322.65840105,
+                    1222387.2356706904,
+                    1218290.2490015028,
+                    1196839.8261149202
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigWriteBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5231105.824699883,
+            "scoreError" : 49454.30483307851,
+            "scoreConfidence" : [
+                5181651.519866805,
+                5280560.129532962
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5086394.3272159705,
+                "50.0" : 5241940.184032401,
+                "90.0" : 5310358.403572721,
+                "95.0" : 5320099.941204713,
+                "99.0" : 5320407.1773937335,
+                "99.9" : 5320407.1773937335,
+                "99.99" : 5320407.1773937335,
+                "99.999" : 5320407.1773937335,
+                "99.9999" : 5320407.1773937335,
+                "100.0" : 5320407.1773937335
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5086394.3272159705,
+                    5120613.893539203,
+                    5223779.888901864,
+                    5140392.765881938,
+                    5236335.857141859,
+                    5248072.365480649,
+                    5250380.799200832,
+                    5254735.451504538,
+                    5228747.655274056,
+                    5233425.806981975
+                ],
+                [
+                    5259990.812582343,
+                    5242932.682123573,
+                    5234592.61836975,
+                    5240947.6859412305,
+                    5247674.613555542,
+                    5314262.453613317,
+                    5320407.1773937335,
+                    5275221.953207366,
+                    5212321.511408121,
+                    5250886.174679817
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigWriteBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0883923852971885E7,
+            "scoreError" : 534249.0455553845,
+            "scoreConfidence" : [
+                1.03496748074165E7,
+                1.141817289852727E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0106335202593276E7,
+                "50.0" : 1.0830289924389776E7,
+                "90.0" : 1.1633422433328928E7,
+                "95.0" : 1.1646123021498393E7,
+                "99.0" : 1.1646405464880638E7,
+                "99.9" : 1.1646405464880638E7,
+                "99.99" : 1.1646405464880638E7,
+                "99.999" : 1.1646405464880638E7,
+                "99.9999" : 1.1646405464880638E7,
+                "100.0" : 1.1646405464880638E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0106335202593276E7,
+                    1.0488884818678306E7,
+                    1.0461535371362543E7,
+                    1.0188033983307758E7,
+                    1.0138183922547203E7,
+                    1.0248373407411676E7,
+                    1.0260826443242092E7,
+                    1.0355833178216366E7,
+                    1.0376746129016694E7,
+                    1.0362716779459061E7
+                ],
+                [
+                    1.164075659723574E7,
+                    1.1453487779193789E7,
+                    1.1567414958167635E7,
+                    1.1346205411255788E7,
+                    1.150836574823316E7,
+                    1.1479327816137219E7,
+                    1.1510453492738407E7,
+                    1.1646405464880638E7,
+                    1.1171695030101243E7,
+                    1.1366895525659114E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirOpenApiJsoniterBenchmark.circeDecode",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 12038.971054495922,
+            "scoreError" : 130.0245576742478,
+            "scoreConfidence" : [
+                11908.946496821674,
+                12168.995612170169
+            ],
+            "scorePercentiles" : {
+                "0.0" : 11786.763785861274,
+                "50.0" : 11982.807314475223,
+                "90.0" : 12235.055070792238,
+                "95.0" : 12289.94869547406,
+                "99.0" : 12292.741645078899,
+                "99.9" : 12292.741645078899,
+                "99.99" : 12292.741645078899,
+                "99.999" : 12292.741645078899,
+                "99.9999" : 12292.741645078899,
+                "100.0" : 12292.741645078899
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    11890.371954664988,
+                    12127.883152922472,
+                    12236.88265298214,
+                    12292.741645078899,
+                    12218.606831083112,
+                    12199.17614494488,
+                    12154.616683936529,
+                    12133.630375413331,
+                    12183.674657319823,
+                    12136.036908269547
+                ],
+                [
+                    11866.888647641328,
+                    11947.826858726745,
+                    11982.415758859972,
+                    11840.22722148427,
+                    11983.198870090477,
+                    11963.415755816175,
+                    11977.575253951518,
+                    11786.763785861274,
+                    11910.043498027391,
+                    11947.444432843582
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirOpenApiJsoniterBenchmark.circeEncode",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 24218.429674107112,
+            "scoreError" : 528.0012103421681,
+            "scoreConfidence" : [
+                23690.428463764943,
+                24746.43088444928
+            ],
+            "scorePercentiles" : {
+                "0.0" : 23220.648957365087,
+                "50.0" : 24142.0375137155,
+                "90.0" : 24894.27204472644,
+                "95.0" : 25070.297295226126,
+                "99.0" : 25079.498060693793,
+                "99.9" : 25079.498060693793,
+                "99.99" : 25079.498060693793,
+                "99.999" : 25079.498060693793,
+                "99.9999" : 25079.498060693793,
+                "100.0" : 25079.498060693793
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    24700.38240120416,
+                    25079.498060693793,
+                    24452.182121508606,
+                    24552.29589907992,
+                    24853.732920314436,
+                    24895.482751340438,
+                    24856.951496421745,
+                    24883.37568520044,
+                    24820.616911690988,
+                    24766.204450177363
+                ],
+                [
+                    23702.880076957532,
+                    23831.89290592239,
+                    23220.648957365087,
+                    23663.03737154291,
+                    23689.242541078707,
+                    23703.28912916758,
+                    23733.07857240646,
+                    23480.285984480943,
+                    23668.190671614073,
+                    23815.324573974784
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirOpenApiJsoniterBenchmark.kindlingsDecode",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 26029.6911086323,
+            "scoreError" : 95.89340617686535,
+            "scoreConfidence" : [
+                25933.797702455435,
+                26125.58451480917
+            ],
+            "scorePercentiles" : {
+                "0.0" : 25795.525471757996,
+                "50.0" : 26037.05902877287,
+                "90.0" : 26178.313160395264,
+                "95.0" : 26218.761710711686,
+                "99.0" : 26220.58156275583,
+                "99.9" : 26220.58156275583,
+                "99.99" : 26220.58156275583,
+                "99.999" : 26220.58156275583,
+                "99.9999" : 26220.58156275583,
+                "100.0" : 26220.58156275583
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    26121.184346826456,
+                    25795.525471757996,
+                    25881.51456224746,
+                    25965.014098278956,
+                    26110.095283453004,
+                    26184.184521872936,
+                    26002.337835998213,
+                    25961.42565580494,
+                    25977.38977341994,
+                    25973.26954455417
+                ],
+                [
+                    26125.470907096213,
+                    26052.074513693467,
+                    26072.021806879027,
+                    26022.043543852276,
+                    26057.011997765054,
+                    26113.361808238948,
+                    25836.260719079284,
+                    26008.863368394665,
+                    26114.190850677183,
+                    26220.58156275583
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirOpenApiJsoniterBenchmark.kindlingsEncode",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 70449.84048912306,
+            "scoreError" : 301.25877926109683,
+            "scoreConfidence" : [
+                70148.58170986196,
+                70751.09926838416
+            ],
+            "scorePercentiles" : {
+                "0.0" : 69623.99967853728,
+                "50.0" : 70589.70606180289,
+                "90.0" : 70755.94433241343,
+                "95.0" : 70869.08697368552,
+                "99.0" : 70875.0094001924,
+                "99.9" : 70875.0094001924,
+                "99.99" : 70875.0094001924,
+                "99.999" : 70875.0094001924,
+                "99.9999" : 70875.0094001924,
+                "100.0" : 70875.0094001924
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    70570.57748455011,
+                    69623.99967853728,
+                    70281.29074093667,
+                    70642.93836835437,
+                    70746.8730897884,
+                    70601.30385994952,
+                    70578.10826365626,
+                    70739.33789769745,
+                    70667.65460136243,
+                    69947.51965826584
+                ],
+                [
+                    70631.12778322939,
+                    69912.36981111226,
+                    70875.0094001924,
+                    70756.56087005475,
+                    70363.78827012869,
+                    70416.48914277632,
+                    69931.06342057018,
+                    70633.42122478965,
+                    70750.39549364157,
+                    70326.98072286794
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.860523858599996E9,
+            "scoreError" : 2.2530805739839915E7,
+            "scoreConfidence" : [
+                3.837993052860156E9,
+                3.883054664339836E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.802790627756261E9,
+                "50.0" : 3.8599861060341535E9,
+                "90.0" : 3.88775550248183E9,
+                "95.0" : 3.894467127064314E9,
+                "99.0" : 3.8948161566608357E9,
+                "99.9" : 3.8948161566608357E9,
+                "99.99" : 3.8948161566608357E9,
+                "99.999" : 3.8948161566608357E9,
+                "99.9999" : 3.8948161566608357E9,
+                "100.0" : 3.8948161566608357E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8091884362657795E9,
+                    3.851744091426911E9,
+                    3.8533283133523583E9,
+                    3.8674400753017306E9,
+                    3.8595509729828506E9,
+                    3.8878355647303967E9,
+                    3.8870349422447305E9,
+                    3.886032061537631E9,
+                    3.870981452449774E9,
+                    3.8524186109699287E9
+                ],
+                [
+                    3.8807515326190352E9,
+                    3.885300260787544E9,
+                    3.8948161566608357E9,
+                    3.886632681009894E9,
+                    3.830577318018341E9,
+                    3.802790627756261E9,
+                    3.8429303324051137E9,
+                    3.844160180387891E9,
+                    3.8565423220074735E9,
+                    3.8604212390854564E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8520893947499022E9,
+            "scoreError" : 2.982486720693102E7,
+            "scoreConfidence" : [
+                3.822264527542971E9,
+                3.8819142619568334E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.7359033539146824E9,
+                "50.0" : 3.8594247118068647E9,
+                "90.0" : 3.879134941614318E9,
+                "95.0" : 3.881886801733024E9,
+                "99.0" : 3.8820163115639143E9,
+                "99.9" : 3.8820163115639143E9,
+                "99.99" : 3.8820163115639143E9,
+                "99.999" : 3.8820163115639143E9,
+                "99.9999" : 3.8820163115639143E9,
+                "100.0" : 3.8820163115639143E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.7359033539146824E9,
+                    3.850438177972771E9,
+                    3.854045369331414E9,
+                    3.872352464383583E9,
+                    3.8654927278788624E9,
+                    3.8598560299509015E9,
+                    3.879426114946109E9,
+                    3.8820163115639143E9,
+                    3.8487251179109855E9,
+                    3.86244603378548E9
+                ],
+                [
+                    3.8570569086478763E9,
+                    3.8717359610190506E9,
+                    3.876514381628201E9,
+                    3.8713481519767213E9,
+                    3.862853085072034E9,
+                    3.7848604619336915E9,
+                    3.832754004160953E9,
+                    3.856367537575684E9,
+                    3.8589933936628284E9,
+                    3.8586023076823044E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8089565150214143E9,
+            "scoreError" : 1.716793008518514E8,
+            "scoreConfidence" : [
+                3.637277214169563E9,
+                3.9806358158732657E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9723306678410754E9,
+                "50.0" : 3.8532021584954076E9,
+                "90.0" : 3.880121901778738E9,
+                "95.0" : 3.8821075692353787E9,
+                "99.0" : 3.88216240293284E9,
+                "99.9" : 3.88216240293284E9,
+                "99.99" : 3.88216240293284E9,
+                "99.999" : 3.88216240293284E9,
+                "99.9999" : 3.88216240293284E9,
+                "100.0" : 3.88216240293284E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8546667243304977E9,
+                    3.853156228566201E9,
+                    3.848417341211281E9,
+                    3.853248088424614E9,
+                    3.84439615754816E9,
+                    3.836848338695272E9,
+                    3.8572672199838037E9,
+                    3.88216240293284E9,
+                    3.8716274569347863E9,
+                    3.8810657289836216E9
+                ],
+                [
+                    3.828219101147323E9,
+                    3.849777618661251E9,
+                    3.855649939682023E9,
+                    3.8662587005096817E9,
+                    3.8111351847837324E9,
+                    3.8285359779685783E9,
+                    2.9723306678410754E9,
+                    3.866672075728096E9,
+                    3.866225837053469E9,
+                    3.8514695094419885E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.800427587470411E9,
+            "scoreError" : 1.6669310570550266E8,
+            "scoreConfidence" : [
+                3.6337344817649083E9,
+                3.9671206931759133E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.988926158566451E9,
+                "50.0" : 3.8452461189134626E9,
+                "90.0" : 3.8667436729213915E9,
+                "95.0" : 3.8676591671421676E9,
+                "99.0" : 3.8677010626126547E9,
+                "99.9" : 3.8677010626126547E9,
+                "99.99" : 3.8677010626126547E9,
+                "99.999" : 3.8677010626126547E9,
+                "99.9999" : 3.8677010626126547E9,
+                "100.0" : 3.8677010626126547E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8601961415706224E9,
+                    3.8293824968762274E9,
+                    3.8668631532029085E9,
+                    3.8677010626126547E9,
+                    3.8628008824954348E9,
+                    3.844752300565951E9,
+                    3.828543542836148E9,
+                    3.8091596635898376E9,
+                    3.844522509393146E9,
+                    3.8514407988146305E9
+                ],
+                [
+                    3.850382166629966E9,
+                    3.814001161586028E9,
+                    3.8457399372609744E9,
+                    3.8308405758945136E9,
+                    3.8074378362709246E9,
+                    3.849449105543017E9,
+                    3.828139738795001E9,
+                    3.8656683503877387E9,
+                    2.988926158566451E9,
+                    3.862604166516053E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.847999285350872E9,
+            "scoreError" : 1.952237423824265E7,
+            "scoreConfidence" : [
+                3.8284769111126294E9,
+                3.8675216595891147E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.7925902333842883E9,
+                "50.0" : 3.847144368210891E9,
+                "90.0" : 3.8706890101780405E9,
+                "95.0" : 3.873156322815287E9,
+                "99.0" : 3.8732834836204696E9,
+                "99.9" : 3.8732834836204696E9,
+                "99.99" : 3.8732834836204696E9,
+                "99.999" : 3.8732834836204696E9,
+                "99.9999" : 3.8732834836204696E9,
+                "100.0" : 3.8732834836204696E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8696262382900553E9,
+                    3.853779325786297E9,
+                    3.8639127806957393E9,
+                    3.8656039882650642E9,
+                    3.869152385825847E9,
+                    3.868902966718263E9,
+                    3.8340526719261856E9,
+                    3.8441858831816525E9,
+                    3.846859299741103E9,
+                    3.8354217251804996E9
+                ],
+                [
+                    3.870740267516816E9,
+                    3.8702276941290603E9,
+                    3.842168757888048E9,
+                    3.7925902333842883E9,
+                    3.824525314863805E9,
+                    3.8436109426152883E9,
+                    3.847429436680679E9,
+                    3.8393386032167606E9,
+                    3.8732834836204696E9,
+                    3.8045737074915285E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.797725803923364E9,
+            "scoreError" : 1.6690480712121177E8,
+            "scoreConfidence" : [
+                3.6308209968021526E9,
+                3.9646306110445757E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9876086376344843E9,
+                "50.0" : 3.8433191339027033E9,
+                "90.0" : 3.867438530341767E9,
+                "95.0" : 3.870237634202285E9,
+                "99.0" : 3.8703827125796323E9,
+                "99.9" : 3.8703827125796323E9,
+                "99.99" : 3.8703827125796323E9,
+                "99.999" : 3.8703827125796323E9,
+                "99.9999" : 3.8703827125796323E9,
+                "100.0" : 3.8703827125796323E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8341262302439103E9,
+                    3.8556548802344003E9,
+                    3.822280609724291E9,
+                    2.9876086376344843E9,
+                    3.85902604695907E9,
+                    3.8670549981234818E9,
+                    3.8475602183352666E9,
+                    3.8445258938032036E9,
+                    3.867481145032687E9,
+                    3.840403163812464E9
+                ],
+                [
+                    3.8703827125796323E9,
+                    3.8615214456523247E9,
+                    3.8325959604054103E9,
+                    3.821351023324438E9,
+                    3.8433823068424416E9,
+                    3.843255960962965E9,
+                    3.8450122730116124E9,
+                    3.814572564390723E9,
+                    3.834645726201328E9,
+                    3.7620742811931243E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8433406843945756E9,
+            "scoreError" : 2.077974930275355E7,
+            "scoreConfidence" : [
+                3.822560935091822E9,
+                3.864120433697329E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.784123912994784E9,
+                "50.0" : 3.8491396164525123E9,
+                "90.0" : 3.8676052998020735E9,
+                "95.0" : 3.8726374763122745E9,
+                "99.0" : 3.8728969522826295E9,
+                "99.9" : 3.8728969522826295E9,
+                "99.99" : 3.8728969522826295E9,
+                "99.999" : 3.8728969522826295E9,
+                "99.9999" : 3.8728969522826295E9,
+                "100.0" : 3.8728969522826295E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8380033642873774E9,
+                    3.8479249005430193E9,
+                    3.846014947835054E9,
+                    3.8223925441664343E9,
+                    3.853364795191416E9,
+                    3.867707432875529E9,
+                    3.8728969522826295E9,
+                    3.8642127015915537E9,
+                    3.83374783272458E9,
+                    3.8666861021409764E9
+                ],
+                [
+                    3.850354332362005E9,
+                    3.8632258609337053E9,
+                    3.8134394072952785E9,
+                    3.818765894801549E9,
+                    3.861585394618593E9,
+                    3.8597837221997466E9,
+                    3.8582351040186124E9,
+                    3.8391143116939383E9,
+                    3.784123912994784E9,
+                    3.8052341733347197E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8390981381937246E9,
+            "scoreError" : 2.0539902103790093E7,
+            "scoreConfidence" : [
+                3.8185582360899343E9,
+                3.859638040297515E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.762659953402353E9,
+                "50.0" : 3.8433388582594633E9,
+                "90.0" : 3.861892532700561E9,
+                "95.0" : 3.866892566305138E9,
+                "99.0" : 3.867153370379235E9,
+                "99.9" : 3.867153370379235E9,
+                "99.99" : 3.867153370379235E9,
+                "99.999" : 3.867153370379235E9,
+                "99.9999" : 3.867153370379235E9,
+                "100.0" : 3.867153370379235E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.867153370379235E9,
+                    3.8619372888972983E9,
+                    3.8534972384953322E9,
+                    3.818755787539543E9,
+                    3.8377959097333827E9,
+                    3.824255239890666E9,
+                    3.843395429764838E9,
+                    3.8525822057612944E9,
+                    3.835282537528123E9,
+                    3.847797115926755E9
+                ],
+                [
+                    3.8475289371939573E9,
+                    3.817457997574844E9,
+                    3.8260434159046574E9,
+                    3.8301716675108833E9,
+                    3.843282286754088E9,
+                    3.861489726929926E9,
+                    3.860992927790829E9,
+                    3.860582912805449E9,
+                    3.762659953402353E9,
+                    3.8293008140910363E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8430041744562263E9,
+            "scoreError" : 2.030160265791953E7,
+            "scoreConfidence" : [
+                3.822702571798307E9,
+                3.8633057771141458E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.79372103489185E9,
+                "50.0" : 3.8479300331620054E9,
+                "90.0" : 3.870595346449228E9,
+                "95.0" : 3.8718379805844846E9,
+                "99.0" : 3.87189689488421E9,
+                "99.9" : 3.87189689488421E9,
+                "99.99" : 3.87189689488421E9,
+                "99.999" : 3.87189689488421E9,
+                "99.9999" : 3.87189689488421E9,
+                "100.0" : 3.87189689488421E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8635258247054977E9,
+                    3.8707186088897033E9,
+                    3.87189689488421E9,
+                    3.863722879874184E9,
+                    3.845139559259682E9,
+                    3.8483990002223845E9,
+                    3.8501362624752903E9,
+                    3.848989215912771E9,
+                    3.845583240289559E9,
+                    3.8098355524384503E9
+                ],
+                [
+                    3.86591318237713E9,
+                    3.79372103489185E9,
+                    3.8219344273859253E9,
+                    3.8473884593270125E9,
+                    3.828490973065516E9,
+                    3.8474610661016264E9,
+                    3.869485984484947E9,
+                    3.802868019562016E9,
+                    3.8162811122881913E9,
+                    3.848592190688587E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonReadBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1281323.2875636679,
+            "scoreError" : 4492.748262921176,
+            "scoreConfidence" : [
+                1276830.5393007468,
+                1285816.035826589
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1266203.2433843864,
+                "50.0" : 1282593.9076079167,
+                "90.0" : 1286564.2597758314,
+                "95.0" : 1288731.4516823883,
+                "99.0" : 1288843.3820516132,
+                "99.9" : 1288843.3820516132,
+                "99.99" : 1288843.3820516132,
+                "99.999" : 1288843.3820516132,
+                "99.9999" : 1288843.3820516132,
+                "100.0" : 1288843.3820516132
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1286199.6257542616,
+                    1288843.3820516132,
+                    1283682.7368813776,
+                    1285505.1504227757,
+                    1281212.1453860174,
+                    1284588.4287695321,
+                    1284114.3537728733,
+                    1283669.407217331,
+                    1283012.2551197482,
+                    1286604.7746671168
+                ],
+                [
+                    1266203.2433843864,
+                    1277520.2986242757,
+                    1278686.9266580106,
+                    1281881.6265874356,
+                    1281633.2703288472,
+                    1283696.8428775123,
+                    1275345.2527166768,
+                    1275694.031043761,
+                    1276196.4389137223,
+                    1282175.5600960855
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonReadBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1435341.1545213358,
+            "scoreError" : 4510.857834608553,
+            "scoreConfidence" : [
+                1430830.2966867273,
+                1439852.0123559444
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1423886.1240831586,
+                "50.0" : 1434597.5423542552,
+                "90.0" : 1444236.698455683,
+                "95.0" : 1446320.3617499606,
+                "99.0" : 1446416.2383057938,
+                "99.9" : 1446416.2383057938,
+                "99.99" : 1446416.2383057938,
+                "99.999" : 1446416.2383057938,
+                "99.9999" : 1446416.2383057938,
+                "100.0" : 1446416.2383057938
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1430641.3601526385,
+                    1432057.9402651337,
+                    1432486.3280622393,
+                    1444498.707189128,
+                    1437086.790951144,
+                    1433717.780813424,
+                    1433053.4537886283,
+                    1430779.7715251376,
+                    1431252.803854267,
+                    1437175.1559038009
+                ],
+                [
+                    1433774.9240023615,
+                    1432199.111001626,
+                    1435420.160706149,
+                    1437643.0007712513,
+                    1439546.213835992,
+                    1441878.6198546765,
+                    1423886.1240831586,
+                    1436079.291352987,
+                    1446416.2383057938,
+                    1437229.3140071859
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonReadBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3836185791668598E7,
+            "scoreError" : 64320.855668043354,
+            "scoreConfidence" : [
+                1.3771864936000554E7,
+                1.3900506647336641E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.3734959416104319E7,
+                "50.0" : 1.3819661995608829E7,
+                "90.0" : 1.3937023874437267E7,
+                "95.0" : 1.394427967368366E7,
+                "99.0" : 1.3944641314035043E7,
+                "99.9" : 1.3944641314035043E7,
+                "99.99" : 1.3944641314035043E7,
+                "99.999" : 1.3944641314035043E7,
+                "99.9999" : 1.3944641314035043E7,
+                "100.0" : 1.3944641314035043E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3812782067230554E7,
+                    1.3764271999922141E7,
+                    1.3734959416104319E7,
+                    1.3787305885559073E7,
+                    1.3786801863179438E7,
+                    1.3803340729828766E7,
+                    1.3770368779464066E7,
+                    1.3747725560054904E7,
+                    1.374745771909209E7,
+                    1.3768820181125997E7
+                ],
+                [
+                    1.3861469137841012E7,
+                    1.3937408507007398E7,
+                    1.393356218130608E7,
+                    1.3931591529060427E7,
+                    1.3932753522257065E7,
+                    1.3826541923987104E7,
+                    1.3847057796392078E7,
+                    1.3944641314035043E7,
+                    1.3911276713392053E7,
+                    1.3873579006532362E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonReadBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1293528322424939E7,
+            "scoreError" : 41418.99547055175,
+            "scoreConfidence" : [
+                1.1252109326954387E7,
+                1.133494731789549E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.115666542309549E7,
+                "50.0" : 1.130627647420384E7,
+                "90.0" : 1.1342063888557294E7,
+                "95.0" : 1.1353400679910617E7,
+                "99.0" : 1.1353976470235268E7,
+                "99.9" : 1.1353976470235268E7,
+                "99.99" : 1.1353976470235268E7,
+                "99.999" : 1.1353976470235268E7,
+                "99.9999" : 1.1353976470235268E7,
+                "100.0" : 1.1353976470235268E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1330541171093613E7,
+                    1.1321361356974432E7,
+                    1.1342460663742254E7,
+                    1.1338492911892667E7,
+                    1.128121684517537E7,
+                    1.1303929590242289E7,
+                    1.12822465761223E7,
+                    1.1319623483706964E7,
+                    1.1319692727546128E7,
+                    1.1323955688953413E7
+                ],
+                [
+                    1.1280493303218922E7,
+                    1.1309803195523337E7,
+                    1.129706584224042E7,
+                    1.1297020907357544E7,
+                    1.122712772592497E7,
+                    1.1224547133609839E7,
+                    1.1308623358165389E7,
+                    1.1353976470235268E7,
+                    1.115666542309549E7,
+                    1.125172207367821E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonWriteBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1264963.30412835,
+            "scoreError" : 4229.084870239495,
+            "scoreConfidence" : [
+                1260734.2192581105,
+                1269192.3889985895
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1253166.1863001112,
+                "50.0" : 1265689.5729101377,
+                "90.0" : 1270109.280113856,
+                "95.0" : 1270516.4032215045,
+                "99.0" : 1270536.4757941517,
+                "99.9" : 1270536.4757941517,
+                "99.99" : 1270536.4757941517,
+                "99.999" : 1270536.4757941517,
+                "99.9999" : 1270536.4757941517,
+                "100.0" : 1270536.4757941517
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1268300.006563734,
+                    1264678.0448284321,
+                    1267549.5726341691,
+                    1270536.4757941517,
+                    1269877.5820676931,
+                    1270135.0243412075,
+                    1269531.7863969256,
+                    1268813.5838042323,
+                    1268663.7225036647,
+                    1269194.9785792567
+                ],
+                [
+                    1264201.5179786126,
+                    1264527.6151940923,
+                    1261280.4167528604,
+                    1260601.4001378168,
+                    1253166.1863001112,
+                    1256472.2915370709,
+                    1262398.9368553434,
+                    1262480.3260680058,
+                    1260155.5132377783,
+                    1266701.1009918433
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonWriteBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1411776.7652193364,
+            "scoreError" : 4898.194003694666,
+            "scoreConfidence" : [
+                1406878.5712156417,
+                1416674.959223031
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1397446.9270763502,
+                "50.0" : 1411900.195684745,
+                "90.0" : 1419749.9842936029,
+                "95.0" : 1419896.0554246015,
+                "99.0" : 1419900.7152115551,
+                "99.9" : 1419900.7152115551,
+                "99.99" : 1419900.7152115551,
+                "99.999" : 1419900.7152115551,
+                "99.9999" : 1419900.7152115551,
+                "100.0" : 1419900.7152115551
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1412415.7540942158,
+                    1410530.7934899414,
+                    1406107.3978534173,
+                    1408554.7667382346,
+                    1413791.5723986472,
+                    1409577.1275250686,
+                    1411835.4652895422,
+                    1411964.9260799475,
+                    1409525.2246381184,
+                    1415615.1538954198
+                ],
+                [
+                    1419807.5194724854,
+                    1417154.3475677548,
+                    1416436.5113515856,
+                    1404994.3975088159,
+                    1407923.029733978,
+                    1419900.7152115551,
+                    1419232.1676836596,
+                    1397446.9270763502,
+                    1407614.063457889,
+                    1415107.443320102
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonWriteBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3413232804811811E7,
+            "scoreError" : 26239.002503774365,
+            "scoreConfidence" : [
+                1.3386993802308036E7,
+                1.3439471807315586E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.3379725270721797E7,
+                "50.0" : 1.340960120972293E7,
+                "90.0" : 1.3452098976792192E7,
+                "95.0" : 1.3490379400904482E7,
+                "99.0" : 1.3492363726177454E7,
+                "99.9" : 1.3492363726177454E7,
+                "99.99" : 1.3492363726177454E7,
+                "99.999" : 1.3492363726177454E7,
+                "99.9999" : 1.3492363726177454E7,
+                "100.0" : 1.3492363726177454E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3382865193054548E7,
+                    1.3398667867527535E7,
+                    1.3410073632582312E7,
+                    1.342715598315898E7,
+                    1.3395475894004442E7,
+                    1.3433612775636788E7,
+                    1.3410144511246918E7,
+                    1.3398055399423853E7,
+                    1.3433812629472982E7,
+                    1.3387638405576386E7
+                ],
+                [
+                    1.3419708021970624E7,
+                    1.3441833669745103E7,
+                    1.3379898749858512E7,
+                    1.3379725270721797E7,
+                    1.3380770345537255E7,
+                    1.3492363726177454E7,
+                    1.3446894781459892E7,
+                    1.3452677220718004E7,
+                    1.3384153231499348E7,
+                    1.3409128786863549E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonWriteBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1227770205656175E7,
+            "scoreError" : 53232.37146959135,
+            "scoreConfidence" : [
+                1.1174537834186584E7,
+                1.1281002577125765E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1020108517536648E7,
+                "50.0" : 1.1230996698973965E7,
+                "90.0" : 1.1302415308206918E7,
+                "95.0" : 1.1304908286177505E7,
+                "99.0" : 1.130499870165976E7,
+                "99.9" : 1.130499870165976E7,
+                "99.99" : 1.130499870165976E7,
+                "99.999" : 1.130499870165976E7,
+                "99.9999" : 1.130499870165976E7,
+                "100.0" : 1.130499870165976E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1184505935226666E7,
+                    1.1218481118848933E7,
+                    1.1227176399138726E7,
+                    1.1224410790089147E7,
+                    1.127043019147754E7,
+                    1.1240778830486061E7,
+                    1.1234816998809204E7,
+                    1.1259974500268694E7,
+                    1.122465014289242E7,
+                    1.125525815999024E7
+                ],
+                [
+                    1.1257241550489772E7,
+                    1.1217888229028132E7,
+                    1.1190412674775658E7,
+                    1.122413611723052E7,
+                    1.1303190392014666E7,
+                    1.130499870165976E7,
+                    1.1020108517536648E7,
+                    1.1166103692133782E7,
+                    1.1235401617089815E7,
+                    1.1295439553937178E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.XmlDecodeBenchmark.kindlingsAddress",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3204815.349700275,
+            "scoreError" : 64535.064051541034,
+            "scoreConfidence" : [
+                3140280.285648734,
+                3269350.413751816
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3075610.7387807393,
+                "50.0" : 3207322.104236357,
+                "90.0" : 3287677.844220868,
+                "95.0" : 3293890.6029946874,
+                "99.0" : 3294193.8806257965,
+                "99.9" : 3294193.8806257965,
+                "99.99" : 3294193.8806257965,
+                "99.999" : 3294193.8806257965,
+                "99.9999" : 3294193.8806257965,
+                "100.0" : 3294193.8806257965
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3294193.8806257965,
+                    3280440.622024047,
+                    3262054.373154189,
+                    3261142.8068486615,
+                    3274309.728949737,
+                    3278491.695159414,
+                    3267527.1042975,
+                    3262642.864398907,
+                    3283623.4901761482,
+                    3288128.328003614
+                ],
+                [
+                    3126190.9298721324,
+                    3143180.35927941,
+                    3075610.7387807393,
+                    3136207.471553251,
+                    3142603.42719853,
+                    3135385.2688147025,
+                    3133371.915122891,
+                    3152396.872270559,
+                    3145303.7158512156,
+                    3153501.401624053
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.XmlDecodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4774503.181446633,
+            "scoreError" : 18322.05879896075,
+            "scoreConfidence" : [
+                4756181.122647673,
+                4792825.240245594
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4716515.588930936,
+                "50.0" : 4778811.272881517,
+                "90.0" : 4800393.874601872,
+                "95.0" : 4802675.446590079,
+                "99.0" : 4802763.71302623,
+                "99.9" : 4802763.71302623,
+                "99.99" : 4802763.71302623,
+                "99.999" : 4802763.71302623,
+                "99.9999" : 4802763.71302623,
+                "100.0" : 4802763.71302623
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4791854.435688364,
+                    4774634.784026929,
+                    4794953.287289943,
+                    4776244.9442926,
+                    4802763.71302623,
+                    4782646.598652103,
+                    4800998.384303197,
+                    4787305.380534083,
+                    4784739.6724115275,
+                    4773712.647348449
+                ],
+                [
+                    4760418.43148956,
+                    4744025.105706479,
+                    4744797.682878902,
+                    4765557.46334248,
+                    4769487.0641787555,
+                    4716515.588930936,
+                    4785740.314188693,
+                    4765104.969140198,
+                    4787185.560032802,
+                    4781377.601470434
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.XmlEncodeBenchmark.kindlingsAddress",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8645403008324765E7,
+            "scoreError" : 251082.80861393592,
+            "scoreConfidence" : [
+                3.839432019971083E7,
+                3.88964858169387E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.781480801048095E7,
+                "50.0" : 3.863366516050166E7,
+                "90.0" : 3.90368533595521E7,
+                "95.0" : 3.90587802175619E7,
+                "99.0" : 3.9059600422414295E7,
+                "99.9" : 3.9059600422414295E7,
+                "99.99" : 3.9059600422414295E7,
+                "99.999" : 3.9059600422414295E7,
+                "99.9999" : 3.9059600422414295E7,
+                "100.0" : 3.9059600422414295E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.867102227732437E7,
+                    3.8586867362845995E7,
+                    3.8766214239926696E7,
+                    3.882020607990323E7,
+                    3.8873357615663186E7,
+                    3.9043196325366355E7,
+                    3.861563746225192E7,
+                    3.8979766667223774E7,
+                    3.9059600422414295E7,
+                    3.8494362741985664E7
+                ],
+                [
+                    3.8166650780811064E7,
+                    3.781480801048095E7,
+                    3.852247640911789E7,
+                    3.881801832992539E7,
+                    3.8775775977527715E7,
+                    3.8610720890973985E7,
+                    3.8470742177585594E7,
+                    3.862397520112331E7,
+                    3.864335511988001E7,
+                    3.8551306074164055E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.XmlEncodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.620196726551176E7,
+            "scoreError" : 346395.33101156575,
+            "scoreConfidence" : [
+                4.5855571934500195E7,
+                4.654836259652332E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.484904467500975E7,
+                "50.0" : 4.631807164422143E7,
+                "90.0" : 4.655215303464437E7,
+                "95.0" : 4.655373376518462E7,
+                "99.0" : 4.655375418310318E7,
+                "99.9" : 4.655375418310318E7,
+                "99.99" : 4.655375418310318E7,
+                "99.999" : 4.655375418310318E7,
+                "99.9999" : 4.655375418310318E7,
+                "100.0" : 4.655375418310318E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.634748029320433E7,
+                    4.6064674422134E7,
+                    4.612286718578063E7,
+                    4.6329909474199675E7,
+                    4.616767917644216E7,
+                    4.6422587879012614E7,
+                    4.630623381424319E7,
+                    4.641991568717527E7,
+                    4.654141792385705E7,
+                    4.559108215839415E7
+                ],
+                [
+                    4.5934131410739735E7,
+                    4.615426447217879E7,
+                    4.61080592937995E7,
+                    4.6449052989407666E7,
+                    4.484904467500975E7,
+                    4.651911416753027E7,
+                    4.655334582473186E7,
+                    4.619766919212731E7,
+                    4.655375418310318E7,
+                    4.640706108716409E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlDecodeBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 721241.7142571914,
+            "scoreError" : 3164.427081926475,
+            "scoreConfidence" : [
+                718077.2871752649,
+                724406.1413391179
+            ],
+            "scorePercentiles" : {
+                "0.0" : 711266.43088056,
+                "50.0" : 721052.2533898356,
+                "90.0" : 724894.2202905855,
+                "95.0" : 728946.9239569354,
+                "99.0" : 729152.3637631163,
+                "99.9" : 729152.3637631163,
+                "99.99" : 729152.3637631163,
+                "99.999" : 729152.3637631163,
+                "99.9999" : 729152.3637631163,
+                "100.0" : 729152.3637631163
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    729152.3637631163,
+                    718639.9785529427,
+                    723162.1581383514,
+                    723550.0941503748,
+                    723535.1356599914,
+                    723418.2332036025,
+                    723093.1318273728,
+                    722635.1419021523,
+                    716001.5503182943,
+                    721067.3546864333
+                ],
+                [
+                    711266.43088056,
+                    719061.6047759894,
+                    720501.645517015,
+                    721037.1520932377,
+                    719160.0670781663,
+                    720657.4283510345,
+                    720941.6935428984,
+                    719592.0498584745,
+                    723317.5032043228,
+                    725043.5676394978
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlDecodeBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 773787.0432902292,
+            "scoreError" : 22897.429470120784,
+            "scoreConfidence" : [
+                750889.6138201084,
+                796684.47276035
+            ],
+            "scorePercentiles" : {
+                "0.0" : 742925.5512941444,
+                "50.0" : 774894.6321338344,
+                "90.0" : 802621.1738266336,
+                "95.0" : 803799.7448936127,
+                "99.0" : 803858.66097316,
+                "99.9" : 803858.66097316,
+                "99.99" : 803858.66097316,
+                "99.999" : 803858.66097316,
+                "99.9999" : 803858.66097316,
+                "100.0" : 803858.66097316
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    757789.6622678663,
+                    746601.962245363,
+                    747989.9320020521,
+                    744244.7527471575,
+                    750462.4475172486,
+                    750163.6201017734,
+                    750817.9464195437,
+                    746895.2302389423,
+                    742925.5512941444,
+                    745956.8081612892
+                ],
+                [
+                    792921.1337571577,
+                    801984.5711842392,
+                    791999.6019998025,
+                    798099.8803123042,
+                    799067.6904513224,
+                    803858.66097316,
+                    802088.6838264025,
+                    802680.3393822148,
+                    798497.2693291712,
+                    800695.1215934284
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlDecodeBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.855165368116315E7,
+            "scoreError" : 652418.2931951138,
+            "scoreConfidence" : [
+                9.789923538796803E7,
+                9.920407197435826E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.730515898180982E7,
+                "50.0" : 9.837061131594735E7,
+                "90.0" : 9.944832177819629E7,
+                "95.0" : 9.94771221621135E7,
+                "99.0" : 9.947823353623916E7,
+                "99.9" : 9.947823353623916E7,
+                "99.99" : 9.947823353623916E7,
+                "99.999" : 9.947823353623916E7,
+                "99.9999" : 9.947823353623916E7,
+                "100.0" : 9.947823353623916E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.800980182253766E7,
+                    9.836646014931658E7,
+                    9.83223380492635E7,
+                    9.823002427750085E7,
+                    9.776713813433772E7,
+                    9.818910704231599E7,
+                    9.837476248257811E7,
+                    9.730515898180982E7,
+                    9.741133261674552E7,
+                    9.730985168991633E7
+                ],
+                [
+                    9.945600605372608E7,
+                    9.935643031912038E7,
+                    9.876174184426141E7,
+                    9.832522995067927E7,
+                    9.926356114611879E7,
+                    9.937916329842821E7,
+                    9.914585746231194E7,
+                    9.936561132046637E7,
+                    9.947823353623916E7,
+                    9.92152634455888E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlDecodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9350326.026151204,
+            "scoreError" : 279454.1957527976,
+            "scoreConfidence" : [
+                9070871.830398407,
+                9629780.221904002
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8960152.728220422,
+                "50.0" : 9336862.402009271,
+                "90.0" : 9710214.630110241,
+                "95.0" : 9733780.28786456,
+                "99.0" : 9734969.950445466,
+                "99.9" : 9734969.950445466,
+                "99.99" : 9734969.950445466,
+                "99.999" : 9734969.950445466,
+                "99.9999" : 9734969.950445466,
+                "100.0" : 9734969.950445466
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9032552.667250717,
+                    9065252.33919207,
+                    9041925.210506715,
+                    9075307.135298064,
+                    9063971.035317758,
+                    9092976.781575946,
+                    8960152.728220422,
+                    9013999.293747928,
+                    8998290.010110948,
+                    9051211.429533161
+                ],
+                [
+                    9734969.950445466,
+                    9580748.022442594,
+                    9654914.456001002,
+                    9660218.667730678,
+                    9623207.854065059,
+                    9701556.011656307,
+                    9711176.698827345,
+                    9693946.542874122,
+                    9646083.30406353,
+                    9604060.38416423
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlEncodeBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 136198.91611400462,
+            "scoreError" : 6034.269460402095,
+            "scoreConfidence" : [
+                130164.64665360253,
+                142233.18557440673
+            ],
+            "scorePercentiles" : {
+                "0.0" : 128797.93138877842,
+                "50.0" : 136112.79155861656,
+                "90.0" : 143655.66837461464,
+                "95.0" : 143796.01672794708,
+                "99.0" : 143801.199438591,
+                "99.9" : 143801.199438591,
+                "99.99" : 143801.199438591,
+                "99.999" : 143801.199438591,
+                "99.9999" : 143801.199438591,
+                "100.0" : 143801.199438591
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    130011.68156958686,
+                    129361.92340680129,
+                    129698.62834196702,
+                    129589.22761267037,
+                    129264.64254213183,
+                    129065.5796211799,
+                    128797.93138877842,
+                    128975.90262688219,
+                    129738.2120552275,
+                    129913.59680200301
+                ],
+                [
+                    142469.68926406532,
+                    143077.392586887,
+                    143243.06073707706,
+                    142213.9015476463,
+                    142887.9152807469,
+                    142432.84521599265,
+                    142458.67030141217,
+                    143697.54522571262,
+                    143278.7767147329,
+                    143801.199438591
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlEncodeBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 147486.9605047474,
+            "scoreError" : 8927.249744074665,
+            "scoreConfidence" : [
+                138559.71076067275,
+                156414.21024882206
+            ],
+            "scorePercentiles" : {
+                "0.0" : 135784.93785943184,
+                "50.0" : 146669.82956262626,
+                "90.0" : 158511.8100010312,
+                "95.0" : 158575.58783200066,
+                "99.0" : 158577.38103838623,
+                "99.9" : 158577.38103838623,
+                "99.99" : 158577.38103838623,
+                "99.999" : 158577.38103838623,
+                "99.9999" : 158577.38103838623,
+                "100.0" : 158577.38103838623
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    156475.80768376548,
+                    157893.8916921152,
+                    157077.31700876047,
+                    158541.51691067472,
+                    158244.44781423957,
+                    154912.65713236912,
+                    156916.34414481287,
+                    157786.0912221589,
+                    158214.38308298308,
+                    158577.38103838623
+                ],
+                [
+                    135784.93785943184,
+                    136958.23913584772,
+                    137731.95027298472,
+                    138427.0019928834,
+                    138015.8869052505,
+                    137960.34980686728,
+                    137655.0936780906,
+                    138046.51338845585,
+                    137737.90520640343,
+                    136781.49411846753
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlEncodeBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2225037.803668356,
+            "scoreError" : 13412.987368239632,
+            "scoreConfidence" : [
+                2211624.8163001165,
+                2238450.7910365956
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2190026.1748042987,
+                "50.0" : 2222075.7363021523,
+                "90.0" : 2248357.9861035105,
+                "95.0" : 2250866.8651526184,
+                "99.0" : 2250992.3402064065,
+                "99.9" : 2250992.3402064065,
+                "99.99" : 2250992.3402064065,
+                "99.999" : 2250992.3402064065,
+                "99.9999" : 2250992.3402064065,
+                "100.0" : 2250992.3402064065
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2221452.612201184,
+                    2220808.8645511516,
+                    2248482.839130641,
+                    2250992.3402064065,
+                    2218080.5925049772,
+                    2228131.0355610996,
+                    2222274.6123109283,
+                    2239186.927113873,
+                    2245788.2011432736,
+                    2247234.308859336
+                ],
+                [
+                    2211511.9246094753,
+                    2190026.1748042987,
+                    2214182.6464016126,
+                    2221876.8602933767,
+                    2204244.805131005,
+                    2223534.6612082343,
+                    2218074.1163449096,
+                    2227996.502674922,
+                    2228756.2790089976,
+                    2218119.769307423
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlEncodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1365323.9286417407,
+            "scoreError" : 10982.044614643106,
+            "scoreConfidence" : [
+                1354341.8840270976,
+                1376305.9732563838
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1339506.8424670375,
+                "50.0" : 1366126.7486847285,
+                "90.0" : 1380766.060241443,
+                "95.0" : 1382282.059004573,
+                "99.0" : 1382359.3155586016,
+                "99.9" : 1382359.3155586016,
+                "99.99" : 1382359.3155586016,
+                "99.999" : 1382359.3155586016,
+                "99.9999" : 1382359.3155586016,
+                "100.0" : 1382359.3155586016
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1377047.1952741584,
+                    1380814.1844780266,
+                    1379638.9522926267,
+                    1382359.3155586016,
+                    1355873.066931321,
+                    1351271.5696830673,
+                    1373724.7101492884,
+                    1371183.4391830745,
+                    1380332.9421121923,
+                    1378214.2350954113
+                ],
+                [
+                    1339506.8424670375,
+                    1356320.9509390034,
+                    1362731.4786942403,
+                    1365780.9101713754,
+                    1368295.8687302454,
+                    1366472.5871980814,
+                    1354626.6293246353,
+                    1361673.4544328041,
+                    1345845.3318998585,
+                    1354764.9082197587
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/docs/research/benchmark-runs/2026-06-17-master/scala3.json
+++ b/docs/research/benchmark-runs/2026-06-17-master/scala3.json
@@ -1,0 +1,17451 @@
+[
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCodecReadBenchmark.anonSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0907899815286253E7,
+            "scoreError" : 541920.2065013134,
+            "scoreConfidence" : [
+                1.036597960878494E7,
+                1.1449820021787565E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9708552.399756836,
+                "50.0" : 1.0967306475477569E7,
+                "90.0" : 1.1838773772265034E7,
+                "95.0" : 1.1887576904131714E7,
+                "99.0" : 1.1889000058197401E7,
+                "99.9" : 1.1889000058197401E7,
+                "99.99" : 1.1889000058197401E7,
+                "99.999" : 1.1889000058197401E7,
+                "99.9999" : 1.1889000058197401E7,
+                "100.0" : 1.1889000058197401E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.051908347617542E7,
+                    1.1393260839121632E7,
+                    1.1011477485977314E7,
+                    1.1642904930697378E7,
+                    1.1860536976883661E7,
+                    1.0934569351329403E7,
+                    1.1308245245655747E7,
+                    1.020821161839899E7,
+                    1.058236925689543E7,
+                    1.043741173532712E7
+                ],
+                [
+                    1.118360641450997E7,
+                    1.0198783534006236E7,
+                    1.1333172121508833E7,
+                    1.1558850622736858E7,
+                    1.1000043599625733E7,
+                    1.0861462219506865E7,
+                    1.1889000058197401E7,
+                    9988874.597162107,
+                    1.0537579822252093E7,
+                    9708552.399756836
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCodecReadBenchmark.factorySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0266551871219331E7,
+            "scoreError" : 363010.47750359884,
+            "scoreConfidence" : [
+                9903541.393715732,
+                1.0629562348722931E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9504747.258195221,
+                "50.0" : 1.0419734725038212E7,
+                "90.0" : 1.069526641908004E7,
+                "95.0" : 1.1165385340111881E7,
+                "99.0" : 1.1189530855470456E7,
+                "99.9" : 1.1189530855470456E7,
+                "99.99" : 1.1189530855470456E7,
+                "99.999" : 1.1189530855470456E7,
+                "99.9999" : 1.1189530855470456E7,
+                "100.0" : 1.1189530855470456E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0366588122782797E7,
+                    9504747.258195221,
+                    1.0384534123059357E7,
+                    9857464.569164772,
+                    1.0479039870858423E7,
+                    1.0210637319890972E7,
+                    1.0465512145020535E7,
+                    9798179.110543694,
+                    9908184.749279575,
+                    1.0593079256109625E7
+                ],
+                [
+                    9791413.178928215,
+                    1.1189530855470456E7,
+                    1.0706620548298974E7,
+                    1.0506356111137673E7,
+                    1.0454935327017065E7,
+                    9847747.56866887,
+                    1.04785998872825E7,
+                    1.0541118247950835E7,
+                    9732550.202113094,
+                    1.0514198972613983E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCodecWriteBenchmark.anonSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.457068558920912E7,
+            "scoreError" : 503500.43379772175,
+            "scoreConfidence" : [
+                6.406718515541139E7,
+                6.507418602300684E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.286233527734228E7,
+                "50.0" : 6.474794922816828E7,
+                "90.0" : 6.5164808440024495E7,
+                "95.0" : 6.519355327126775E7,
+                "99.0" : 6.519502174966526E7,
+                "99.9" : 6.519502174966526E7,
+                "99.99" : 6.519502174966526E7,
+                "99.999" : 6.519502174966526E7,
+                "99.9999" : 6.519502174966526E7,
+                "100.0" : 6.519502174966526E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.4849911463322975E7,
+                    6.286233527734228E7,
+                    6.4232177665440194E7,
+                    6.464685250594457E7,
+                    6.498840011520567E7,
+                    6.4976912490741275E7,
+                    6.471564070233342E7,
+                    6.483004384422535E7,
+                    6.445069161044846E7,
+                    6.478025775400314E7
+                ],
+                [
+                    6.495128506944978E7,
+                    6.4412081741449334E7,
+                    6.38094610662589E7,
+                    6.443382330116048E7,
+                    6.515721476480986E7,
+                    6.519502174966526E7,
+                    6.516565218171501E7,
+                    6.491516259523937E7,
+                    6.370049986747619E7,
+                    6.434028601795075E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCodecWriteBenchmark.factorySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.5117032614548564E7,
+            "scoreError" : 786451.356430977,
+            "scoreConfidence" : [
+                6.433058125811759E7,
+                6.590348397097954E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.322574990859304E7,
+                "50.0" : 6.520340487218034E7,
+                "90.0" : 6.619238788225501E7,
+                "95.0" : 6.641706895396261E7,
+                "99.0" : 6.642863098647776E7,
+                "99.9" : 6.642863098647776E7,
+                "99.99" : 6.642863098647776E7,
+                "99.999" : 6.642863098647776E7,
+                "99.9999" : 6.642863098647776E7,
+                "100.0" : 6.642863098647776E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.642863098647776E7,
+                    6.619739033617473E7,
+                    6.584690679716684E7,
+                    6.614168837879797E7,
+                    6.549231470058917E7,
+                    6.609544136361707E7,
+                    6.614736579697758E7,
+                    6.5398111410341024E7,
+                    6.5654821119604334E7,
+                    6.550802708850768E7
+                ],
+                [
+                    6.486667744206563E7,
+                    6.322574990859304E7,
+                    6.456426853233466E7,
+                    6.417970479993629E7,
+                    6.471046828975744E7,
+                    6.456413397918366E7,
+                    6.405874738169219E7,
+                    6.4270992016914986E7,
+                    6.398051362821929E7,
+                    6.500869833401965E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.anonCodecCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.292153167993968E8,
+            "scoreError" : 4760075.487458714,
+            "scoreConfidence" : [
+                3.244552413119381E8,
+                3.339753922868555E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1870397026802784E8,
+                "50.0" : 3.308666398025855E8,
+                "90.0" : 3.356937868653378E8,
+                "95.0" : 3.3582017233463734E8,
+                "99.0" : 3.358220144843835E8,
+                "99.9" : 3.358220144843835E8,
+                "99.99" : 3.358220144843835E8,
+                "99.999" : 3.358220144843835E8,
+                "99.9999" : 3.358220144843835E8,
+                "100.0" : 3.358220144843835E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.330199741812227E8,
+                    3.3578517148945963E8,
+                    3.3386850416307783E8,
+                    3.358220144843835E8,
+                    3.348713252482409E8,
+                    3.34464897172184E8,
+                    3.341494309855155E8,
+                    3.32247331413568E8,
+                    3.330473737923401E8,
+                    3.234917111855525E8
+                ],
+                [
+                    3.295998874560404E8,
+                    3.231799054798687E8,
+                    3.2431266662227947E8,
+                    3.3019913695319456E8,
+                    3.2048835430182093E8,
+                    3.233790919257971E8,
+                    3.261747205338726E8,
+                    3.1870397026802784E8,
+                    3.259667256795123E8,
+                    3.315341426519764E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.anonHashCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.28947995508834E8,
+            "scoreError" : 4629202.1372357905,
+            "scoreConfidence" : [
+                3.2431879337159824E8,
+                3.3357719764606977E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1313561460499555E8,
+                "50.0" : 3.300634146092096E8,
+                "90.0" : 3.341916411246197E8,
+                "95.0" : 3.3465720449512076E8,
+                "99.0" : 3.346788168548721E8,
+                "99.9" : 3.346788168548721E8,
+                "99.99" : 3.346788168548721E8,
+                "99.999" : 3.346788168548721E8,
+                "99.9999" : 3.346788168548721E8,
+                "100.0" : 3.346788168548721E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.290099354718795E8,
+                    3.313063507030029E8,
+                    3.2969083811309236E8,
+                    3.346788168548721E8,
+                    3.33697284307585E8,
+                    3.212414526369538E8,
+                    3.311554760837616E8,
+                    3.21487195424722E8,
+                    3.3424656965984577E8,
+                    3.300176587895383E8
+                ],
+                [
+                    3.240718055579447E8,
+                    3.3354392859161794E8,
+                    3.2735480940178835E8,
+                    3.28206949513761E8,
+                    3.3274113463503814E8,
+                    3.314056820060589E8,
+                    3.1313561460499555E8,
+                    3.3008637467420924E8,
+                    3.318415786018014E8,
+                    3.3004045454420996E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.anonShowCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.318413166286761E8,
+            "scoreError" : 2212167.3007956757,
+            "scoreConfidence" : [
+                3.2962914932788044E8,
+                3.340534839294718E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.2631935769887316E8,
+                "50.0" : 3.3172567054256094E8,
+                "90.0" : 3.3588892484603184E8,
+                "95.0" : 3.361680734183946E8,
+                "99.0" : 3.361756213574197E8,
+                "99.9" : 3.361756213574197E8,
+                "99.99" : 3.361756213574197E8,
+                "99.999" : 3.361756213574197E8,
+                "99.9999" : 3.361756213574197E8,
+                "100.0" : 3.361756213574197E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.3392092545389754E8,
+                    3.31854426262131E8,
+                    3.361756213574197E8,
+                    3.346672852680588E8,
+                    3.3180164263798946E8,
+                    3.3249234108455366E8,
+                    3.293614545476336E8,
+                    3.3164969844713235E8,
+                    3.313508523795399E8,
+                    3.314270243966913E8
+                ],
+                [
+                    3.280843926631345E8,
+                    3.340867822217107E8,
+                    3.306362630888714E8,
+                    3.360246625769177E8,
+                    3.301769228024584E8,
+                    3.308677945384223E8,
+                    3.331578833680914E8,
+                    3.290703874961806E8,
+                    3.337006142838145E8,
+                    3.2631935769887316E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.factoryCodecCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.746902451162574E8,
+            "scoreError" : 6664475.122249688,
+            "scoreConfidence" : [
+                8.680257699940077E8,
+                8.813547202385072E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.553677848220836E8,
+                "50.0" : 8.746030649660554E8,
+                "90.0" : 8.85295510860468E8,
+                "95.0" : 8.853652766327161E8,
+                "99.0" : 8.853661591349846E8,
+                "99.9" : 8.853661591349846E8,
+                "99.99" : 8.853661591349846E8,
+                "99.999" : 8.853661591349846E8,
+                "99.9999" : 8.853661591349846E8,
+                "100.0" : 8.853661591349846E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.80127397629297E8,
+                    8.848185267981626E8,
+                    8.853661591349846E8,
+                    8.853485090896131E8,
+                    8.830791404204876E8,
+                    8.714777957842563E8,
+                    8.806127678654069E8,
+                    8.700447030886738E8,
+                    8.7620659260803E8,
+                    8.755884507438656E8
+                ],
+                [
+                    8.685562514808059E8,
+                    8.723523718527337E8,
+                    8.73270992747596E8,
+                    8.73204313346886E8,
+                    8.67660612442967E8,
+                    8.553677848220836E8,
+                    8.630028498186198E8,
+                    8.770518349512857E8,
+                    8.770501685111471E8,
+                    8.736176791882452E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.factoryHashCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.62031540024245E8,
+            "scoreError" : 6934128.1873383,
+            "scoreConfidence" : [
+                8.550974118369067E8,
+                8.689656682115834E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.4060190020671E8,
+                "50.0" : 8.631137534463904E8,
+                "90.0" : 8.700130592544659E8,
+                "95.0" : 8.711721932733263E8,
+                "99.0" : 8.712297169250618E8,
+                "99.9" : 8.712297169250618E8,
+                "99.99" : 8.712297169250618E8,
+                "99.999" : 8.712297169250618E8,
+                "99.9999" : 8.712297169250618E8,
+                "100.0" : 8.712297169250618E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.600526838473855E8,
+                    8.683448135572143E8,
+                    8.712297169250618E8,
+                    8.70079243890352E8,
+                    8.694173975314918E8,
+                    8.667290474377741E8,
+                    8.586410249758137E8,
+                    8.609736012263888E8,
+                    8.672053375816618E8,
+                    8.640892767014709E8
+                ],
+                [
+                    8.6267990769225E8,
+                    8.582895024049724E8,
+                    8.614613123790762E8,
+                    8.595768949817338E8,
+                    8.621158723094813E8,
+                    8.4060190020671E8,
+                    8.426511421522349E8,
+                    8.671135909890082E8,
+                    8.658309344942939E8,
+                    8.635475992005309E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaCreationBenchmark.factoryShowCreation",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0068843679676985E9,
+            "scoreError" : 1.2378012199822662E7,
+            "scoreConfidence" : [
+                9.945063557678758E8,
+                1.0192623801675211E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.510465576265022E8,
+                "50.0" : 1.010376337224366E9,
+                "90.0" : 1.0160959355083793E9,
+                "95.0" : 1.0169053698693969E9,
+                "99.0" : 1.0169478264108754E9,
+                "99.9" : 1.0169478264108754E9,
+                "99.99" : 1.0169478264108754E9,
+                "99.999" : 1.0169478264108754E9,
+                "99.9999" : 1.0169478264108754E9,
+                "100.0" : 1.0169478264108754E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0116071557009916E9,
+                    1.0057865525292101E9,
+                    1.0079248704356844E9,
+                    1.0152351827478826E9,
+                    1.0101945946497122E9,
+                    1.0169478264108754E9,
+                    1.0070607094154706E9,
+                    1.0105580797990197E9,
+                    1.016098695581306E9,
+                    1.0127634658230526E9
+                ],
+                [
+                    1.0131355253224875E9,
+                    1.015320281315188E9,
+                    1.0059384133441386E9,
+                    1.01607109485204E9,
+                    9.976165949792583E8,
+                    9.980333537786398E8,
+                    1.0098068939805926E9,
+                    1.0043286971027908E9,
+                    1.0122128139591265E9,
+                    9.510465576265022E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaEncoderBenchmark.anonPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3679117.723856018,
+            "scoreError" : 26854.99120494831,
+            "scoreConfidence" : [
+                3652262.7326510698,
+                3705972.715060966
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3593693.3398197587,
+                "50.0" : 3684529.70192363,
+                "90.0" : 3715348.4771982306,
+                "95.0" : 3720790.569243856,
+                "99.0" : 3721051.8819366843,
+                "99.9" : 3721051.8819366843,
+                "99.99" : 3721051.8819366843,
+                "99.999" : 3721051.8819366843,
+                "99.9999" : 3721051.8819366843,
+                "100.0" : 3721051.8819366843
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3715825.628080114,
+                    3721051.8819366843,
+                    3697599.611501082,
+                    3699751.7007487714,
+                    3593693.3398197587,
+                    3635000.885468337,
+                    3673566.2736225133,
+                    3682820.477983736,
+                    3698947.961226011,
+                    3711054.1192612806
+                ],
+                [
+                    3676189.2673612037,
+                    3686238.9258635244,
+                    3692498.6916784807,
+                    3680556.6393840583,
+                    3643453.463718788,
+                    3639022.552613152,
+                    3679218.6005512034,
+                    3696658.540079528,
+                    3670397.386414057,
+                    3688808.5298080803
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaEncoderBenchmark.anonSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.1504873580491908E7,
+            "scoreError" : 182508.4938797651,
+            "scoreConfidence" : [
+                3.1322365086612143E7,
+                3.1687382074371673E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.1065552593984973E7,
+                "50.0" : 3.1471367695837982E7,
+                "90.0" : 3.182745602441497E7,
+                "95.0" : 3.192485857888842E7,
+                "99.0" : 3.192977137964182E7,
+                "99.9" : 3.192977137964182E7,
+                "99.99" : 3.192977137964182E7,
+                "99.999" : 3.192977137964182E7,
+                "99.9999" : 3.192977137964182E7,
+                "100.0" : 3.192977137964182E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.146492962884072E7,
+                    3.1343232415068693E7,
+                    3.1292823855065536E7,
+                    3.1233873860705484E7,
+                    3.147603495454144E7,
+                    3.139754197986819E7,
+                    3.1479937960225966E7,
+                    3.142557840782885E7,
+                    3.1466700437134527E7,
+                    3.1390317777841292E7
+                ],
+                [
+                    3.1831515364573795E7,
+                    3.192977137964182E7,
+                    3.1684813930427924E7,
+                    3.1410883454701364E7,
+                    3.1580287286968682E7,
+                    3.1640687304273803E7,
+                    3.168354794996382E7,
+                    3.179092196298554E7,
+                    3.1065552593984973E7,
+                    3.1508519105195772E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaEncoderBenchmark.factoryPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3774706.5217121905,
+            "scoreError" : 65206.61447332376,
+            "scoreConfidence" : [
+                3709499.9072388667,
+                3839913.1361855143
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3683980.755145385,
+                "50.0" : 3749664.010292814,
+                "90.0" : 3865022.526236278,
+                "95.0" : 3868146.7854744284,
+                "99.0" : 3868308.3609919366,
+                "99.9" : 3868308.3609919366,
+                "99.99" : 3868308.3609919366,
+                "99.999" : 3868308.3609919366,
+                "99.9999" : 3868308.3609919366,
+                "100.0" : 3868308.3609919366
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3711894.1786356564,
+                    3713854.5558281117,
+                    3713807.860974193,
+                    3701880.3131056814,
+                    3683980.755145385,
+                    3704135.8980157273,
+                    3708248.2297099186,
+                    3696742.615106852,
+                    3704165.086193294,
+                    3705442.732547229
+                ],
+                [
+                    3864533.6065867944,
+                    3857653.7604132798,
+                    3840624.9977012267,
+                    3799656.7714732965,
+                    3785473.4647575165,
+                    3862537.2811956285,
+                    3865076.8506417763,
+                    3868308.3609919366,
+                    3857754.790186892,
+                    3848358.325033411
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaEncoderBenchmark.factorySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.1972469768977113E7,
+            "scoreError" : 481241.9633655036,
+            "scoreConfidence" : [
+                3.149122780561161E7,
+                3.2453711732342616E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.115581566947374E7,
+                "50.0" : 3.1942566309736937E7,
+                "90.0" : 3.2712482567097124E7,
+                "95.0" : 3.2759523782419365E7,
+                "99.0" : 3.2761447778813038E7,
+                "99.9" : 3.2761447778813038E7,
+                "99.99" : 3.2761447778813038E7,
+                "99.999" : 3.2761447778813038E7,
+                "99.9999" : 3.2761447778813038E7,
+                "100.0" : 3.2761447778813038E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.230580650398938E7,
+                    3.27229678509396E7,
+                    3.2248595678694755E7,
+                    3.2549994506474346E7,
+                    3.219015870008541E7,
+                    3.2578280444031473E7,
+                    3.261811501251481E7,
+                    3.2596072585938E7,
+                    3.2761447778813038E7,
+                    3.2207851777898267E7
+                ],
+                [
+                    3.1522204091580547E7,
+                    3.169497391938846E7,
+                    3.1246696314132426E7,
+                    3.115581566947374E7,
+                    3.158092066330693E7,
+                    3.1461412338966724E7,
+                    3.1667249651597604E7,
+                    3.127758140003379E7,
+                    3.151154553992609E7,
+                    3.155170495175674E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaFunctorBenchmark.anonMapSimpleCCBox",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.778586266633364E8,
+            "scoreError" : 1494277.7428208613,
+            "scoreConfidence" : [
+                2.7636434892051554E8,
+                2.7935290440615726E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.7259953883825535E8,
+                "50.0" : 2.7832088901699877E8,
+                "90.0" : 2.795704173196947E8,
+                "95.0" : 2.7976927691245914E8,
+                "99.0" : 2.7977842417237353E8,
+                "99.9" : 2.7977842417237353E8,
+                "99.99" : 2.7977842417237353E8,
+                "99.999" : 2.7977842417237353E8,
+                "99.9999" : 2.7977842417237353E8,
+                "100.0" : 2.7977842417237353E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.762612718212918E8,
+                    2.792557666224809E8,
+                    2.793448624301733E8,
+                    2.777791014198405E8,
+                    2.7977842417237353E8,
+                    2.7857956258183986E8,
+                    2.79595478974086E8,
+                    2.784843896982749E8,
+                    2.7762858350486517E8,
+                    2.7714826526546234E8
+                ],
+                [
+                    2.777257811262474E8,
+                    2.790709649250689E8,
+                    2.7259953883825535E8,
+                    2.756958534060321E8,
+                    2.78226415323173E8,
+                    2.7829477649540347E8,
+                    2.756477639350601E8,
+                    2.78347001538594E8,
+                    2.7861468211038995E8,
+                    2.790940490778137E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaFunctorBenchmark.factoryMapSimpleCCBox",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7258766029438484E8,
+            "scoreError" : 4826376.383231442,
+            "scoreConfidence" : [
+                2.677612839111534E8,
+                2.774140366776163E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.640851403290505E8,
+                "50.0" : 2.703160174021433E8,
+                "90.0" : 2.7966298166667455E8,
+                "95.0" : 2.801987647489975E8,
+                "99.0" : 2.802255738086805E8,
+                "99.9" : 2.802255738086805E8,
+                "99.99" : 2.802255738086805E8,
+                "99.999" : 2.802255738086805E8,
+                "99.9999" : 2.802255738086805E8,
+                "100.0" : 2.802255738086805E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.6597012237364236E8,
+                    2.640851403290505E8,
+                    2.6778115594699788E8,
+                    2.6706870740848684E8,
+                    2.6895910832373655E8,
+                    2.6861166554824543E8,
+                    2.6778213885072812E8,
+                    2.704149205898511E8,
+                    2.680599091279174E8,
+                    2.702171142144355E8
+                ],
+                [
+                    2.796893926150211E8,
+                    2.7591816934025383E8,
+                    2.767097324116354E8,
+                    2.802255738086805E8,
+                    2.772969152658764E8,
+                    2.7914163769268525E8,
+                    2.6792016114989963E8,
+                    2.781635116795296E8,
+                    2.7942528313155574E8,
+                    2.7831284607946825E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.anonEqvPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.734914556252326E9,
+            "scoreError" : 1.7019289810052222E8,
+            "scoreConfidence" : [
+                3.564721658151804E9,
+                3.905107454352848E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9074266993032928E9,
+                "50.0" : 3.777027764764201E9,
+                "90.0" : 3.8031401598942246E9,
+                "95.0" : 3.806251220114016E9,
+                "99.0" : 3.8064146891281414E9,
+                "99.9" : 3.8064146891281414E9,
+                "99.99" : 3.8064146891281414E9,
+                "99.999" : 3.8064146891281414E9,
+                "99.9999" : 3.8064146891281414E9,
+                "100.0" : 3.8064146891281414E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.771979852251122E9,
+                    3.747147913549076E9,
+                    3.7483051138044386E9,
+                    3.770043341684574E9,
+                    3.77023530926221E9,
+                    3.768082126080089E9,
+                    3.79974852652654E9,
+                    3.771039131435119E9,
+                    3.7928350733547444E9,
+                    3.785007476041716E9
+                ],
+                [
+                    3.770029083700617E9,
+                    3.7208325378606424E9,
+                    3.7820756772772803E9,
+                    3.803093819331534E9,
+                    3.799509993078264E9,
+                    3.8031453088456345E9,
+                    3.8064146891281414E9,
+                    2.9074266993032928E9,
+                    3.788715289641506E9,
+                    3.792624162889982E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.anonEqvSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3483951296977859E9,
+            "scoreError" : 5451369.836768932,
+            "scoreConfidence" : [
+                1.342943759861017E9,
+                1.3538464995345547E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.334283090146835E9,
+                "50.0" : 1.3488597807027378E9,
+                "90.0" : 1.3552818428043065E9,
+                "95.0" : 1.3567136022828963E9,
+                "99.0" : 1.3567885558641474E9,
+                "99.9" : 1.3567885558641474E9,
+                "99.99" : 1.3567885558641474E9,
+                "99.999" : 1.3567885558641474E9,
+                "99.9999" : 1.3567885558641474E9,
+                "100.0" : 1.3567885558641474E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3506571794649484E9,
+                    1.3523868818237722E9,
+                    1.344627182865761E9,
+                    1.3552130698909507E9,
+                    1.3480515329646258E9,
+                    1.3515797065434353E9,
+                    1.350887704211032E9,
+                    1.3405465425405893E9,
+                    1.3479839535805283E9,
+                    1.334283090146835E9
+                ],
+                [
+                    1.3384757181482584E9,
+                    1.3390180124937866E9,
+                    1.346532742495292E9,
+                    1.3485707521624963E9,
+                    1.354787726006514E9,
+                    1.3491488092429795E9,
+                    1.3567885558641474E9,
+                    1.3552894842391238E9,
+                    1.3483198357623842E9,
+                    1.3547541135082557E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.anonHashPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.8870061557441987E7,
+            "scoreError" : 138572.90523344092,
+            "scoreConfidence" : [
+                1.8731488652208544E7,
+                1.900863446267543E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.85619293634658E7,
+                "50.0" : 1.8848189150080457E7,
+                "90.0" : 1.906427683750236E7,
+                "95.0" : 1.906863682962947E7,
+                "99.0" : 1.906881109854552E7,
+                "99.9" : 1.906881109854552E7,
+                "99.99" : 1.906881109854552E7,
+                "99.999" : 1.906881109854552E7,
+                "99.9999" : 1.906881109854552E7,
+                "100.0" : 1.906881109854552E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9054836893003386E7,
+                    1.900988934709117E7,
+                    1.9016460681864385E7,
+                    1.902081738684267E7,
+                    1.905195531968024E7,
+                    1.906881109854552E7,
+                    1.903448657636007E7,
+                    1.906532572022447E7,
+                    1.89267638578125E7,
+                    1.886876349351672E7
+                ],
+                [
+                    1.85619293634658E7,
+                    1.8769662216043457E7,
+                    1.8761419268165357E7,
+                    1.8707637122297134E7,
+                    1.8717406332123328E7,
+                    1.8746984876261666E7,
+                    1.8693849112378072E7,
+                    1.8827614806644198E7,
+                    1.8769184389035553E7,
+                    1.872743328748404E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.anonHashSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7515579075699854E9,
+            "scoreError" : 1.6953166786376223E8,
+            "scoreConfidence" : [
+                3.582026239706223E9,
+                3.921089575433748E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.926172237618307E9,
+                "50.0" : 3.795524447983329E9,
+                "90.0" : 3.8272260808072314E9,
+                "95.0" : 3.8296874231993675E9,
+                "99.0" : 3.829796299787423E9,
+                "99.9" : 3.829796299787423E9,
+                "99.99" : 3.829796299787423E9,
+                "99.999" : 3.829796299787423E9,
+                "99.9999" : 3.829796299787423E9,
+                "100.0" : 3.829796299787423E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.7965329597001915E9,
+                    3.7841450859609485E9,
+                    3.7784210174362535E9,
+                    3.78704802863469E9,
+                    3.8157584812971954E9,
+                    3.8028394848268805E9,
+                    3.7972487188614407E9,
+                    3.8236918958354926E9,
+                    3.7605537182828574E9,
+                    3.7782246100705156E9
+                ],
+                [
+                    3.7855400099439893E9,
+                    3.8276187680263133E9,
+                    3.829796299787423E9,
+                    3.771525334387461E9,
+                    3.7945159362664666E9,
+                    3.799691230711887E9,
+                    3.8039137254322834E9,
+                    2.926172237618307E9,
+                    3.8009448251056027E9,
+                    3.7669757832135096E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.factoryEqvPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.729102828336566E9,
+            "scoreError" : 2.4096112156796667E8,
+            "scoreConfidence" : [
+                3.4881417067685995E9,
+                3.9700639499045324E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.895861675579323E9,
+                "50.0" : 3.8137932418765736E9,
+                "90.0" : 3.840948274453402E9,
+                "95.0" : 3.841412333794449E9,
+                "99.0" : 3.841427299052174E9,
+                "99.9" : 3.841427299052174E9,
+                "99.99" : 3.841427299052174E9,
+                "99.999" : 3.841427299052174E9,
+                "99.9999" : 3.841427299052174E9,
+                "100.0" : 3.841427299052174E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.814079741095853E9,
+                    3.808751981567128E9,
+                    3.794557219223002E9,
+                    3.8098364973074727E9,
+                    3.791330032977272E9,
+                    3.8117673956603966E9,
+                    3.8258294926574016E9,
+                    2.895861675579323E9,
+                    3.83011318094695E9,
+                    3.813506742657294E9
+                ],
+                [
+                    3.812379686249121E9,
+                    3.8346232519794006E9,
+                    3.839330799455018E9,
+                    3.841127993897667E9,
+                    3.8174965336879377E9,
+                    3.8334246254586525E9,
+                    3.841427299052174E9,
+                    2.9422837009647713E9,
+                    3.8147550331137805E9,
+                    3.809573683200693E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.factoryEqvSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.2753816352805407E9,
+            "scoreError" : 6.204656246751657E7,
+            "scoreConfidence" : [
+                1.213335072813024E9,
+                1.3374281977480574E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0907604604932792E9,
+                "50.0" : 1.293502043288302E9,
+                "90.0" : 1.3366482213727233E9,
+                "95.0" : 1.3395230871214106E9,
+                "99.0" : 1.3396665196052208E9,
+                "99.9" : 1.3396665196052208E9,
+                "99.99" : 1.3396665196052208E9,
+                "99.999" : 1.3396665196052208E9,
+                "99.9999" : 1.3396665196052208E9,
+                "100.0" : 1.3396665196052208E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3197219003219726E9,
+                    1.2929550106653082E9,
+                    1.2508271920454242E9,
+                    1.2986016339111435E9,
+                    1.314191088789991E9,
+                    1.2839625821593122E9,
+                    1.3191336286670747E9,
+                    1.2236540535926435E9,
+                    1.1124910829483407E9,
+                    1.3353013843660815E9
+                ],
+                [
+                    1.2876517734982646E9,
+                    1.3367978699290168E9,
+                    1.2601536544076507E9,
+                    1.1892745693951159E9,
+                    1.3396665196052208E9,
+                    1.334348910090507E9,
+                    1.3343386427344015E9,
+                    1.2940490759112954E9,
+                    1.289751672078771E9,
+                    1.0907604604932792E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.factoryHashPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.8443450993224017E7,
+            "scoreError" : 336229.7362670886,
+            "scoreConfidence" : [
+                1.8107221256956927E7,
+                1.8779680729491107E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.8038882957489714E7,
+                "50.0" : 1.8377542451925997E7,
+                "90.0" : 1.885924030650316E7,
+                "95.0" : 1.889776592211108E7,
+                "99.0" : 1.8899716616017815E7,
+                "99.9" : 1.8899716616017815E7,
+                "99.99" : 1.8899716616017815E7,
+                "99.999" : 1.8899716616017815E7,
+                "99.9999" : 1.8899716616017815E7,
+                "100.0" : 1.8899716616017815E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.8844398902031835E7,
+                    1.8824567286328368E7,
+                    1.8899716616017815E7,
+                    1.8790882806050837E7,
+                    1.8807610706400704E7,
+                    1.883173339669716E7,
+                    1.865193099187688E7,
+                    1.886070273788307E7,
+                    1.882309029726501E7,
+                    1.8846078424083993E7
+                ],
+                [
+                    1.8046510439325906E7,
+                    1.8038882957489714E7,
+                    1.8065902970783688E7,
+                    1.806909891933241E7,
+                    1.8076776738528177E7,
+                    1.8071001263432622E7,
+                    1.8066380712180126E7,
+                    1.810315391197511E7,
+                    1.808909058685499E7,
+                    1.8061509199941915E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaHashBenchmark.factoryHashSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7558601237431016E9,
+            "scoreError" : 1.7100491249925256E8,
+            "scoreConfidence" : [
+                3.584855211243849E9,
+                3.9268650362423544E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9253643519804435E9,
+                "50.0" : 3.8055307183212404E9,
+                "90.0" : 3.8224804279236465E9,
+                "95.0" : 3.8291250368508506E9,
+                "99.0" : 3.8294504403067126E9,
+                "99.9" : 3.8294504403067126E9,
+                "99.99" : 3.8294504403067126E9,
+                "99.999" : 3.8294504403067126E9,
+                "99.9999" : 3.8294504403067126E9,
+                "100.0" : 3.8294504403067126E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.9253643519804435E9,
+                    3.7902649888688927E9,
+                    3.8294504403067126E9,
+                    3.809571802719269E9,
+                    3.814664008908419E9,
+                    3.816389502550014E9,
+                    3.7539026696857395E9,
+                    3.8156086531142373E9,
+                    3.796922675222296E9,
+                    3.8014896339232125E9
+                ],
+                [
+                    3.81652978211067E9,
+                    3.7663707421518006E9,
+                    3.8229423711894674E9,
+                    3.818322938531258E9,
+                    3.794840852036361E9,
+                    3.8099112934132814E9,
+                    3.792268441380019E9,
+                    3.787308069070138E9,
+                    3.7370184485755606E9,
+                    3.8180608091242275E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.anonEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2821253.9152946146,
+            "scoreError" : 13612.075188605651,
+            "scoreConfidence" : [
+                2807641.840106009,
+                2834865.99048322
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2784661.3327058638,
+                "50.0" : 2821387.1738906624,
+                "90.0" : 2841160.3255686737,
+                "95.0" : 2847738.847198781,
+                "99.0" : 2848081.7477268144,
+                "99.9" : 2848081.7477268144,
+                "99.99" : 2848081.7477268144,
+                "99.999" : 2848081.7477268144,
+                "99.9999" : 2848081.7477268144,
+                "100.0" : 2848081.7477268144
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2805427.183549187,
+                    2811756.852384421,
+                    2816212.044144567,
+                    2822121.9349427917,
+                    2798432.413289037,
+                    2784661.3327058638,
+                    2811279.461660149,
+                    2820652.412838533,
+                    2829493.495060936,
+                    2840009.559642533
+                ],
+                [
+                    2832010.5856119534,
+                    2840589.6211913833,
+                    2829283.999479993,
+                    2816570.6952368603,
+                    2848081.7477268144,
+                    2824882.1740311943,
+                    2825094.5451265285,
+                    2807149.040670489,
+                    2820145.469432901,
+                    2841223.7371661505
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.anonPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3126886.0339640337,
+            "scoreError" : 17755.228785915224,
+            "scoreConfidence" : [
+                3109130.8051781184,
+                3144641.262749949
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3081779.728506048,
+                "50.0" : 3131498.177980652,
+                "90.0" : 3153171.3866476975,
+                "95.0" : 3157286.762484598,
+                "99.0" : 3157500.198939673,
+                "99.9" : 3157500.198939673,
+                "99.99" : 3157500.198939673,
+                "99.999" : 3157500.198939673,
+                "99.9999" : 3157500.198939673,
+                "100.0" : 3157500.198939673
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3142720.613322194,
+                    3132596.8102238514,
+                    3104423.565212455,
+                    3120375.7268085885,
+                    3087646.681945705,
+                    3081779.728506048,
+                    3121151.3851368125,
+                    3099581.8153084232,
+                    3125730.2204931346,
+                    3129963.30247299
+                ],
+                [
+                    3120263.2473571356,
+                    3130693.3351801606,
+                    3152630.637933444,
+                    3137481.866019082,
+                    3153231.4698381703,
+                    3157500.198939673,
+                    3132303.020781144,
+                    3136618.2508762605,
+                    3137962.395864285,
+                    3133066.4070611075
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.anonSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.2587853184143074E8,
+            "scoreError" : 791400.2873433932,
+            "scoreConfidence" : [
+                1.2508713155408734E8,
+                1.2666993212877414E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.2297911014703868E8,
+                "50.0" : 1.2595840624323419E8,
+                "90.0" : 1.27007348493611E8,
+                "95.0" : 1.2709396571972185E8,
+                "99.0" : 1.2709702290444449E8,
+                "99.9" : 1.2709702290444449E8,
+                "99.99" : 1.2709702290444449E8,
+                "99.999" : 1.2709702290444449E8,
+                "99.9999" : 1.2709702290444449E8,
+                "100.0" : 1.2709702290444449E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2703587920999193E8,
+                    1.2638070947811423E8,
+                    1.2640649157422169E8,
+                    1.2543264960780449E8,
+                    1.2297911014703868E8,
+                    1.2570777935655381E8,
+                    1.262061023261308E8,
+                    1.262539902354001E8,
+                    1.2586288520717123E8,
+                    1.2709702290444449E8
+                ],
+                [
+                    1.2577086705671555E8,
+                    1.2675057204618247E8,
+                    1.2658313272015315E8,
+                    1.2519802841259731E8,
+                    1.2649761598729226E8,
+                    1.2605392727929714E8,
+                    1.25695117132482E8,
+                    1.2539924416462642E8,
+                    1.2504900488806069E8,
+                    1.2521050709433666E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.factoryEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2809290.931322028,
+            "scoreError" : 28222.589930829075,
+            "scoreConfidence" : [
+                2781068.341391199,
+                2837513.521252857
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2750690.7389972736,
+                "50.0" : 2807596.4873987017,
+                "90.0" : 2856198.8901384184,
+                "95.0" : 2859762.3953709267,
+                "99.0" : 2859885.527929282,
+                "99.9" : 2859885.527929282,
+                "99.99" : 2859885.527929282,
+                "99.999" : 2859885.527929282,
+                "99.9999" : 2859885.527929282,
+                "100.0" : 2859885.527929282
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2780980.1095457305,
+                    2769809.152210974,
+                    2764898.622691612,
+                    2797429.888850195,
+                    2750690.7389972736,
+                    2797147.476635537,
+                    2795085.0495109987,
+                    2796518.123748469,
+                    2790864.531842025,
+                    2767522.7103022165
+                ],
+                [
+                    2817763.085947209,
+                    2859885.527929282,
+                    2845183.0105245253,
+                    2828621.956667826,
+                    2830027.526634576,
+                    2826941.651349453,
+                    2835932.7243648665,
+                    2857422.8767621843,
+                    2839763.356706862,
+                    2833330.505218738
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.factoryPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3096025.9388035736,
+            "scoreError" : 16057.41827951245,
+            "scoreConfidence" : [
+                3079968.5205240613,
+                3112083.357083086
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3041226.066856338,
+                "50.0" : 3099014.169729806,
+                "90.0" : 3119846.3840836016,
+                "95.0" : 3121765.5470162476,
+                "99.0" : 3121851.449898465,
+                "99.9" : 3121851.449898465,
+                "99.99" : 3121851.449898465,
+                "99.999" : 3121851.449898465,
+                "99.9999" : 3121851.449898465,
+                "100.0" : 3121851.449898465
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3097984.7474015565,
+                    3089952.9331423743,
+                    3100043.5920580556,
+                    3041226.066856338,
+                    3083364.07663479,
+                    3100971.567833335,
+                    3080775.7845645756,
+                    3105054.114880889,
+                    3120133.3922541123,
+                    3072444.432001014
+                ],
+                [
+                    3090597.6905353023,
+                    3091861.642078671,
+                    3094507.344955926,
+                    3113926.398334444,
+                    3117263.3105490073,
+                    3085748.66770527,
+                    3105190.0458967816,
+                    3104954.584685694,
+                    3102666.9338048734,
+                    3121851.449898465
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AnonVsLambdaShowBenchmark.factorySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.2473945767327623E8,
+            "scoreError" : 800629.4292549981,
+            "scoreConfidence" : [
+                1.2393882824402124E8,
+                1.2554008710253122E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.2224413054817803E8,
+                "50.0" : 1.2480783210813722E8,
+                "90.0" : 1.2571678184464177E8,
+                "95.0" : 1.2618978808578295E8,
+                "99.0" : 1.2621443477284953E8,
+                "99.9" : 1.2621443477284953E8,
+                "99.99" : 1.2621443477284953E8,
+                "99.999" : 1.2621443477284953E8,
+                "99.9999" : 1.2621443477284953E8,
+                "100.0" : 1.2621443477284953E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2405334039004946E8,
+                    1.2482348174222425E8,
+                    1.2387510644480759E8,
+                    1.243140737913521E8,
+                    1.2479218247405021E8,
+                    1.241708658940599E8,
+                    1.2353063686922884E8,
+                    1.2456765667664398E8,
+                    1.242141087672792E8,
+                    1.2224413054817803E8
+                ],
+                [
+                    1.2456359329635487E8,
+                    1.2533799279748145E8,
+                    1.2518298191310757E8,
+                    1.2543632758620723E8,
+                    1.2501322693842474E8,
+                    1.2562291885839728E8,
+                    1.2567430916275819E8,
+                    1.2621443477284953E8,
+                    1.2543628351055297E8,
+                    1.2572150103151773E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8550984.337059956,
+            "scoreError" : 322448.9467377623,
+            "scoreConfidence" : [
+                8228535.3903221935,
+                8873433.283797719
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7998394.115159606,
+                "50.0" : 8584518.628837084,
+                "90.0" : 8945016.423643103,
+                "95.0" : 8946083.845467947,
+                "99.0" : 8946119.115266161,
+                "99.9" : 8946119.115266161,
+                "99.99" : 8946119.115266161,
+                "99.999" : 8946119.115266161,
+                "99.9999" : 8946119.115266161,
+                "100.0" : 8946119.115266161
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8946119.115266161,
+                    8876614.562039468,
+                    8847948.235675,
+                    8935743.868005963,
+                    8945413.719301885,
+                    8941440.762714054,
+                    8870713.762606893,
+                    8936987.9533027,
+                    8863499.455845252,
+                    8873598.20046909
+                ],
+                [
+                    8321089.021999168,
+                    8203088.071688629,
+                    8263008.911107358,
+                    8282862.55138527,
+                    8301428.724436601,
+                    8247224.3682415085,
+                    8232132.7851728145,
+                    8057535.441267622,
+                    7998394.115159606,
+                    8074843.1155141
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9252619.511429,
+            "scoreError" : 132970.47323167798,
+            "scoreConfidence" : [
+                9119649.038197322,
+                9385589.98466068
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8911497.108758416,
+                "50.0" : 9273160.60619241,
+                "90.0" : 9417864.935091723,
+                "95.0" : 9427409.584399495,
+                "99.0" : 9427886.450269235,
+                "99.9" : 9427886.450269235,
+                "99.99" : 9427886.450269235,
+                "99.999" : 9427886.450269235,
+                "99.9999" : 9427886.450269235,
+                "100.0" : 9427886.450269235
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9081930.785515938,
+                    8911497.108758416,
+                    9033425.909110446,
+                    9407216.022976467,
+                    9418349.13287444,
+                    9204683.559768995,
+                    9388258.420856977,
+                    9166310.895738034,
+                    9352430.5045171,
+                    9427886.450269235
+                ],
+                [
+                    9288085.457182504,
+                    9195593.360854022,
+                    9258235.755202316,
+                    9018023.512959296,
+                    9406334.155362435,
+                    9413507.15504727,
+                    9348646.417572277,
+                    9336629.828931535,
+                    9211410.176301895,
+                    9183935.61878037
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6695046418161076E8,
+            "scoreError" : 563010.6525728515,
+            "scoreConfidence" : [
+                1.6638745352903792E8,
+                1.675134748341836E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.648746981988632E8,
+                "50.0" : 1.671948294837577E8,
+                "90.0" : 1.6742172044468707E8,
+                "95.0" : 1.674409819329174E8,
+                "99.0" : 1.6744198182774264E8,
+                "99.9" : 1.6744198182774264E8,
+                "99.99" : 1.6744198182774264E8,
+                "99.999" : 1.6744198182774264E8,
+                "99.9999" : 1.6744198182774264E8,
+                "100.0" : 1.6744198182774264E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.648746981988632E8,
+                    1.6689795903703624E8,
+                    1.673232909197185E8,
+                    1.670423043024574E8,
+                    1.6703789700780374E8,
+                    1.6729076959880343E8,
+                    1.6596921952596593E8,
+                    1.6606179072871986E8,
+                    1.6742198393123794E8,
+                    1.674193490657292E8
+                ],
+                [
+                    1.673883829052787E8,
+                    1.6744198182774264E8,
+                    1.668179921827355E8,
+                    1.671986673100263E8,
+                    1.6719099165748912E8,
+                    1.6737128533107558E8,
+                    1.670487025073704E8,
+                    1.6655768180287188E8,
+                    1.6741297545814294E8,
+                    1.6724136033314726E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.2716149270660198E8,
+            "scoreError" : 1345597.9186711155,
+            "scoreConfidence" : [
+                1.2581589478793086E8,
+                1.285070906252731E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.2290268964519715E8,
+                "50.0" : 1.2771839398977247E8,
+                "90.0" : 1.2851194754620136E8,
+                "95.0" : 1.2862049658907619E8,
+                "99.0" : 1.2862604230517681E8,
+                "99.9" : 1.2862604230517681E8,
+                "99.99" : 1.2862604230517681E8,
+                "99.999" : 1.2862604230517681E8,
+                "99.9999" : 1.2862604230517681E8,
+                "100.0" : 1.2862604230517681E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2290268964519715E8,
+                    1.2747240388331078E8,
+                    1.2745375388203937E8,
+                    1.2773070063678503E8,
+                    1.2770608734275992E8,
+                    1.2698132614952403E8,
+                    1.2577988708092979E8,
+                    1.2580975809575433E8,
+                    1.2731595741830885E8,
+                    1.2792782707316597E8
+                ],
+                [
+                    1.2835942959232919E8,
+                    1.2431870818650575E8,
+                    1.2783089044533095E8,
+                    1.2862604230517681E8,
+                    1.2848332361353292E8,
+                    1.2836859887900329E8,
+                    1.2793992712612313E8,
+                    1.2537684244966128E8,
+                    1.2851512798316452E8,
+                    1.2833057234343667E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4407017.559427272,
+            "scoreError" : 114441.26447165807,
+            "scoreConfidence" : [
+                4292576.294955613,
+                4521458.82389893
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4215776.824133536,
+                "50.0" : 4419709.513861315,
+                "90.0" : 4547799.9552335255,
+                "95.0" : 4553088.531935306,
+                "99.0" : 4553362.218841918,
+                "99.9" : 4553362.218841918,
+                "99.99" : 4553362.218841918,
+                "99.999" : 4553362.218841918,
+                "99.9999" : 4553362.218841918,
+                "100.0" : 4553362.218841918
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4297011.446657439,
+                    4295224.304979423,
+                    4267172.711793838,
+                    4315786.685900119,
+                    4325716.881525812,
+                    4215776.824133536,
+                    4256307.05175567,
+                    4256517.162130633,
+                    4282637.953048298,
+                    4295985.196581908
+                ],
+                [
+                    4547003.22594806,
+                    4529855.530365666,
+                    4514233.733160895,
+                    4518222.760188385,
+                    4547888.480709688,
+                    4539993.756319274,
+                    4513702.146196819,
+                    4540026.677657367,
+                    4527926.440650699,
+                    4553362.218841918
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.389037341084613E7,
+            "scoreError" : 3.6603162639486074E7,
+            "scoreConfidence" : [
+                4.7287210771360055E7,
+                1.204935360503322E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.263560789506544E7,
+                "50.0" : 8.316447768513983E7,
+                "90.0" : 1.2586459034201564E8,
+                "95.0" : 1.2614930589660683E8,
+                "99.0" : 1.2616321990260911E8,
+                "99.9" : 1.2616321990260911E8,
+                "99.99" : 1.2616321990260911E8,
+                "99.999" : 1.2616321990260911E8,
+                "99.9999" : 1.2616321990260911E8,
+                "100.0" : 1.2616321990260911E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2616321990260911E8,
+                    1.2568144537708375E8,
+                    1.252765405866049E8,
+                    1.2588493978256363E8,
+                    1.2411410237042774E8,
+                    1.2445960997345184E8,
+                    1.2490843690061505E8,
+                    1.2545649123482068E8,
+                    1.2328807816343243E8,
+                    1.2447576064683995E8
+                ],
+                [
+                    4.269419783613885E7,
+                    4.283547910594348E7,
+                    4.304087720684723E7,
+                    4.269137476575711E7,
+                    4.2874621061446734E7,
+                    4.2823278943406016E7,
+                    4.291570913804617E7,
+                    4.270823649798352E7,
+                    4.2879460827838644E7,
+                    4.263560789506544E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3130157.725595782,
+            "scoreError" : 17585.21609657372,
+            "scoreConfidence" : [
+                3112572.5094992085,
+                3147742.9416923556
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3082503.2628560555,
+                "50.0" : 3132169.515240958,
+                "90.0" : 3151323.829691771,
+                "95.0" : 3160379.6520845583,
+                "99.0" : 3160836.3586861244,
+                "99.9" : 3160836.3586861244,
+                "99.99" : 3160836.3586861244,
+                "99.999" : 3160836.3586861244,
+                "99.9999" : 3160836.3586861244,
+                "100.0" : 3160836.3586861244
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3146647.6066253297,
+                    3146669.8480462236,
+                    3151702.2266548057,
+                    3124314.8820497836,
+                    3103016.8591841967,
+                    3133451.707885214,
+                    3145165.775460558,
+                    3147905.3021796774,
+                    3115505.9109653337,
+                    3160836.3586861244
+                ],
+                [
+                    3128923.193354685,
+                    3102857.940873591,
+                    3117658.6966084572,
+                    3130887.3225967023,
+                    3082503.2628560555,
+                    3139964.3090081327,
+                    3144905.1112816273,
+                    3123582.490324436,
+                    3147918.2570244563,
+                    3108737.4502502503
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroDecodeBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.6018113599113442E7,
+            "scoreError" : 2177620.4069577553,
+            "scoreConfidence" : [
+                2.3840493192155685E7,
+                2.81957340060712E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.213529522791567E7,
+                "50.0" : 2.5940845876118474E7,
+                "90.0" : 2.879410433179103E7,
+                "95.0" : 2.8836489122337274E7,
+                "99.0" : 2.8838199931465384E7,
+                "99.9" : 2.8838199931465384E7,
+                "99.99" : 2.8838199931465384E7,
+                "99.999" : 2.8838199931465384E7,
+                "99.9999" : 2.8838199931465384E7,
+                "100.0" : 2.8838199931465384E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.371152353409474E7,
+                    2.392716160497714E7,
+                    2.41995105862643E7,
+                    2.312471323109035E7,
+                    2.3523439801781576E7,
+                    2.4110391578837387E7,
+                    2.3170877550205346E7,
+                    2.3895662040563717E7,
+                    2.213529522791567E7,
+                    2.458329769383798E7
+                ],
+                [
+                    2.8666930651640203E7,
+                    2.8572146984824833E7,
+                    2.8705189577781297E7,
+                    2.8105577256393E7,
+                    2.8838199931465384E7,
+                    2.880398374890322E7,
+                    2.729839405839897E7,
+                    2.829496984620113E7,
+                    2.8356440422683787E7,
+                    2.8338566654408842E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.795620123276171E7,
+            "scoreError" : 220298.41302726514,
+            "scoreConfidence" : [
+                1.7735902819734447E7,
+                1.8176499645788975E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.759075205050807E7,
+                "50.0" : 1.7970404066146366E7,
+                "90.0" : 1.8305426612386603E7,
+                "95.0" : 1.8376660106895324E7,
+                "99.0" : 1.8380028151451677E7,
+                "99.9" : 1.8380028151451677E7,
+                "99.99" : 1.8380028151451677E7,
+                "99.999" : 1.8380028151451677E7,
+                "99.9999" : 1.8380028151451677E7,
+                "100.0" : 1.8380028151451677E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.813111640706863E7,
+                    1.813468777724399E7,
+                    1.807270442329381E7,
+                    1.8380028151451677E7,
+                    1.8312667260324627E7,
+                    1.8151408727421433E7,
+                    1.818201164617477E7,
+                    1.815197916661541E7,
+                    1.811530175779749E7,
+                    1.8240260780944377E7
+                ],
+                [
+                    1.759075205050807E7,
+                    1.762080557677295E7,
+                    1.7833904667654227E7,
+                    1.771776452537111E7,
+                    1.7675023626650613E7,
+                    1.7790738552048743E7,
+                    1.767901374370677E7,
+                    1.7773257856656935E7,
+                    1.7868103708998926E7,
+                    1.7702494248529762E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.910851673539888E7,
+            "scoreError" : 166204.76494635304,
+            "scoreConfidence" : [
+                1.894231197045253E7,
+                1.9274721500345234E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.8567400323703878E7,
+                "50.0" : 1.912491518449086E7,
+                "90.0" : 1.934223201539099E7,
+                "95.0" : 1.9352646735680588E7,
+                "99.0" : 1.9353153782874554E7,
+                "99.9" : 1.9353153782874554E7,
+                "99.99" : 1.9353153782874554E7,
+                "99.999" : 1.9353153782874554E7,
+                "99.9999" : 1.9353153782874554E7,
+                "100.0" : 1.9353153782874554E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.8965852889217597E7,
+                    1.896548751257723E7,
+                    1.9086381330276694E7,
+                    1.9201821757733036E7,
+                    1.8567400323703878E7,
+                    1.9242701725655284E7,
+                    1.8808841447692767E7,
+                    1.9025251873972055E7,
+                    1.913154196681356E7,
+                    1.9071840404040907E7
+                ],
+                [
+                    1.9181088979555085E7,
+                    1.9118288402168155E7,
+                    1.8995694712394275E7,
+                    1.931317922190741E7,
+                    1.9353153782874554E7,
+                    1.920411330290888E7,
+                    1.9343012838995226E7,
+                    1.9335204602952864E7,
+                    1.911587134182483E7,
+                    1.914360629071339E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.784583417828285E8,
+            "scoreError" : 4884623.339476848,
+            "scoreConfidence" : [
+                3.735737184433517E8,
+                3.8334296512230533E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.6741426670686996E8,
+                "50.0" : 3.77155296060622E8,
+                "90.0" : 3.859723214504926E8,
+                "95.0" : 3.8622712562713975E8,
+                "99.0" : 3.862394612826903E8,
+                "99.9" : 3.862394612826903E8,
+                "99.99" : 3.862394612826903E8,
+                "99.999" : 3.862394612826903E8,
+                "99.9999" : 3.862394612826903E8,
+                "100.0" : 3.862394612826903E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.7784482117398435E8,
+                    3.8018484829206187E8,
+                    3.846138715438923E8,
+                    3.831493028075438E8,
+                    3.8599274817167985E8,
+                    3.844469191732961E8,
+                    3.8578848095980775E8,
+                    3.862394612826903E8,
+                    3.81444707387E8,
+                    3.826155058211616E8
+                ],
+                [
+                    3.696835191776309E8,
+                    3.7501511592531997E8,
+                    3.740473013227371E8,
+                    3.764657709472596E8,
+                    3.7452573758874786E8,
+                    3.75701242915715E8,
+                    3.7487248889023954E8,
+                    3.730983454745234E8,
+                    3.7602238009440905E8,
+                    3.6741426670686996E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.773755929819399E8,
+            "scoreError" : 1.2087206220935447E7,
+            "scoreConfidence" : [
+                2.6528838676100448E8,
+                2.894627992028754E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6098515043193597E8,
+                "50.0" : 2.725018985122797E8,
+                "90.0" : 2.9376058455087453E8,
+                "95.0" : 2.9449587840428716E8,
+                "99.0" : 2.9453186659456223E8,
+                "99.9" : 2.9453186659456223E8,
+                "99.99" : 2.9453186659456223E8,
+                "99.999" : 2.9453186659456223E8,
+                "99.9999" : 2.9453186659456223E8,
+                "100.0" : 2.9453186659456223E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.6098515043193597E8,
+                    2.6254939356221527E8,
+                    2.6509871269487795E8,
+                    2.657573855788443E8,
+                    2.61806429497837E8,
+                    2.6499761434364814E8,
+                    2.6441226102327168E8,
+                    2.651202889591029E8,
+                    2.6554730479358625E8,
+                    2.6598556874128693E8
+                ],
+                [
+                    2.9196895826764816E8,
+                    2.894110653375418E8,
+                    2.931228923645599E8,
+                    2.932969204072E8,
+                    2.932253053034891E8,
+                    2.938121027890606E8,
+                    2.7901822828327245E8,
+                    2.893042793198711E8,
+                    2.875601313449864E8,
+                    2.9453186659456223E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5846560.750331111,
+            "scoreError" : 66850.96784803676,
+            "scoreConfidence" : [
+                5779709.782483075,
+                5913411.718179148
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5719267.9279357465,
+                "50.0" : 5835056.640461258,
+                "90.0" : 5969019.337336147,
+                "95.0" : 5999870.478760882,
+                "99.0" : 6001299.455738434,
+                "99.9" : 6001299.455738434,
+                "99.99" : 6001299.455738434,
+                "99.999" : 6001299.455738434,
+                "99.9999" : 6001299.455738434,
+                "100.0" : 6001299.455738434
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5719267.9279357465,
+                    5801779.319458431,
+                    5780264.350322029,
+                    5839457.700434438,
+                    5830655.580488077,
+                    5811773.270555499,
+                    5843851.892914426,
+                    5817779.432372808,
+                    5787842.893173763,
+                    5779132.343040064
+                ],
+                [
+                    5935714.127674756,
+                    5886953.200407687,
+                    5907999.373326872,
+                    5915219.342691106,
+                    5972719.916187413,
+                    6001299.455738434,
+                    5919331.5910510225,
+                    5798674.523664127,
+                    5727844.408092936,
+                    5853654.357092593
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.051612300039004E7,
+            "scoreError" : 917673.5451804191,
+            "scoreConfidence" : [
+                4.959844945520962E7,
+                5.1433796545570455E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.896419294962755E7,
+                "50.0" : 5.022661027937709E7,
+                "90.0" : 5.1755878896747604E7,
+                "95.0" : 5.186506971507784E7,
+                "99.0" : 5.18705151210949E7,
+                "99.9" : 5.18705151210949E7,
+                "99.99" : 5.18705151210949E7,
+                "99.999" : 5.18705151210949E7,
+                "99.9999" : 5.18705151210949E7,
+                "100.0" : 5.18705151210949E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.93021074097389E7,
+                    4.9635029020780526E7,
+                    4.968541232013582E7,
+                    4.896419294962755E7,
+                    4.962470331935749E7,
+                    4.963074622009259E7,
+                    4.958416011489664E7,
+                    4.9642062955836885E7,
+                    4.962518454787939E7,
+                    4.9476166489344195E7
+                ],
+                [
+                    5.147625012699916E7,
+                    5.170432596069188E7,
+                    5.153766443471573E7,
+                    5.152707953469338E7,
+                    5.159090196727733E7,
+                    5.1404601830347426E7,
+                    5.17616070007538E7,
+                    5.076780823861836E7,
+                    5.15119404449187E7,
+                    5.18705151210949E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5752290.62114436,
+            "scoreError" : 25385.799072113223,
+            "scoreConfidence" : [
+                5726904.822072247,
+                5777676.420216473
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5691054.958685953,
+                "50.0" : 5757450.038723953,
+                "90.0" : 5786478.708150878,
+                "95.0" : 5795152.56648422,
+                "99.0" : 5795598.242977152,
+                "99.9" : 5795598.242977152,
+                "99.99" : 5795598.242977152,
+                "99.999" : 5795598.242977152,
+                "99.9999" : 5795598.242977152,
+                "100.0" : 5795598.242977152
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5745553.406808644,
+                    5761989.496242245,
+                    5781582.0996615095,
+                    5717161.274931288,
+                    5758516.6663937755,
+                    5767137.845177273,
+                    5783194.782322606,
+                    5756383.411054132,
+                    5719672.277219346,
+                    5751028.734011267
+                ],
+                [
+                    5768588.621266382,
+                    5767664.085577158,
+                    5728799.668342577,
+                    5795598.242977152,
+                    5784624.663442101,
+                    5746353.72636632,
+                    5705023.672079924,
+                    5691054.958685953,
+                    5786684.71311852,
+                    5729200.077209018
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.AvroEncodeBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.868904444304964E7,
+            "scoreError" : 441427.42670162866,
+            "scoreConfidence" : [
+                4.824761701634801E7,
+                4.913047186975127E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.780339449741626E7,
+                "50.0" : 4.852423655704045E7,
+                "90.0" : 4.937324694390814E7,
+                "95.0" : 4.938446645270699E7,
+                "99.0" : 4.938479885112949E7,
+                "99.9" : 4.938479885112949E7,
+                "99.99" : 4.938479885112949E7,
+                "99.999" : 4.938479885112949E7,
+                "99.9999" : 4.938479885112949E7,
+                "100.0" : 4.938479885112949E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.8224806220246345E7,
+                    4.822901214552853E7,
+                    4.780339449741626E7,
+                    4.822304846897849E7,
+                    4.835293632765451E7,
+                    4.840518243952493E7,
+                    4.810791813767404E7,
+                    4.842833231739899E7,
+                    4.841243931631389E7,
+                    4.8193121241994165E7
+                ],
+                [
+                    4.9378150882679544E7,
+                    4.932911149496552E7,
+                    4.938479885112949E7,
+                    4.9240450672989815E7,
+                    4.899595510375959E7,
+                    4.917677176760382E7,
+                    4.862014079668192E7,
+                    4.8889465973090895E7,
+                    4.916024003091904E7,
+                    4.9225612174442865E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEmptyBenchmark.kindlingsEmpty",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.7525006156228657E9,
+            "scoreError" : 1.3580455258666666E7,
+            "scoreConfidence" : [
+                1.738920160364199E9,
+                1.7660810708815324E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.7019212271266265E9,
+                "50.0" : 1.7573754867524414E9,
+                "90.0" : 1.7702107230490253E9,
+                "95.0" : 1.7712528160503416E9,
+                "99.0" : 1.7712852074203486E9,
+                "99.9" : 1.7712852074203486E9,
+                "99.99" : 1.7712852074203486E9,
+                "99.999" : 1.7712852074203486E9,
+                "99.9999" : 1.7712852074203486E9,
+                "100.0" : 1.7712852074203486E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7363797152414868E9,
+                    1.746431267314263E9,
+                    1.7488551136742606E9,
+                    1.7531852821887155E9,
+                    1.7019212271266265E9,
+                    1.7478818613699298E9,
+                    1.7576015561639023E9,
+                    1.760715926173753E9,
+                    1.760849181261433E9,
+                    1.7660887263936603E9
+                ],
+                [
+                    1.7478579979502954E9,
+                    1.757416778702989E9,
+                    1.7712852074203486E9,
+                    1.770637380020209E9,
+                    1.7663708103083713E9,
+                    1.7401471991219928E9,
+                    1.738740841012782E9,
+                    1.7573341948018935E9,
+                    1.7583124916442225E9,
+                    1.761999554566171E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEmptyBenchmark.originalSemiAutoEmpty",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0628616902110488E9,
+            "scoreError" : 9487300.531639745,
+            "scoreConfidence" : [
+                1.0533743896794091E9,
+                1.0723489907426885E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0410609556497437E9,
+                "50.0" : 1.0637857876002395E9,
+                "90.0" : 1.079223137052592E9,
+                "95.0" : 1.0809968637583861E9,
+                "99.0" : 1.0810634182672784E9,
+                "99.9" : 1.0810634182672784E9,
+                "99.99" : 1.0810634182672784E9,
+                "99.999" : 1.0810634182672784E9,
+                "99.9999" : 1.0810634182672784E9,
+                "100.0" : 1.0810634182672784E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0601819174054458E9,
+                    1.0461739070567912E9,
+                    1.0444564179939055E9,
+                    1.0674967155792145E9,
+                    1.062442314419367E9,
+                    1.0592117363063395E9,
+                    1.0630625069535018E9,
+                    1.0653878623431925E9,
+                    1.0645090682469771E9,
+                    1.074016843045389E9
+                ],
+                [
+                    1.0687877794106772E9,
+                    1.061379984202001E9,
+                    1.0696774856162474E9,
+                    1.0410609556497437E9,
+                    1.0797323280894332E9,
+                    1.0540625903679543E9,
+                    1.0657278492844831E9,
+                    1.054161706262013E9,
+                    1.0810634182672784E9,
+                    1.0746404177210226E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEqBenchmark.kindlingsSimpleCCEqual",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.022997787628077E8,
+            "scoreError" : 402433.33778719837,
+            "scoreConfidence" : [
+                1.018973454250205E8,
+                1.027022121005949E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0119734730770095E8,
+                "50.0" : 1.0237614664384061E8,
+                "90.0" : 1.0274714265349524E8,
+                "95.0" : 1.0275253520186052E8,
+                "99.0" : 1.0275279950199643E8,
+                "99.9" : 1.0275279950199643E8,
+                "99.99" : 1.0275279950199643E8,
+                "99.999" : 1.0275279950199643E8,
+                "99.9999" : 1.0275279950199643E8,
+                "100.0" : 1.0275279950199643E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0274380504144806E8,
+                    1.0250675931961413E8,
+                    1.0274751349927826E8,
+                    1.0269033603469054E8,
+                    1.0275279950199643E8,
+                    1.0272649067511436E8,
+                    1.0249785455054511E8,
+                    1.0260171320533854E8,
+                    1.0260437784261881E8,
+                    1.0266292307678644E8
+                ],
+                [
+                    1.0213516475558636E8,
+                    1.0191668389739394E8,
+                    1.0220941126838933E8,
+                    1.0209434522778022E8,
+                    1.0120144728472416E8,
+                    1.0119734730770095E8,
+                    1.0201030758076118E8,
+                    1.0224583443396412E8,
+                    1.0225443873713613E8,
+                    1.021960220152875E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEqBenchmark.kindlingsSimpleCCNotEqual",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.614414029599168E8,
+            "scoreError" : 2.64511085802033E7,
+            "scoreConfidence" : [
+                5.3499029437971354E8,
+                5.878925115401201E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.8212247728214747E8,
+                "50.0" : 5.765770193046324E8,
+                "90.0" : 5.860434275067741E8,
+                "95.0" : 5.864849391086026E8,
+                "99.0" : 5.864991008878189E8,
+                "99.9" : 5.864991008878189E8,
+                "99.99" : 5.864991008878189E8,
+                "99.999" : 5.864991008878189E8,
+                "99.9999" : 5.864991008878189E8,
+                "100.0" : 5.864991008878189E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.772206786324881E8,
+                    5.759185427999706E8,
+                    5.817876855880326E8,
+                    5.844150575304111E8,
+                    5.862158653034939E8,
+                    5.843100978417048E8,
+                    5.864991008878189E8,
+                    5.795439804825737E8,
+                    5.83058170394783E8,
+                    5.844914873362964E8
+                ],
+                [
+                    5.770945043151212E8,
+                    5.0731474787159026E8,
+                    5.760595342941436E8,
+                    4.8212247728214747E8,
+                    5.574997837728237E8,
+                    5.2729368150283325E8,
+                    5.731480459686475E8,
+                    5.362512404930344E8,
+                    5.3034420306548476E8,
+                    5.382391738349383E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEqBenchmark.originalAutoSimpleCCEqual",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.217069197821166E7,
+            "scoreError" : 832459.174273979,
+            "scoreConfidence" : [
+                9.133823280393767E7,
+                9.300315115248564E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.008147732281563E7,
+                "50.0" : 9.190015090132841E7,
+                "90.0" : 9.343469205946112E7,
+                "95.0" : 9.360013062316525E7,
+                "99.0" : 9.360866718289453E7,
+                "99.9" : 9.360866718289453E7,
+                "99.99" : 9.360866718289453E7,
+                "99.999" : 9.360866718289453E7,
+                "99.9999" : 9.360866718289453E7,
+                "100.0" : 9.360866718289453E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.142155571633391E7,
+                    9.151344770694897E7,
+                    9.12417965048134E7,
+                    9.158275817551619E7,
+                    9.008147732281563E7,
+                    9.15392414714246E7,
+                    9.177038151765515E7,
+                    9.147685995679954E7,
+                    9.151728619610374E7,
+                    9.168011904425994E7
+                ],
+                [
+                    9.20299202850017E7,
+                    9.360866718289453E7,
+                    9.32589640137736E7,
+                    9.215156623472925E7,
+                    9.270710847548887E7,
+                    9.245001383870354E7,
+                    9.343793598830907E7,
+                    9.340549669982953E7,
+                    9.330905604994659E7,
+                    9.323018718288523E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsEqBenchmark.originalSemiAutoSimpleCCEqual",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.654345335043988E7,
+            "scoreError" : 806444.8706385383,
+            "scoreConfidence" : [
+                8.573700847980134E7,
+                8.734989822107841E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.42933634475895E7,
+                "50.0" : 8.668924271881208E7,
+                "90.0" : 8.75446697816246E7,
+                "95.0" : 8.755573761598302E7,
+                "99.0" : 8.75560601045558E7,
+                "99.9" : 8.75560601045558E7,
+                "99.99" : 8.75560601045558E7,
+                "99.999" : 8.75560601045558E7,
+                "99.9999" : 8.75560601045558E7,
+                "100.0" : 8.75560601045558E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.740098025937666E7,
+                    8.650073349440922E7,
+                    8.748556428263474E7,
+                    8.736154131088905E7,
+                    8.702202288706857E7,
+                    8.750020481834471E7,
+                    8.647218107686666E7,
+                    8.687775194321494E7,
+                    8.747245706451821E7,
+                    8.754961033310014E7
+                ],
+                [
+                    8.578943357418348E7,
+                    8.61650954884315E7,
+                    8.577014361414197E7,
+                    8.42933634475895E7,
+                    8.591018857813424E7,
+                    8.578245022314264E7,
+                    8.596865737228481E7,
+                    8.75560601045558E7,
+                    8.690283879197924E7,
+                    8.508778834393156E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsFoldableBenchmark.kindlingsSimpleCCBoxFoldLeft",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.6281140319383953E9,
+            "scoreError" : 5.692795207825796E7,
+            "scoreConfidence" : [
+                1.5711860798601372E9,
+                1.6850419840166533E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.4749619328336525E9,
+                "50.0" : 1.659962455812705E9,
+                "90.0" : 1.677051340438666E9,
+                "95.0" : 1.6782273829542563E9,
+                "99.0" : 1.6782854623698566E9,
+                "99.9" : 1.6782854623698566E9,
+                "99.99" : 1.6782854623698566E9,
+                "99.999" : 1.6782854623698566E9,
+                "99.9999" : 1.6782854623698566E9,
+                "100.0" : 1.6782854623698566E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6763985378660035E9,
+                    1.6771238740578508E9,
+                    1.6750728551763637E9,
+                    1.5351564517623675E9,
+                    1.6494789367959187E9,
+                    1.528474713343589E9,
+                    1.6755898014717143E9,
+                    1.6743544545484915E9,
+                    1.5720464357879093E9,
+                    1.6732253131125286E9
+                ],
+                [
+                    1.6758774067418394E9,
+                    1.52345293484062E9,
+                    1.646566991748457E9,
+                    1.6742936869149394E9,
+                    1.6696614053681183E9,
+                    1.584903759256633E9,
+                    1.4749619328336525E9,
+                    1.6782854623698566E9,
+                    1.6470921785137582E9,
+                    1.6502635062572916E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsFoldableKittensBenchmark.kittensFoldLeft",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0959639789746955E8,
+            "scoreError" : 1073528.191977368,
+            "scoreConfidence" : [
+                1.0852286970549218E8,
+                1.1066992608944692E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0806038051781477E8,
+                "50.0" : 1.0932473272521529E8,
+                "90.0" : 1.1106000390273465E8,
+                "95.0" : 1.1149243047882189E8,
+                "99.0" : 1.1151515103368431E8,
+                "99.9" : 1.1151515103368431E8,
+                "99.99" : 1.1151515103368431E8,
+                "99.999" : 1.1151515103368431E8,
+                "99.9999" : 1.1151515103368431E8,
+                "100.0" : 1.1151515103368431E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0812484423861454E8,
+                    1.0875399326860675E8,
+                    1.0871101090340157E8,
+                    1.0875303466375248E8,
+                    1.0858870906885177E8,
+                    1.0809115525408478E8,
+                    1.0846739914221624E8,
+                    1.0859038163852942E8,
+                    1.083955960549803E8,
+                    1.0806038051781477E8
+                ],
+                [
+                    1.1090928774562097E8,
+                    1.1039053447350585E8,
+                    1.098954721818238E8,
+                    1.1106073993643586E8,
+                    1.1090134190353651E8,
+                    1.1151515103368431E8,
+                    1.1098252207659565E8,
+                    1.1105337959942369E8,
+                    1.1004768879824692E8,
+                    1.1063533544966525E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsFunctorBenchmark.kindlingsSimpleCCBoxMap",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.7587542641977394E8,
+            "scoreError" : 2262071.032061326,
+            "scoreConfidence" : [
+                2.736133553877126E8,
+                2.781374974518353E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.688824020056315E8,
+                "50.0" : 2.7690679036967766E8,
+                "90.0" : 2.780544432716947E8,
+                "95.0" : 2.783122258699648E8,
+                "99.0" : 2.7832445365360624E8,
+                "99.9" : 2.7832445365360624E8,
+                "99.99" : 2.7832445365360624E8,
+                "99.999" : 2.7832445365360624E8,
+                "99.9999" : 2.7832445365360624E8,
+                "100.0" : 2.7832445365360624E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.775952204231452E8,
+                    2.771685135755497E8,
+                    2.77461367582496E8,
+                    2.7782535088995755E8,
+                    2.780798979807766E8,
+                    2.76466668292098E8,
+                    2.7832445365360624E8,
+                    2.773910369560297E8,
+                    2.7764114603673863E8,
+                    2.7639931848593485E8
+                ],
+                [
+                    2.688824020056315E8,
+                    2.70186475363174E8,
+                    2.761955908469873E8,
+                    2.7727122499449056E8,
+                    2.7726628870923775E8,
+                    2.744260803986982E8,
+                    2.756488979103672E8,
+                    2.733470760579642E8,
+                    2.732864510687897E8,
+                    2.766450671638056E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsFunctorBenchmark.originalSemiAutoSimpleCCBoxMap",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.520431103111885E7,
+            "scoreError" : 612823.2019248637,
+            "scoreConfidence" : [
+                6.459148782919399E7,
+                6.581713423304371E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.394088919008778E7,
+                "50.0" : 6.528690667686352E7,
+                "90.0" : 6.59641572278154E7,
+                "95.0" : 6.601851234519185E7,
+                "99.0" : 6.60213228178228E7,
+                "99.9" : 6.60213228178228E7,
+                "99.99" : 6.60213228178228E7,
+                "99.999" : 6.60213228178228E7,
+                "99.9999" : 6.60213228178228E7,
+                "100.0" : 6.60213228178228E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.579365889285467E7,
+                    6.587044515987548E7,
+                    6.5955551991319105E7,
+                    6.60213228178228E7,
+                    6.575059999037522E7,
+                    6.571988106957889E7,
+                    6.5827606250601634E7,
+                    6.596511336520387E7,
+                    6.566650739169358E7,
+                    6.593388535223287E7
+                ],
+                [
+                    6.394088919008778E7,
+                    6.446889269891216E7,
+                    6.468286921069106E7,
+                    6.479276508914932E7,
+                    6.472123706399436E7,
+                    6.4907305962033466E7,
+                    6.461677484486533E7,
+                    6.400845476761235E7,
+                    6.461958337049617E7,
+                    6.482287614297642E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsHashBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8.282511037338026E8,
+            "scoreError" : 5730428.93447694,
+            "scoreConfidence" : [
+                8.225206747993256E8,
+                8.339815326682795E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.115503266935436E8,
+                "50.0" : 8.297998539459729E8,
+                "90.0" : 8.346206635127833E8,
+                "95.0" : 8.347934881385797E8,
+                "99.0" : 8.34796626429423E8,
+                "99.9" : 8.34796626429423E8,
+                "99.99" : 8.34796626429423E8,
+                "99.999" : 8.34796626429423E8,
+                "99.9999" : 8.34796626429423E8,
+                "100.0" : 8.34796626429423E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.295421223528157E8,
+                    8.29051394018482E8,
+                    8.194337936161363E8,
+                    8.311236929212097E8,
+                    8.326161122658287E8,
+                    8.336018896148039E8,
+                    8.300575855391301E8,
+                    8.33015379088289E8,
+                    8.115503266935436E8,
+                    8.34796626429423E8
+                ],
+                [
+                    8.237212655484898E8,
+                    8.27735670995371E8,
+                    8.32886776810625E8,
+                    8.333466620004717E8,
+                    8.265292764159503E8,
+                    8.335984639034373E8,
+                    8.239888577797652E8,
+                    8.289765369870445E8,
+                    8.347338606125587E8,
+                    8.147157810826718E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsHashBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0826335689161733E8,
+            "scoreError" : 5062144.978732086,
+            "scoreConfidence" : [
+                1.0320121191288525E8,
+                1.133255018703494E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.017303005067114E8,
+                "50.0" : 1.0817389215344892E8,
+                "90.0" : 1.1416194591502324E8,
+                "95.0" : 1.1420575315211415E8,
+                "99.0" : 1.1420765266792615E8,
+                "99.9" : 1.1420765266792615E8,
+                "99.99" : 1.1420765266792615E8,
+                "99.999" : 1.1420765266792615E8,
+                "99.9999" : 1.1420765266792615E8,
+                "100.0" : 1.1420765266792615E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1420765266792615E8,
+                    1.1405862117548917E8,
+                    1.1416966235168636E8,
+                    1.134468226876721E8,
+                    1.1401614381537782E8,
+                    1.1367252874287368E8,
+                    1.1409249798505513E8,
+                    1.1359847511385967E8,
+                    1.1403857498356444E8,
+                    1.140767484692134E8
+                ],
+                [
+                    1.0264458774350825E8,
+                    1.0244227845007047E8,
+                    1.0267582711673906E8,
+                    1.0281649260644925E8,
+                    1.0290096161922576E8,
+                    1.0235545547673087E8,
+                    1.017303005067114E8,
+                    1.0269261036109827E8,
+                    1.0279273566344139E8,
+                    1.0283816029565375E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsHashBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0995193606982677E8,
+            "scoreError" : 9829705.48482761,
+            "scoreConfidence" : [
+                1.0012223058499916E8,
+                1.1978164155465437E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.787530369800375E7,
+                "50.0" : 1.0995574181178737E8,
+                "90.0" : 1.212305481487061E8,
+                "95.0" : 1.2124628690565774E8,
+                "99.0" : 1.2124694578321157E8,
+                "99.9" : 1.2124694578321157E8,
+                "99.99" : 1.2124694578321157E8,
+                "99.999" : 1.2124694578321157E8,
+                "99.9999" : 1.2124694578321157E8,
+                "100.0" : 1.2124694578321157E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2085507194468114E8,
+                    1.2123376823213482E8,
+                    1.2096202247568616E8,
+                    1.2120156739784756E8,
+                    1.2112543031927188E8,
+                    1.2082362378294513E8,
+                    1.208346824992265E8,
+                    1.2058995120278032E8,
+                    1.2124694578321157E8,
+                    1.2092577011183193E8
+                ],
+                [
+                    9.932153242079441E7,
+                    9.928031080535719E7,
+                    9.90377768934706E7,
+                    9.899692425776124E7,
+                    9.928369333488603E7,
+                    9.854466766964722E7,
+                    9.860066981190124E7,
+                    9.93021789011404E7,
+                    9.899682985395613E7,
+                    9.787530369800375E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsMonoidBenchmark.kindlingsCombine",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.9387990731639808E8,
+            "scoreError" : 681868.7835077232,
+            "scoreConfidence" : [
+                1.9319803853289035E8,
+                1.9456177609990582E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.9239578191735572E8,
+                "50.0" : 1.939546840648166E8,
+                "90.0" : 1.9479473147702417E8,
+                "95.0" : 1.9481858737411273E8,
+                "99.0" : 1.948197332664678E8,
+                "99.9" : 1.948197332664678E8,
+                "99.99" : 1.948197332664678E8,
+                "99.999" : 1.948197332664678E8,
+                "99.9999" : 1.948197332664678E8,
+                "100.0" : 1.948197332664678E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9304492685197625E8,
+                    1.9298622160915625E8,
+                    1.9239578191735572E8,
+                    1.9293517629446465E8,
+                    1.9368863740993783E8,
+                    1.934711787899209E8,
+                    1.9307281905387294E8,
+                    1.934360935230401E8,
+                    1.930547186351143E8,
+                    1.9369706388665262E8
+                ],
+                [
+                    1.9459550605477962E8,
+                    1.9464303317732617E8,
+                    1.9421230424298054E8,
+                    1.9477597599594805E8,
+                    1.9434169663953483E8,
+                    1.948197332664678E8,
+                    1.9479681541936597E8,
+                    1.9470813668399027E8,
+                    1.943010227215049E8,
+                    1.9462130415457252E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsMonoidBenchmark.kindlingsEmpty",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.741460747572539E9,
+            "scoreError" : 1.6836640511814198E8,
+            "scoreConfidence" : [
+                3.5730943424543967E9,
+                3.909827152690681E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.921327714607404E9,
+                "50.0" : 3.7868798991014767E9,
+                "90.0" : 3.8096601002612567E9,
+                "95.0" : 3.812586189543413E9,
+                "99.0" : 3.8127338734617105E9,
+                "99.9" : 3.8127338734617105E9,
+                "99.99" : 3.8127338734617105E9,
+                "99.999" : 3.8127338734617105E9,
+                "99.9999" : 3.8127338734617105E9,
+                "100.0" : 3.8127338734617105E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.7935479854054513E9,
+                    2.921327714607404E9,
+                    3.7882766882720613E9,
+                    3.7720657439303646E9,
+                    3.770783564974663E9,
+                    3.7663620280956745E9,
+                    3.771816898979628E9,
+                    3.765748482539472E9,
+                    3.806070753719346E9,
+                    3.7908408594850307E9
+                ],
+                [
+                    3.7883347409328485E9,
+                    3.7975142882328796E9,
+                    3.7854831099308925E9,
+                    3.8127338734617105E9,
+                    3.751537611931824E9,
+                    3.796354371542689E9,
+                    3.808579246750643E9,
+                    3.8097801950957694E9,
+                    3.752510685417803E9,
+                    3.779546108144643E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsMonoidBenchmark.originalSemiAutoCombine",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1948698612840179E8,
+            "scoreError" : 4588900.027097647,
+            "scoreConfidence" : [
+                1.1489808610130414E8,
+                1.2407588615549943E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1404761609089495E8,
+                "50.0" : 1.1896671527431662E8,
+                "90.0" : 1.2501413554273418E8,
+                "95.0" : 1.2503579946961068E8,
+                "99.0" : 1.2503670772073962E8,
+                "99.9" : 1.2503670772073962E8,
+                "99.99" : 1.2503670772073962E8,
+                "99.999" : 1.2503670772073962E8,
+                "99.9999" : 1.2503670772073962E8,
+                "100.0" : 1.2503670772073962E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1459802051020868E8,
+                    1.1409381621120143E8,
+                    1.1469435958999173E8,
+                    1.1433966022526391E8,
+                    1.141981935092146E8,
+                    1.1404761609089495E8,
+                    1.1437677438202189E8,
+                    1.1438876533245963E8,
+                    1.145734948660099E8,
+                    1.142385887990015E8
+                ],
+                [
+                    1.250185426981608E8,
+                    1.2481223752957806E8,
+                    1.2496192627154022E8,
+                    1.2323907095864151E8,
+                    1.2372651302370912E8,
+                    1.2503670772073962E8,
+                    1.2497447114389457E8,
+                    1.2482916540902855E8,
+                    1.2482731201876351E8,
+                    1.2476448627771135E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsMonoidBenchmark.originalSemiAutoEmpty",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0343686288812845E9,
+            "scoreError" : 1.002427882119255E7,
+            "scoreConfidence" : [
+                1.024344350060092E9,
+                1.044392907702477E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0179503973941321E9,
+                "50.0" : 1.0302462223147833E9,
+                "90.0" : 1.0511263431958698E9,
+                "95.0" : 1.0523787503988509E9,
+                "99.0" : 1.0524309350410414E9,
+                "99.9" : 1.0524309350410414E9,
+                "99.99" : 1.0524309350410414E9,
+                "99.999" : 1.0524309350410414E9,
+                "99.9999" : 1.0524309350410414E9,
+                "100.0" : 1.0524309350410414E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0209904629858336E9,
+                    1.0301786995242819E9,
+                    1.0271123182178677E9,
+                    1.0303137451052848E9,
+                    1.0226944506354684E9,
+                    1.0248103221629039E9,
+                    1.0230730656153424E9,
+                    1.026758907955981E9,
+                    1.0260411443655268E9,
+                    1.0230300255370367E9
+                ],
+                [
+                    1.0417399353659856E9,
+                    1.0524309350410414E9,
+                    1.0422792511507276E9,
+                    1.0179503973941321E9,
+                    1.0465299567197452E9,
+                    1.0416596269036818E9,
+                    1.0484372270121036E9,
+                    1.0411766115518938E9,
+                    1.0513872421972313E9,
+                    1.0487782521836165E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsOrderBenchmark.kindlingsSimpleCCCompare",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.297095539703573E8,
+            "scoreError" : 3.8123835978412844E7,
+            "scoreConfidence" : [
+                3.9158571799194443E8,
+                4.6783338994877017E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.479953613749198E8,
+                "50.0" : 4.289644103014952E8,
+                "90.0" : 4.7441301508913517E8,
+                "95.0" : 4.744759034487671E8,
+                "99.0" : 4.7447726657317233E8,
+                "99.9" : 4.7447726657317233E8,
+                "99.99" : 4.7447726657317233E8,
+                "99.999" : 4.7447726657317233E8,
+                "99.9999" : 4.7447726657317233E8,
+                "100.0" : 4.7447726657317233E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.008824813141125E8,
+                    4.0323824401157206E8,
+                    3.5632886021921384E8,
+                    4.011459169747649E8,
+                    3.8989625338518465E8,
+                    4.0230458971785027E8,
+                    3.8679361712516534E8,
+                    4.0332083359093493E8,
+                    3.479953613749198E8,
+                    4.032538641562606E8
+                ],
+                [
+                    4.738360043699534E8,
+                    4.740170783077325E8,
+                    4.702487480195279E8,
+                    4.546079870120554E8,
+                    4.720639576671459E8,
+                    4.744500040850687E8,
+                    4.732754665330091E8,
+                    4.7447726657317233E8,
+                    4.7408011412573355E8,
+                    4.5797443084376895E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsOrderBenchmark.originalAutoSimpleCCCompare",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.476006291176884E8,
+            "scoreError" : 1.1557960049246863E7,
+            "scoreConfidence" : [
+                3.3604266906844157E8,
+                3.5915858916693527E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.179745120364377E8,
+                "50.0" : 3.503446970873817E8,
+                "90.0" : 3.6009145006534255E8,
+                "95.0" : 3.6020038047922313E8,
+                "99.0" : 3.602056444277346E8,
+                "99.9" : 3.602056444277346E8,
+                "99.99" : 3.602056444277346E8,
+                "99.999" : 3.602056444277346E8,
+                "99.9999" : 3.602056444277346E8,
+                "100.0" : 3.602056444277346E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.454833838954096E8,
+                    3.586105889462821E8,
+                    3.60011211535881E8,
+                    3.5859589628324234E8,
+                    3.4986110053337765E8,
+                    3.2941775623347145E8,
+                    3.5567843853906554E8,
+                    3.601003654575049E8,
+                    3.59956063584958E8,
+                    3.602056444277346E8
+                ],
+                [
+                    3.179745120364377E8,
+                    3.346974781236925E8,
+                    3.410595286988982E8,
+                    3.4770115751724726E8,
+                    3.5082829364138573E8,
+                    3.434358472025915E8,
+                    3.231881009142788E8,
+                    3.3681796593700695E8,
+                    3.5855119679493374E8,
+                    3.5983805205036896E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsOrderBenchmark.originalSemiAutoSimpleCCCompare",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.138627980541034E8,
+            "scoreError" : 1.3435080278812898E7,
+            "scoreConfidence" : [
+                3.004277177752905E8,
+                3.2729787833291626E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6841652175055304E8,
+                "50.0" : 3.1630757554907936E8,
+                "90.0" : 3.2677818700418884E8,
+                "95.0" : 3.26977967003721E8,
+                "99.0" : 3.2698762645036286E8,
+                "99.9" : 3.2698762645036286E8,
+                "99.99" : 3.2698762645036286E8,
+                "99.999" : 3.2698762645036286E8,
+                "99.9999" : 3.2698762645036286E8,
+                "100.0" : 3.2698762645036286E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.0929289560653085E8,
+                    2.6841652175055304E8,
+                    3.0788272018275815E8,
+                    3.099907728821891E8,
+                    3.0808750927174413E8,
+                    3.0927458450339663E8,
+                    3.0815687557982385E8,
+                    2.86754717285398E8,
+                    3.084477537783745E8,
+                    3.0304035807595736E8
+                ],
+                [
+                    3.262076090644234E8,
+                    3.226243782159696E8,
+                    3.235887802655812E8,
+                    3.2698762645036286E8,
+                    3.254211226022809E8,
+                    3.267944375175255E8,
+                    3.2662703652074736E8,
+                    3.2652301458581513E8,
+                    3.265053145584763E8,
+                    3.2663193238415885E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsSemigroupBenchmark.kindlingsCombine",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.9362933346339938E8,
+            "scoreError" : 868110.2128250031,
+            "scoreConfidence" : [
+                1.9276122325057438E8,
+                1.9449744367622438E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.9103711308540827E8,
+                "50.0" : 1.940087480128436E8,
+                "90.0" : 1.947437627087279E8,
+                "95.0" : 1.9495594859293568E8,
+                "99.0" : 1.949668321606717E8,
+                "99.9" : 1.949668321606717E8,
+                "99.99" : 1.949668321606717E8,
+                "99.999" : 1.949668321606717E8,
+                "99.9999" : 1.949668321606717E8,
+                "100.0" : 1.949668321606717E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9246865704199132E8,
+                    1.9427777948275614E8,
+                    1.9371252963430014E8,
+                    1.9373317456475854E8,
+                    1.941007626302278E8,
+                    1.940278753971981E8,
+                    1.9408944295696953E8,
+                    1.9398962062848914E8,
+                    1.9474916080595127E8,
+                    1.925381252346544E8
+                ],
+                [
+                    1.9190013365660515E8,
+                    1.930787505059998E8,
+                    1.940356705063902E8,
+                    1.9354141688128275E8,
+                    1.943943470138839E8,
+                    1.9103711308540827E8,
+                    1.9321236161128643E8,
+                    1.9403773563544524E8,
+                    1.949668321606717E8,
+                    1.9469517983371744E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsSemigroupBenchmark.originalSemiAutoCombine",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.4631534254162347E8,
+            "scoreError" : 1.5827984519599395E7,
+            "scoreConfidence" : [
+                1.3048735802202408E8,
+                1.6214332706122288E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.2647611400134863E8,
+                "50.0" : 1.4366653063526508E8,
+                "90.0" : 1.6619648305377752E8,
+                "95.0" : 1.6659882719788975E8,
+                "99.0" : 1.6661922991721976E8,
+                "99.9" : 1.6661922991721976E8,
+                "99.99" : 1.6661922991721976E8,
+                "99.999" : 1.6661922991721976E8,
+                "99.9999" : 1.6661922991721976E8,
+                "100.0" : 1.6661922991721976E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6602435955918723E8,
+                    1.6439498981262612E8,
+                    1.581098623427337E8,
+                    1.660642507622008E8,
+                    1.6661922991721976E8,
+                    1.6567065902360508E8,
+                    1.6621117553061938E8,
+                    1.6019993798760647E8,
+                    1.6354748659587723E8,
+                    1.6284795829111177E8
+                ],
+                [
+                    1.2647611400134863E8,
+                    1.291746404252121E8,
+                    1.2922319892779647E8,
+                    1.2861444301147462E8,
+                    1.2906431234720206E8,
+                    1.2844821055949154E8,
+                    1.2895577471877998E8,
+                    1.289498455665876E8,
+                    1.2867289403640756E8,
+                    1.2903750741538078E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1507782.2545003337,
+            "scoreError" : 18246.02221227727,
+            "scoreConfidence" : [
+                1489536.2322880565,
+                1526028.2767126109
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1476213.3402931283,
+                "50.0" : 1501527.9834351374,
+                "90.0" : 1538635.2742670388,
+                "95.0" : 1546019.6364240306,
+                "99.0" : 1546401.0069586844,
+                "99.9" : 1546401.0069586844,
+                "99.99" : 1546401.0069586844,
+                "99.999" : 1546401.0069586844,
+                "99.9999" : 1546401.0069586844,
+                "100.0" : 1546401.0069586844
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1533813.6879372038,
+                    1506516.8211428006,
+                    1506954.6944429418,
+                    1500719.456091195,
+                    1535424.1646117016,
+                    1546401.0069586844,
+                    1538773.5962656105,
+                    1537390.3762798922,
+                    1490638.8372871534,
+                    1529782.8962272154
+                ],
+                [
+                    1476213.3402931283,
+                    1494490.2134099677,
+                    1503444.2210614744,
+                    1492417.389764393,
+                    1486347.7090835753,
+                    1492401.5938509987,
+                    1489292.9778953958,
+                    1499439.6341705215,
+                    1502336.5107790797,
+                    1492845.9624537334
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1649815.9739552229,
+            "scoreError" : 15756.655636436019,
+            "scoreConfidence" : [
+                1634059.3183187868,
+                1665572.629591659
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1617734.4418370654,
+                "50.0" : 1646726.6007017542,
+                "90.0" : 1678488.0565492015,
+                "95.0" : 1687386.4755156504,
+                "99.0" : 1687843.5436718494,
+                "99.9" : 1687843.5436718494,
+                "99.99" : 1687843.5436718494,
+                "99.999" : 1687843.5436718494,
+                "99.9999" : 1687843.5436718494,
+                "100.0" : 1687843.5436718494
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1651234.7245561124,
+                    1687843.5436718494,
+                    1676560.940561185,
+                    1678702.18054787,
+                    1662973.9042055944,
+                    1659972.5995451156,
+                    1664306.755163178,
+                    1653454.5540949134,
+                    1635659.9620796007,
+                    1657984.8463772084
+                ],
+                [
+                    1635794.5839408475,
+                    1641291.8282928485,
+                    1646045.8575927068,
+                    1647407.3438108016,
+                    1630998.8262376632,
+                    1634597.966458408,
+                    1617734.4418370654,
+                    1627557.5194221628,
+                    1643975.781282072,
+                    1642221.3194272614
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 7.277029696567181E7,
+            "scoreError" : 6051114.30375235,
+            "scoreConfidence" : [
+                6.671918266191946E7,
+                7.882141126942416E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.550493920281466E7,
+                "50.0" : 7.24931151237247E7,
+                "90.0" : 8.039858081417908E7,
+                "95.0" : 8.052810305665685E7,
+                "99.0" : 8.053357404680423E7,
+                "99.9" : 8.053357404680423E7,
+                "99.99" : 8.053357404680423E7,
+                "99.999" : 8.053357404680423E7,
+                "99.9999" : 8.053357404680423E7,
+                "100.0" : 8.053357404680423E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7.875404923619625E7,
+                    8.042415424385653E7,
+                    7.930688963908023E7,
+                    8.005550002916908E7,
+                    7.923711667906976E7,
+                    7.921579453659745E7,
+                    8.016841994708201E7,
+                    7.835441749511044E7,
+                    7.936112136467603E7,
+                    8.053357404680423E7
+                ],
+                [
+                    6.601506921636956E7,
+                    6.590791621841746E7,
+                    6.550493920281466E7,
+                    6.593910883443163E7,
+                    6.629176198933047E7,
+                    6.575691418576768E7,
+                    6.598535028580544E7,
+                    6.565077719867292E7,
+                    6.6311252211845346E7,
+                    6.663181275233896E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.720299049096787E7,
+            "scoreError" : 102483.74612181913,
+            "scoreConfidence" : [
+                2.710050674484605E7,
+                2.730547423708969E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6963916095027447E7,
+                "50.0" : 2.719228315376369E7,
+                "90.0" : 2.7348707516672347E7,
+                "95.0" : 2.7364008931533366E7,
+                "99.0" : 2.7364793150572646E7,
+                "99.9" : 2.7364793150572646E7,
+                "99.99" : 2.7364793150572646E7,
+                "99.999" : 2.7364793150572646E7,
+                "99.9999" : 2.7364793150572646E7,
+                "100.0" : 2.7364793150572646E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.7168741025234524E7,
+                    2.7284416532738857E7,
+                    2.712430395174057E7,
+                    2.7332830266245555E7,
+                    2.72060549979809E7,
+                    2.7245292528750837E7,
+                    2.6963916095027447E7,
+                    2.698258859697879E7,
+                    2.717842992547027E7,
+                    2.7137241586833872E7
+                ],
+                [
+                    2.711443516005654E7,
+                    2.713536867710269E7,
+                    2.7345096238639876E7,
+                    2.732368252679622E7,
+                    2.717851130954648E7,
+                    2.730485564486105E7,
+                    2.708270843226153E7,
+                    2.7237434402731642E7,
+                    2.7349108769787066E7,
+                    2.7364793150572646E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1210549.5853076247,
+            "scoreError" : 10606.562812492715,
+            "scoreConfidence" : [
+                1199943.022495132,
+                1221156.1481201174
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1178906.2379384516,
+                "50.0" : 1213020.699323318,
+                "90.0" : 1224585.137147531,
+                "95.0" : 1225992.817566131,
+                "99.0" : 1226066.6139574545,
+                "99.9" : 1226066.6139574545,
+                "99.99" : 1226066.6139574545,
+                "99.999" : 1226066.6139574545,
+                "99.9999" : 1226066.6139574545,
+                "100.0" : 1226066.6139574545
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1200329.944372716,
+                    1223707.3691128914,
+                    1224590.6861309856,
+                    1216410.6574858676,
+                    1212484.3635825003,
+                    1214082.818619883,
+                    1178906.2379384516,
+                    1198087.0339972097,
+                    1205154.5464704535,
+                    1205414.2710915084
+                ],
+                [
+                    1209772.5751097717,
+                    1188418.3398664203,
+                    1226066.6139574545,
+                    1224535.1962964374,
+                    1214231.506661545,
+                    1214963.3168215991,
+                    1212919.4154545094,
+                    1206726.3262404418,
+                    1213121.9831921267,
+                    1221068.5037497156
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1396689.2795152972,
+            "scoreError" : 11696.018650647025,
+            "scoreConfidence" : [
+                1384993.2608646501,
+                1408385.2981659442
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1378166.4222365979,
+                "50.0" : 1392554.967779168,
+                "90.0" : 1419559.946670459,
+                "95.0" : 1422553.6077409163,
+                "99.0" : 1422683.6204243856,
+                "99.9" : 1422683.6204243856,
+                "99.99" : 1422683.6204243856,
+                "99.999" : 1422683.6204243856,
+                "99.9999" : 1422683.6204243856,
+                "100.0" : 1422683.6204243856
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1392733.7361440714,
+                    1385211.396258281,
+                    1380845.7773055425,
+                    1392376.1994142644,
+                    1420083.3667549978,
+                    1385908.0296697223,
+                    1384615.993403601,
+                    1400234.1872838887,
+                    1378166.4222365979,
+                    1422683.6204243856
+                ],
+                [
+                    1414849.1659096098,
+                    1414031.5533181415,
+                    1399736.1586139195,
+                    1396620.4676247116,
+                    1390725.5644826256,
+                    1410701.0666723906,
+                    1401578.790653191,
+                    1382478.063288081,
+                    1388531.277675187,
+                    1391674.7531727322
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.282663258507551E7,
+            "scoreError" : 385115.2807171923,
+            "scoreConfidence" : [
+                5.244151730435832E7,
+                5.321174786579271E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.158257651139187E7,
+                "50.0" : 5.278154493723782E7,
+                "90.0" : 5.339161065651723E7,
+                "95.0" : 5.344176844349884E7,
+                "99.0" : 5.344387470886169E7,
+                "99.9" : 5.344387470886169E7,
+                "99.99" : 5.344387470886169E7,
+                "99.999" : 5.344387470886169E7,
+                "99.9999" : 5.344387470886169E7,
+                "100.0" : 5.344387470886169E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.253014751300832E7,
+                    5.276045142955122E7,
+                    5.25232666033612E7,
+                    5.250002821340395E7,
+                    5.2660807096205235E7,
+                    5.158257651139187E7,
+                    5.2675195380606174E7,
+                    5.280263844492442E7,
+                    5.256705605326383E7,
+                    5.270668006617678E7
+                ],
+                [
+                    5.240146215298649E7,
+                    5.329423957253166E7,
+                    5.330036195072859E7,
+                    5.344387470886169E7,
+                    5.3183794841909334E7,
+                    5.315638700090477E7,
+                    5.340174940160485E7,
+                    5.325055585086258E7,
+                    5.294344539620651E7,
+                    5.284793351302069E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.985796330293648E7,
+            "scoreError" : 83614.00221989967,
+            "scoreConfidence" : [
+                1.977434930071658E7,
+                1.994157730515638E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.9552681842252973E7,
+                "50.0" : 1.9860367376767054E7,
+                "90.0" : 1.996084051181176E7,
+                "95.0" : 1.9974411278354347E7,
+                "99.0" : 1.997508386048437E7,
+                "99.9" : 1.997508386048437E7,
+                "99.99" : 1.997508386048437E7,
+                "99.999" : 1.997508386048437E7,
+                "99.9999" : 1.997508386048437E7,
+                "100.0" : 1.997508386048437E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9837496639156897E7,
+                    1.985721146103114E7,
+                    1.9817800168215398E7,
+                    1.981338138405541E7,
+                    1.9552681842252973E7,
+                    1.9742151402415127E7,
+                    1.9826068231579665E7,
+                    1.9819230647176106E7,
+                    1.9796682476475522E7,
+                    1.9882186152744226E7
+                ],
+                [
+                    1.9863523292502973E7,
+                    1.9875264695901982E7,
+                    1.9940815423062902E7,
+                    1.9922877000679296E7,
+                    1.9940979325959075E7,
+                    1.996163221788392E7,
+                    1.9938500903338484E7,
+                    1.995371515716231E7,
+                    1.997508386048437E7,
+                    1.9841983776651725E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 534624.68152313,
+            "scoreError" : 5637.690884941451,
+            "scoreConfidence" : [
+                528986.9906381886,
+                540262.3724080715
+            ],
+            "scorePercentiles" : {
+                "0.0" : 522368.37872949033,
+                "50.0" : 535312.0603909825,
+                "90.0" : 544143.0432599882,
+                "95.0" : 545630.7498399758,
+                "99.0" : 545706.853537408,
+                "99.9" : 545706.853537408,
+                "99.99" : 545706.853537408,
+                "99.999" : 545706.853537408,
+                "99.9999" : 545706.853537408,
+                "100.0" : 545706.853537408
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    535931.8300397143,
+                    543767.4163010052,
+                    545706.853537408,
+                    541780.0159896591,
+                    522368.37872949033,
+                    531063.2063111289,
+                    539031.8038954011,
+                    544184.7795887641,
+                    539845.5620248892,
+                    535793.0972896774
+                ],
+                [
+                    530255.6668609971,
+                    525893.7708566346,
+                    536757.3509313529,
+                    530940.9237529195,
+                    527412.522514881,
+                    528793.7913057467,
+                    530179.5107334555,
+                    530885.7065823833,
+                    537070.4197248081,
+                    534831.0234922876
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.1936058655256E7,
+            "scoreError" : 536678.1330296226,
+            "scoreConfidence" : [
+                5.139938052222638E7,
+                5.247273678828563E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.990091126462961E7,
+                "50.0" : 5.210157733899537E7,
+                "90.0" : 5.244099041286495E7,
+                "95.0" : 5.2724875255229615E7,
+                "99.0" : 5.2739767867140874E7,
+                "99.9" : 5.2739767867140874E7,
+                "99.99" : 5.2739767867140874E7,
+                "99.999" : 5.2739767867140874E7,
+                "99.9999" : 5.2739767867140874E7,
+                "100.0" : 5.2739767867140874E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.206951731483278E7,
+                    5.1576109946267575E7,
+                    5.1803504681427196E7,
+                    5.130534825657179E7,
+                    5.202691309728054E7,
+                    5.21876158489116E7,
+                    5.2075882696041994E7,
+                    5.212727198194875E7,
+                    5.214208796804146E7,
+                    5.14034245623943E7
+                ],
+                [
+                    5.2739767867140874E7,
+                    5.240306918848957E7,
+                    5.227021546898588E7,
+                    5.1338882478108324E7,
+                    4.990091126462961E7,
+                    5.188663878274712E7,
+                    5.234252000075241E7,
+                    5.2441915628915735E7,
+                    5.2432663468407914E7,
+                    5.224691260322466E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.9612758284555443E7,
+            "scoreError" : 78830.34697254557,
+            "scoreConfidence" : [
+                1.95339279375829E7,
+                1.9691588631527986E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.9419701353635807E7,
+                "50.0" : 1.9608995205992445E7,
+                "90.0" : 1.9721476314168636E7,
+                "95.0" : 1.9742258382834658E7,
+                "99.0" : 1.9743332683193423E7,
+                "99.9" : 1.9743332683193423E7,
+                "99.99" : 1.9743332683193423E7,
+                "99.999" : 1.9743332683193423E7,
+                "99.9999" : 1.9743332683193423E7,
+                "100.0" : 1.9743332683193423E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.9686072603557706E7,
+                    1.9717523625364464E7,
+                    1.96109869008733E7,
+                    1.9419701353635807E7,
+                    1.972184667601816E7,
+                    1.9696730973125048E7,
+                    1.971814305752293E7,
+                    1.9743332683193423E7,
+                    1.970939863610521E7,
+                    1.9506184544374384E7
+                ],
+                [
+                    1.9502978549844198E7,
+                    1.9556411842082955E7,
+                    1.9568419805941407E7,
+                    1.960700351111159E7,
+                    1.963161991528044E7,
+                    1.9650996948338855E7,
+                    1.957243661469848E7,
+                    1.952729901410496E7,
+                    1.954209925673022E7,
+                    1.9565979179205365E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsFastShowPrettyPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1316107.128995641,
+            "scoreError" : 7044.496322741021,
+            "scoreConfidence" : [
+                1309062.6326728999,
+                1323151.625318382
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1297834.9236963566,
+                "50.0" : 1318058.4001247648,
+                "90.0" : 1327012.0476496762,
+                "95.0" : 1329580.3715227668,
+                "99.0" : 1329702.7004224784,
+                "99.9" : 1329702.7004224784,
+                "99.99" : 1329702.7004224784,
+                "99.999" : 1329702.7004224784,
+                "99.9999" : 1329702.7004224784,
+                "100.0" : 1329702.7004224784
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1324815.374642528,
+                    1324124.763692659,
+                    1297834.9236963566,
+                    1310196.4909225076,
+                    1309771.885586993,
+                    1318217.7797622716,
+                    1318479.1610240706,
+                    1329702.7004224784,
+                    1311873.1431152106,
+                    1308004.351515402
+                ],
+                [
+                    1317903.1747363093,
+                    1318213.6255132202,
+                    1303988.0716193942,
+                    1317015.4195144272,
+                    1307327.3203043751,
+                    1327256.1224282482,
+                    1320127.7696109898,
+                    1322827.728371975,
+                    1316168.8160799216,
+                    1318293.9573534753
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsFastShowPrettySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.801140532541523E7,
+            "scoreError" : 118714.64290876182,
+            "scoreConfidence" : [
+                1.789269068250647E7,
+                1.8130119968323994E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.7788114355082512E7,
+                "50.0" : 1.799112818157716E7,
+                "90.0" : 1.8266758906121377E7,
+                "95.0" : 1.829880092271223E7,
+                "99.0" : 1.8300259540988408E7,
+                "99.9" : 1.8300259540988408E7,
+                "99.99" : 1.8300259540988408E7,
+                "99.999" : 1.8300259540988408E7,
+                "99.9999" : 1.8300259540988408E7,
+                "100.0" : 1.8300259540988408E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.793780796164686E7,
+                    1.7788114355082512E7,
+                    1.7994199405734282E7,
+                    1.7876287259711158E7,
+                    1.790854205100655E7,
+                    1.7982856623264905E7,
+                    1.7869781656914927E7,
+                    1.827108717546487E7,
+                    1.8002766147935677E7,
+                    1.8070176219873067E7
+                ],
+                [
+                    1.803283102549921E7,
+                    1.8300259540988408E7,
+                    1.7944759683513433E7,
+                    1.793613336596073E7,
+                    1.814273146053674E7,
+                    1.8018275710404426E7,
+                    1.8058365006792217E7,
+                    1.8227804482029945E7,
+                    1.7988056957420044E7,
+                    1.7877270418524653E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsShowPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1674050.3240799648,
+            "scoreError" : 14504.358924705664,
+            "scoreConfidence" : [
+                1659545.965155259,
+                1688554.6830046705
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1632459.3274745306,
+                "50.0" : 1672816.246306725,
+                "90.0" : 1693460.2168375787,
+                "95.0" : 1700439.7929192472,
+                "99.0" : 1700801.1650735713,
+                "99.9" : 1700801.1650735713,
+                "99.99" : 1700801.1650735713,
+                "99.999" : 1700801.1650735713,
+                "99.9999" : 1700801.1650735713,
+                "100.0" : 1700801.1650735713
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1693573.7219870905,
+                    1645423.385153261,
+                    1671328.8535942275,
+                    1665366.3214545678,
+                    1680448.6370031284,
+                    1692438.670491971,
+                    1686543.7312679153,
+                    1659244.8647231513,
+                    1632459.3274745306,
+                    1670090.7012967553
+                ],
+                [
+                    1672540.007308214,
+                    1680101.3548312804,
+                    1672714.6755236858,
+                    1663448.08925079,
+                    1672917.8170897644,
+                    1700801.1650735713,
+                    1689723.3235821829,
+                    1689716.9464694138,
+                    1679390.7006580797,
+                    1662734.1873657017
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsShowPrettyPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1760651.904764938,
+            "scoreError" : 17231.84054556097,
+            "scoreConfidence" : [
+                1743420.064219377,
+                1777883.7453104989
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1716865.6085699715,
+                "50.0" : 1758502.9083058897,
+                "90.0" : 1795709.3993362645,
+                "95.0" : 1800258.9315265357,
+                "99.0" : 1800438.3414634871,
+                "99.9" : 1800438.3414634871,
+                "99.99" : 1800438.3414634871,
+                "99.999" : 1800438.3414634871,
+                "99.9999" : 1800438.3414634871,
+                "100.0" : 1800438.3414634871
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1767217.9121053768,
+                    1741802.2137387998,
+                    1755503.771978974,
+                    1777072.4531184582,
+                    1761294.9039492283,
+                    1767581.3235635795,
+                    1796850.1427244556,
+                    1744710.4210216142,
+                    1716865.6085699715,
+                    1754131.4643871938
+                ],
+                [
+                    1769312.8534867654,
+                    1785442.7088425437,
+                    1751758.681457525,
+                    1755710.912662551,
+                    1766016.6894857835,
+                    1749152.315257316,
+                    1764272.0115581625,
+                    1800438.3414634871,
+                    1751262.3542998657,
+                    1736641.011627109
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsShowPrettySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.428255687405279E7,
+            "scoreError" : 257572.72949206614,
+            "scoreConfidence" : [
+                3.4024984144560724E7,
+                3.454012960354486E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.363443544437225E7,
+                "50.0" : 3.4287926008617066E7,
+                "90.0" : 3.473473016398024E7,
+                "95.0" : 3.4833935793691516E7,
+                "99.0" : 3.4838046499607995E7,
+                "99.9" : 3.4838046499607995E7,
+                "99.99" : 3.4838046499607995E7,
+                "99.999" : 3.4838046499607995E7,
+                "99.9999" : 3.4838046499607995E7,
+                "100.0" : 3.4838046499607995E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.375139282533249E7,
+                    3.3947581559478275E7,
+                    3.444995786706843E7,
+                    3.475583238127843E7,
+                    3.4514638089054964E7,
+                    3.4838046499607995E7,
+                    3.42183330810428E7,
+                    3.363443544437225E7,
+                    3.442086598939307E7,
+                    3.4319697924312524E7
+                ],
+                [
+                    3.4094832105338834E7,
+                    3.413315188338886E7,
+                    3.4544810208296515E7,
+                    3.425531924421392E7,
+                    3.4460704392206796E7,
+                    3.439784813271833E7,
+                    3.425615409292161E7,
+                    3.4353186365301505E7,
+                    3.420883867885905E7,
+                    3.409551071686926E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyBenchmark.kindlingsShowSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.6997654066611577E7,
+            "scoreError" : 243565.945349565,
+            "scoreConfidence" : [
+                2.675408812126201E7,
+                2.7241220011961143E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.625794164903132E7,
+                "50.0" : 2.708485498533851E7,
+                "90.0" : 2.7272618574270874E7,
+                "95.0" : 2.736716312715671E7,
+                "99.0" : 2.7372060451538302E7,
+                "99.9" : 2.7372060451538302E7,
+                "99.99" : 2.7372060451538302E7,
+                "99.999" : 2.7372060451538302E7,
+                "99.9999" : 2.7372060451538302E7,
+                "100.0" : 2.7372060451538302E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.625794164903132E7,
+                    2.693003510495764E7,
+                    2.686033625351988E7,
+                    2.7004499617682572E7,
+                    2.7043713782156754E7,
+                    2.69132082017833E7,
+                    2.6491579293957695E7,
+                    2.678939222690986E7,
+                    2.690549714399529E7,
+                    2.6668972307362802E7
+                ],
+                [
+                    2.7154933564887475E7,
+                    2.717261028802499E7,
+                    2.724656335951481E7,
+                    2.716974166273948E7,
+                    2.7125996188520268E7,
+                    2.7147554210991677E7,
+                    2.7259160067550927E7,
+                    2.716517199320006E7,
+                    2.7372060451538302E7,
+                    2.7274113963906422E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyKittensBenchmark.kittensShowPrettyPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 556991.5678496781,
+            "scoreError" : 3355.9605687600533,
+            "scoreConfidence" : [
+                553635.607280918,
+                560347.5284184382
+            ],
+            "scorePercentiles" : {
+                "0.0" : 549159.639161142,
+                "50.0" : 557166.4884946411,
+                "90.0" : 562044.5007938873,
+                "95.0" : 564495.2265134391,
+                "99.0" : 564619.2950910829,
+                "99.9" : 564619.2950910829,
+                "99.99" : 564619.2950910829,
+                "99.999" : 564619.2950910829,
+                "99.9999" : 564619.2950910829,
+                "100.0" : 564619.2950910829
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    557143.8432547622,
+                    560354.8356289528,
+                    558644.4034453754,
+                    556686.9226996565,
+                    554949.854698444,
+                    549159.639161142,
+                    549555.4212166601,
+                    553251.8396028107,
+                    557145.1660048813,
+                    557187.810984401
+                ],
+                [
+                    555485.464321471,
+                    556121.8566249597,
+                    564619.2950910829,
+                    562137.9235382066,
+                    560233.8966989735,
+                    557912.6578860563,
+                    552840.5781820171,
+                    557515.0345767712,
+                    561203.6960950134,
+                    557681.21728192
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsShowPrettyKittensBenchmark.kittensShowPrettySimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5362617.811203225,
+            "scoreError" : 183880.72097032386,
+            "scoreConfidence" : [
+                5178737.0902329,
+                5546498.532173549
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4992789.104151797,
+                "50.0" : 5345304.057528737,
+                "90.0" : 5646968.498152448,
+                "95.0" : 5683100.185342596,
+                "99.0" : 5684716.843977077,
+                "99.9" : 5684716.843977077,
+                "99.99" : 5684716.843977077,
+                "99.999" : 5684716.843977077,
+                "99.9999" : 5684716.843977077,
+                "100.0" : 5684716.843977077
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5536182.980820199,
+                    5554006.001697442,
+                    5511687.394356907,
+                    5598231.939937339,
+                    5684716.843977077,
+                    5146825.536889704,
+                    5505692.117392921,
+                    5652383.67128746,
+                    5577186.400027766,
+                    5321882.773420193
+                ],
+                [
+                    5114406.781529184,
+                    5277169.271491884,
+                    5405119.535361563,
+                    5331548.272083233,
+                    5157874.902638567,
+                    5004614.980598085,
+                    4992789.104151797,
+                    5359059.842974241,
+                    5313546.539754015,
+                    5207431.333674901
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsTraverseBenchmark.kindlingsSimpleCCBoxTraverse",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.641813566467962E8,
+            "scoreError" : 760145.7042980758,
+            "scoreConfidence" : [
+                1.6342121094249812E8,
+                1.6494150235109428E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.6221435118960276E8,
+                "50.0" : 1.6417616368621644E8,
+                "90.0" : 1.6542106733338004E8,
+                "95.0" : 1.6547304953720483E8,
+                "99.0" : 1.654753488466493E8,
+                "99.9" : 1.654753488466493E8,
+                "99.99" : 1.654753488466493E8,
+                "99.999" : 1.654753488466493E8,
+                "99.9999" : 1.654753488466493E8,
+                "100.0" : 1.654753488466493E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6389398542442277E8,
+                    1.6382627176017985E8,
+                    1.6347508777795E8,
+                    1.6394506745330107E8,
+                    1.6221435118960276E8,
+                    1.6267903861496562E8,
+                    1.6422725257756633E8,
+                    1.6314974762181175E8,
+                    1.639054354838288E8,
+                    1.6382275483263567E8
+                ],
+                [
+                    1.65346409413961E8,
+                    1.6485603634977955E8,
+                    1.646137414200737E8,
+                    1.6439177214003223E8,
+                    1.6443409382299513E8,
+                    1.6412507479486656E8,
+                    1.6490423217679626E8,
+                    1.649120685767455E8,
+                    1.6542936265775993E8,
+                    1.654753488466493E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CatsTraverseKittensBenchmark.kittensTraverse",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.8745595064217E7,
+            "scoreError" : 707824.4342534159,
+            "scoreConfidence" : [
+                1.8037770629963584E7,
+                1.945341949847042E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.7670338379165452E7,
+                "50.0" : 1.8786496803919785E7,
+                "90.0" : 1.959010879031107E7,
+                "95.0" : 1.9595077213639546E7,
+                "99.0" : 1.9595176063676275E7,
+                "99.9" : 1.9595176063676275E7,
+                "99.99" : 1.9595176063676275E7,
+                "99.999" : 1.9595176063676275E7,
+                "99.9999" : 1.9595176063676275E7,
+                "100.0" : 1.9595176063676275E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.809098157910305E7,
+                    1.8059443553101253E7,
+                    1.8065991066281598E7,
+                    1.8030953858486768E7,
+                    1.7699318064353876E7,
+                    1.806396391535434E7,
+                    1.8073599405475516E7,
+                    1.804235267103418E7,
+                    1.7798858068111874E7,
+                    1.7670338379165452E7
+                ],
+                [
+                    1.9595176063676275E7,
+                    1.9593199062941708E7,
+                    1.950274243306285E7,
+                    1.9502530262032863E7,
+                    1.951800836497798E7,
+                    1.948216727558725E7,
+                    1.9557364015756994E7,
+                    1.9520604880464423E7,
+                    1.9482012028736524E7,
+                    1.956229633663532E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 995823.9068052138,
+            "scoreError" : 14086.878087362547,
+            "scoreConfidence" : [
+                981737.0287178513,
+                1009910.7848925763
+            ],
+            "scorePercentiles" : {
+                "0.0" : 973672.7765326977,
+                "50.0" : 993299.9387749443,
+                "90.0" : 1015158.272100998,
+                "95.0" : 1018024.9599514848,
+                "99.0" : 1018174.4017347826,
+                "99.9" : 1018174.4017347826,
+                "99.99" : 1018174.4017347826,
+                "99.999" : 1018174.4017347826,
+                "99.9999" : 1018174.4017347826,
+                "100.0" : 1018174.4017347826
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1008012.5142939176,
+                    1011850.49933673,
+                    1010163.9707325076,
+                    997001.7939725663,
+                    1004225.1418233663,
+                    1014842.8295042051,
+                    1018174.4017347826,
+                    1015185.5660688264,
+                    1012280.6606634321,
+                    1014912.6263905425
+                ],
+                [
+                    989598.0835773223,
+                    988327.2466358091,
+                    981313.4236697452,
+                    974502.2242584685,
+                    973672.7765326977,
+                    976849.8686096556,
+                    982507.2929594044,
+                    980970.2937709346,
+                    980779.1242569031,
+                    981307.7973124614
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1253324.5465106675,
+            "scoreError" : 22919.137992565313,
+            "scoreConfidence" : [
+                1230405.4085181023,
+                1276243.6845032328
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1210497.8957689756,
+                "50.0" : 1256240.6926334095,
+                "90.0" : 1283114.9059867482,
+                "95.0" : 1283715.1871843,
+                "99.0" : 1283737.4704207228,
+                "99.9" : 1283737.4704207228,
+                "99.99" : 1283737.4704207228,
+                "99.999" : 1283737.4704207228,
+                "99.9999" : 1283737.4704207228,
+                "100.0" : 1283737.4704207228
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1225522.78201785,
+                    1244853.5733108493,
+                    1220169.734507667,
+                    1220664.0031761802,
+                    1237345.146133527,
+                    1226931.4147844869,
+                    1246980.6379041637,
+                    1210497.8957689756,
+                    1224736.085016695,
+                    1232645.5655624142
+                ],
+                [
+                    1283737.4704207228,
+                    1265500.7473626556,
+                    1275229.914745386,
+                    1275411.798063907,
+                    1275171.4264781883,
+                    1277747.2925146855,
+                    1279695.2456006801,
+                    1278835.5825149564,
+                    1283291.8056922657,
+                    1281522.8086370896
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0850855884497412E7,
+            "scoreError" : 232075.9961531653,
+            "scoreConfidence" : [
+                1.0618779888344247E7,
+                1.1082931880650576E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0544429375839265E7,
+                "50.0" : 1.0789946286667947E7,
+                "90.0" : 1.1139906713246776E7,
+                "95.0" : 1.1146441681032315E7,
+                "99.0" : 1.1146765584293382E7,
+                "99.9" : 1.1146765584293382E7,
+                "99.99" : 1.1146765584293382E7,
+                "99.999" : 1.1146765584293382E7,
+                "99.9999" : 1.1146765584293382E7,
+                "100.0" : 1.1146765584293382E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.113407741324507E7,
+                    1.1140287519072035E7,
+                    1.0931594143205311E7,
+                    1.111113401351131E7,
+                    1.1097575204500154E7,
+                    1.1136479460819438E7,
+                    1.1132320821085118E7,
+                    1.1126961970939998E7,
+                    1.1146765584293382E7,
+                    1.1109891884226268E7
+                ],
+                [
+                    1.0602672646593964E7,
+                    1.054784474498656E7,
+                    1.059513439510324E7,
+                    1.0544429375839265E7,
+                    1.057523695006454E7,
+                    1.0615301318599531E7,
+                    1.0648298430130584E7,
+                    1.0627142491491672E7,
+                    1.062992556927658E7,
+                    1.0564043752964247E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8757222.89739567,
+            "scoreError" : 432764.1396147016,
+            "scoreConfidence" : [
+                8324458.757780969,
+                9189987.037010372
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8199777.883722195,
+                "50.0" : 8566142.619854119,
+                "90.0" : 9514274.55789526,
+                "95.0" : 9602405.279375676,
+                "99.0" : 9606740.878810748,
+                "99.9" : 9606740.878810748,
+                "99.99" : 9606740.878810748,
+                "99.999" : 9606740.878810748,
+                "99.9999" : 9606740.878810748,
+                "100.0" : 9606740.878810748
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8423123.616279544,
+                    8199777.883722195,
+                    9462485.567968797,
+                    8263234.694452127,
+                    9606740.878810748,
+                    9446852.357490994,
+                    8529581.00905126,
+                    9520028.890109312,
+                    8381059.227915641,
+                    9436671.251408042
+                ],
+                [
+                    8376411.468763542,
+                    8648678.059152583,
+                    8338215.541327662,
+                    8545830.276018595,
+                    8586454.96368964,
+                    9356845.5675439,
+                    8491414.568881102,
+                    8628728.575174294,
+                    8652335.087633012,
+                    8249988.46252041
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsNoBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 835560.5821032734,
+            "scoreError" : 7404.849626667013,
+            "scoreConfidence" : [
+                828155.7324766064,
+                842965.4317299403
+            ],
+            "scorePercentiles" : {
+                "0.0" : 815931.0080625608,
+                "50.0" : 836662.3350860139,
+                "90.0" : 845338.7352535581,
+                "95.0" : 846701.742158934,
+                "99.0" : 846767.54932711,
+                "99.9" : 846767.54932711,
+                "99.99" : 846767.54932711,
+                "99.999" : 846767.54932711,
+                "99.9999" : 846767.54932711,
+                "100.0" : 846767.54932711
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    815931.0080625608,
+                    830345.8548403096,
+                    842499.97019303,
+                    842132.5140646476,
+                    836387.4639884069,
+                    842948.3881062843,
+                    831284.9173145286,
+                    829867.5020886508,
+                    838957.2143323687,
+                    834787.1971182788
+                ],
+                [
+                    836937.2061836208,
+                    827454.3682339352,
+                    827884.9257773244,
+                    846767.54932711,
+                    845451.4059635882,
+                    841061.7295824157,
+                    844324.6988632879,
+                    843965.0387619815,
+                    820941.8879178229,
+                    831280.801345313
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsNoBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1057516.433953266,
+            "scoreError" : 18672.445273230645,
+            "scoreConfidence" : [
+                1038843.9886800352,
+                1076188.8792264964
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1022239.3845332332,
+                "50.0" : 1054607.7925619627,
+                "90.0" : 1084449.8178474465,
+                "95.0" : 1088980.089014384,
+                "99.0" : 1089215.9470848553,
+                "99.9" : 1089215.9470848553,
+                "99.99" : 1089215.9470848553,
+                "99.999" : 1089215.9470848553,
+                "99.9999" : 1089215.9470848553,
+                "100.0" : 1089215.9470848553
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1057623.9471515235,
+                    1068445.2587056654,
+                    1079578.2159020568,
+                    1084009.1073956161,
+                    1066869.845988475,
+                    1078236.8500097112,
+                    1084498.7856754276,
+                    1089215.9470848553,
+                    1072313.2025859207,
+                    1082494.709548173
+                ],
+                [
+                    1038342.8175516945,
+                    1040890.2077460397,
+                    1050273.3693719255,
+                    1033904.8904189712,
+                    1029184.4509087303,
+                    1051591.6379724017,
+                    1045138.9108623853,
+                    1045252.696292148,
+                    1022239.3845332332,
+                    1030224.4433603568
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsNoBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9783327.852967247,
+            "scoreError" : 118117.69492507582,
+            "scoreConfidence" : [
+                9665210.158042172,
+                9901445.547892323
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9556337.545579595,
+                "50.0" : 9763603.53147044,
+                "90.0" : 1.0024938877008269E7,
+                "95.0" : 1.0044708921288649E7,
+                "99.0" : 1.00455647411612E7,
+                "99.9" : 1.00455647411612E7,
+                "99.99" : 1.00455647411612E7,
+                "99.999" : 1.00455647411612E7,
+                "99.9999" : 1.00455647411612E7,
+                "100.0" : 1.00455647411612E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9786691.123728603,
+                    9685428.029834725,
+                    9876741.099821076,
+                    9709520.1840816,
+                    9877108.101124782,
+                    9652424.456724463,
+                    9705992.274715226,
+                    9747891.327065822,
+                    9643518.25062421,
+                    9790578.369349435
+                ],
+                [
+                    9779315.735875057,
+                    9633024.466857925,
+                    9727584.448134948,
+                    9993353.676690934,
+                    1.0028448343710195E7,
+                    9902279.160461089,
+                    1.00455647411612E7,
+                    9556337.545579595,
+                    9832326.760737536,
+                    9692428.963066548
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.kindlingsNoBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 7101139.878733863,
+            "scoreError" : 68384.00647855748,
+            "scoreConfidence" : [
+                7032755.872255306,
+                7169523.8852124205
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6964571.4478116045,
+                "50.0" : 7098879.76868538,
+                "90.0" : 7216765.2261283705,
+                "95.0" : 7231543.222324779,
+                "99.0" : 7232282.766618897,
+                "99.9" : 7232282.766618897,
+                "99.99" : 7232282.766618897,
+                "99.999" : 7232282.766618897,
+                "99.9999" : 7232282.766618897,
+                "100.0" : 7232282.766618897
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7179626.503033938,
+                    7072630.546808622,
+                    6967455.843184117,
+                    7002952.147142319,
+                    7063579.102439422,
+                    7089631.597114222,
+                    7111623.076458516,
+                    7095927.111162808,
+                    7184596.771878134,
+                    7129588.1464376515
+                ],
+                [
+                    7101832.426207952,
+                    7049316.192817438,
+                    6964571.4478116045,
+                    7232282.766618897,
+                    7210225.334654813,
+                    7217491.880736544,
+                    7029161.605091178,
+                    7056965.775884221,
+                    7110177.369017927,
+                    7153161.930176938
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 825217.2409595066,
+            "scoreError" : 4634.372439949098,
+            "scoreConfidence" : [
+                820582.8685195575,
+                829851.6133994557
+            ],
+            "scorePercentiles" : {
+                "0.0" : 814254.156997729,
+                "50.0" : 826605.3772491503,
+                "90.0" : 831551.2179162056,
+                "95.0" : 833055.9481565297,
+                "99.0" : 833126.8283282152,
+                "99.9" : 833126.8283282152,
+                "99.99" : 833126.8283282152,
+                "99.999" : 833126.8283282152,
+                "99.9999" : 833126.8283282152,
+                "100.0" : 833126.8283282152
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    833126.8283282152,
+                    828282.8338431694,
+                    818227.7401980796,
+                    824324.7241647724,
+                    831709.2248945065,
+                    830064.7102288685,
+                    830129.1551114983,
+                    829019.8889371809,
+                    828077.2972889944,
+                    824611.3637055417
+                ],
+                [
+                    828877.8174297871,
+                    827500.6818021076,
+                    823625.1850222826,
+                    826405.2543444899,
+                    820456.9130537866,
+                    817854.8849360886,
+                    814254.156997729,
+                    816019.7795722696,
+                    826805.5001538108,
+                    824970.879176954
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1001047.7628076377,
+            "scoreError" : 13336.5355576459,
+            "scoreConfidence" : [
+                987711.2272499917,
+                1014384.2983652836
+            ],
+            "scorePercentiles" : {
+                "0.0" : 975392.5416691544,
+                "50.0" : 998920.0381589427,
+                "90.0" : 1021845.3361391718,
+                "95.0" : 1022885.8975458978,
+                "99.0" : 1022917.6579301385,
+                "99.9" : 1022917.6579301385,
+                "99.99" : 1022917.6579301385,
+                "99.999" : 1022917.6579301385,
+                "99.9999" : 1022917.6579301385,
+                "100.0" : 1022917.6579301385
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    999983.6014060606,
+                    975392.5416691544,
+                    979247.8848468349,
+                    986861.4779126426,
+                    986585.5299341477,
+                    986810.4535162281,
+                    995610.6658627588,
+                    991078.9724846715,
+                    990925.7974944181,
+                    984579.3800472209
+                ],
+                [
+                    1009952.7646451413,
+                    1016497.267068107,
+                    1022917.6579301385,
+                    1013024.8857169801,
+                    1015711.4109022088,
+                    997856.4749118248,
+                    1015043.7661899973,
+                    1022282.4502453227,
+                    1012680.9641850761,
+                    1017911.3091838141
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9186970.92207435,
+            "scoreError" : 267112.69218153995,
+            "scoreConfidence" : [
+                8919858.229892809,
+                9454083.61425589
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8745465.788860712,
+                "50.0" : 9174097.334403219,
+                "90.0" : 9674311.116549715,
+                "95.0" : 9697364.90675002,
+                "99.0" : 9698482.966938576,
+                "99.9" : 9698482.966938576,
+                "99.99" : 9698482.966938576,
+                "99.999" : 9698482.966938576,
+                "99.9999" : 9698482.966938576,
+                "100.0" : 9698482.966938576
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8745465.788860712,
+                    9601779.406083979,
+                    9607141.642884132,
+                    9658015.296990044,
+                    8915506.96262799,
+                    9698482.966938576,
+                    9676121.763167456,
+                    8842608.889708946,
+                    8962150.696095835,
+                    8818508.004329963
+                ],
+                [
+                    9213682.769900052,
+                    9169337.611661015,
+                    9020103.297301138,
+                    9178857.057145422,
+                    9131807.337934513,
+                    8920899.233034333,
+                    9190133.79516495,
+                    9211092.140465591,
+                    8965797.669237558,
+                    9211926.111954786
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6642693.0087803295,
+            "scoreError" : 163705.4912561803,
+            "scoreConfidence" : [
+                6478987.517524149,
+                6806398.50003651
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6348053.870172258,
+                "50.0" : 6622888.728780653,
+                "90.0" : 6866179.614151385,
+                "95.0" : 6874063.393578881,
+                "99.0" : 6874391.625605095,
+                "99.9" : 6874391.625605095,
+                "99.99" : 6874391.625605095,
+                "99.999" : 6874391.625605095,
+                "99.9999" : 6874391.625605095,
+                "100.0" : 6874391.625605095
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6797737.107354862,
+                    6764376.310076037,
+                    6851353.27578646,
+                    6739061.043676114,
+                    6850646.719206616,
+                    6867826.9850808205,
+                    6874391.625605095,
+                    6848212.038457459,
+                    6823622.098110943,
+                    6786614.182287739
+                ],
+                [
+                    6492807.392284004,
+                    6506716.413885193,
+                    6493342.517717603,
+                    6395173.484101424,
+                    6348053.870172258,
+                    6487133.394140804,
+                    6490138.362009528,
+                    6495532.659022039,
+                    6487624.283981476,
+                    6453496.412650108
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalNoBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 703496.1832549495,
+            "scoreError" : 6644.9059988784,
+            "scoreConfidence" : [
+                696851.2772560711,
+                710141.0892538279
+            ],
+            "scorePercentiles" : {
+                "0.0" : 692377.5862847962,
+                "50.0" : 702489.9094194565,
+                "90.0" : 713206.6633517831,
+                "95.0" : 713863.6663231137,
+                "99.0" : 713896.9527708815,
+                "99.9" : 713896.9527708815,
+                "99.99" : 713896.9527708815,
+                "99.999" : 713896.9527708815,
+                "99.9999" : 713896.9527708815,
+                "100.0" : 713896.9527708815
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    701894.8627753754,
+                    713896.9527708815,
+                    712985.6191780856,
+                    699057.2512745016,
+                    706765.6081177857,
+                    702465.0040318242,
+                    708602.8812362235,
+                    712713.0357924511,
+                    701497.4928784587,
+                    700135.5779743253
+                ],
+                [
+                    705334.191456309,
+                    693420.4555342506,
+                    713231.2238155272,
+                    692717.5837012073,
+                    692377.5862847962,
+                    702514.8148070887,
+                    694972.9626969973,
+                    711110.3372798726,
+                    711579.747333955,
+                    692650.4761590743
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalNoBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 874066.7148886664,
+            "scoreError" : 15070.840770538858,
+            "scoreConfidence" : [
+                858995.8741181275,
+                889137.5556592053
+            ],
+            "scorePercentiles" : {
+                "0.0" : 834995.4108341498,
+                "50.0" : 877245.0876477608,
+                "90.0" : 892386.1574435802,
+                "95.0" : 894435.8448626399,
+                "99.0" : 894542.2642540412,
+                "99.9" : 894542.2642540412,
+                "99.99" : 894542.2642540412,
+                "99.999" : 894542.2642540412,
+                "99.9999" : 894542.2642540412,
+                "100.0" : 894542.2642540412
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    888429.2466883637,
+                    886597.7059431751,
+                    894542.2642540412,
+                    889600.3355039796,
+                    892413.8764260155,
+                    886523.7396116867,
+                    887885.7113101333,
+                    886474.0859686517,
+                    890315.0342223322,
+                    892136.6866016621
+                ],
+                [
+                    862021.2793788307,
+                    865225.6580239045,
+                    834995.4108341498,
+                    859128.2048225523,
+                    868016.0893268698,
+                    864434.5934225866,
+                    864658.0894230672,
+                    863964.5481979426,
+                    850578.1671702354,
+                    853393.5706431445
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalNoBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8505563.722949082,
+            "scoreError" : 35896.72545774834,
+            "scoreConfidence" : [
+                8469666.997491334,
+                8541460.44840683
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8423671.364440687,
+                "50.0" : 8513934.17784562,
+                "90.0" : 8548388.703785243,
+                "95.0" : 8559866.22210399,
+                "99.0" : 8560443.804956673,
+                "99.9" : 8560443.804956673,
+                "99.99" : 8560443.804956673,
+                "99.999" : 8560443.804956673,
+                "99.9999" : 8560443.804956673,
+                "100.0" : 8560443.804956673
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8548892.14790303,
+                    8503929.968336748,
+                    8538145.556755729,
+                    8473218.826124582,
+                    8503937.122002171,
+                    8526516.72896877,
+                    8537330.906780735,
+                    8423671.364440687,
+                    8543520.60791179,
+                    8517664.015904572
+                ],
+                [
+                    8521911.053875519,
+                    8471485.108888134,
+                    8500506.444757741,
+                    8510204.33978667,
+                    8543857.706725148,
+                    8438868.099117972,
+                    8560443.804956673,
+                    8477400.05529417,
+                    8427065.982924627,
+                    8542704.617526185
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterDecodeBenchmark.originalNoBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5865833.234295588,
+            "scoreError" : 164290.76333680446,
+            "scoreConfidence" : [
+                5701542.470958783,
+                6030123.997632393
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5636639.216666962,
+                "50.0" : 5871087.144160736,
+                "90.0" : 6108283.042048534,
+                "95.0" : 6112854.495427122,
+                "99.0" : 6112943.529103977,
+                "99.9" : 6112943.529103977,
+                "99.99" : 6112943.529103977,
+                "99.999" : 6112943.529103977,
+                "99.9999" : 6112943.529103977,
+                "100.0" : 6112943.529103977
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5637970.892224281,
+                    5724466.913306133,
+                    5766213.991358924,
+                    5737110.79166786,
+                    5702532.173345077,
+                    5651225.301348183,
+                    5665750.353787449,
+                    5636639.216666962,
+                    5698091.477948465,
+                    5654631.958458327
+                ],
+                [
+                    5975960.29696255,
+                    5981724.783918129,
+                    6112943.529103977,
+                    6111162.855566892,
+                    6063507.71633345,
+                    6082364.720383313,
+                    6053921.070892756,
+                    5978331.1041575605,
+                    6013866.692145749,
+                    6068248.846335715
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1411786.6250168455,
+            "scoreError" : 9296.941205901332,
+            "scoreConfidence" : [
+                1402489.6838109442,
+                1421083.5662227469
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1392911.034544125,
+                "50.0" : 1416811.4440404368,
+                "90.0" : 1423204.246947294,
+                "95.0" : 1425034.4531488505,
+                "99.0" : 1425130.6138469188,
+                "99.9" : 1425130.6138469188,
+                "99.99" : 1425130.6138469188,
+                "99.999" : 1425130.6138469188,
+                "99.9999" : 1425130.6138469188,
+                "100.0" : 1425130.6138469188
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1418024.7008029302,
+                    1412555.7528024707,
+                    1416989.5986961864,
+                    1423207.3998855518,
+                    1408363.4568510538,
+                    1417012.6426294788,
+                    1398297.2289081432,
+                    1418768.270046168,
+                    1404113.1384470516,
+                    1420052.1431085062
+                ],
+                [
+                    1393493.3150471302,
+                    1392911.034544125,
+                    1417994.0264367466,
+                    1415321.8902678455,
+                    1423175.8705029753,
+                    1425130.6138469188,
+                    1397001.7861636316,
+                    1396758.3293233064,
+                    1416633.289384687,
+                    1419928.0126420066
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1670280.6143191478,
+            "scoreError" : 25929.10847050847,
+            "scoreConfidence" : [
+                1644351.5058486394,
+                1696209.7227896561
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1620899.2004935099,
+                "50.0" : 1665023.5857837994,
+                "90.0" : 1711212.0848489422,
+                "95.0" : 1717201.3376256702,
+                "99.0" : 1717464.9538164695,
+                "99.9" : 1717464.9538164695,
+                "99.99" : 1717464.9538164695,
+                "99.999" : 1717464.9538164695,
+                "99.9999" : 1717464.9538164695,
+                "100.0" : 1717464.9538164695
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1661860.2656673768,
+                    1652648.0751245522,
+                    1647920.8184319213,
+                    1651013.0183686449,
+                    1638964.306834329,
+                    1629827.3998021365,
+                    1662389.444343526,
+                    1620899.2004935099,
+                    1657879.0749595158,
+                    1628413.385057148
+                ],
+                [
+                    1701287.3894758185,
+                    1702387.1784850734,
+                    1673552.9189925604,
+                    1696225.5229701074,
+                    1700044.0646337948,
+                    1681210.7306436184,
+                    1667657.727224073,
+                    1701774.1810582965,
+                    1717464.9538164695,
+                    1712192.6300004832
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5627920290356642E7,
+            "scoreError" : 153090.0445391413,
+            "scoreConfidence" : [
+                1.5474830245817501E7,
+                1.5781010334895782E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.5356529521776624E7,
+                "50.0" : 1.5592066257879453E7,
+                "90.0" : 1.589996551382125E7,
+                "95.0" : 1.5908441028322684E7,
+                "99.0" : 1.590868949692977E7,
+                "99.9" : 1.590868949692977E7,
+                "99.99" : 1.590868949692977E7,
+                "99.999" : 1.590868949692977E7,
+                "99.9999" : 1.590868949692977E7,
+                "100.0" : 1.590868949692977E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.5412571134367982E7,
+                    1.5610703314540159E7,
+                    1.5551833177512819E7,
+                    1.5587221683870709E7,
+                    1.5480411772007419E7,
+                    1.5356529521776624E7,
+                    1.5377644570521547E7,
+                    1.5529721080545196E7,
+                    1.5488400160474664E7,
+                    1.5523720586803053E7
+                ],
+                [
+                    1.563317837296337E7,
+                    1.5739636241525242E7,
+                    1.5860556463618534E7,
+                    1.590372012478803E7,
+                    1.5866174015120238E7,
+                    1.5576087602954878E7,
+                    1.5700486742318511E7,
+                    1.5854208912605962E7,
+                    1.590868949692977E7,
+                    1.5596910831888197E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5541844152174046E7,
+            "scoreError" : 121051.90462537906,
+            "scoreConfidence" : [
+                1.5420792247548668E7,
+                1.5662896056799425E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.5240167418534322E7,
+                "50.0" : 1.5538935304815859E7,
+                "90.0" : 1.5711114700694144E7,
+                "95.0" : 1.5821413842367318E7,
+                "99.0" : 1.5826894258301498E7,
+                "99.9" : 1.5826894258301498E7,
+                "99.99" : 1.5826894258301498E7,
+                "99.999" : 1.5826894258301498E7,
+                "99.9999" : 1.5826894258301498E7,
+                "100.0" : 1.5826894258301498E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.5602002665672876E7,
+                    1.5619422289831117E7,
+                    1.5240167418534322E7,
+                    1.5515614199939428E7,
+                    1.533840683826687E7,
+                    1.5390946917634875E7,
+                    1.5355018703291804E7,
+                    1.547063036742701E7,
+                    1.5516821542268049E7,
+                    1.5561049067363668E7
+                ],
+                [
+                    1.5655573550380437E7,
+                    1.565142716081963E7,
+                    1.560745346662691E7,
+                    1.5612521785705755E7,
+                    1.550429701066605E7,
+                    1.5486835675932422E7,
+                    1.5648568186264131E7,
+                    1.5717285939617889E7,
+                    1.5515945998936167E7,
+                    1.5826894258301498E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsNoBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 938907.6087635176,
+            "scoreError" : 4471.5113648909655,
+            "scoreConfidence" : [
+                934436.0973986266,
+                943379.1201284085
+            ],
+            "scorePercentiles" : {
+                "0.0" : 925551.6372666998,
+                "50.0" : 938838.068169361,
+                "90.0" : 945026.8146226326,
+                "95.0" : 947456.490351747,
+                "99.0" : 947575.6677564518,
+                "99.9" : 947575.6677564518,
+                "99.99" : 947575.6677564518,
+                "99.999" : 947575.6677564518,
+                "99.9999" : 947575.6677564518,
+                "100.0" : 947575.6677564518
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    947575.6677564518,
+                    945192.1196623567,
+                    942431.5110790883,
+                    935282.7393814396,
+                    942639.2038588789,
+                    934733.012186859,
+                    939198.6236790558,
+                    937293.5643626235,
+                    940203.9744968733,
+                    943530.3524088397
+                ],
+                [
+                    938342.3138896246,
+                    937244.2136716185,
+                    937485.3781895136,
+                    925551.6372666998,
+                    938477.5126596662,
+                    943539.0692651159,
+                    941844.1043828265,
+                    941334.9969673167,
+                    929960.9584686053,
+                    936291.2216368971
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsNoBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1078706.6093329361,
+            "scoreError" : 15161.696868949388,
+            "scoreConfidence" : [
+                1063544.9124639868,
+                1093868.3062018855
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1053025.9581077895,
+                "50.0" : 1075701.7846349373,
+                "90.0" : 1099823.3014518258,
+                "95.0" : 1101380.4959705104,
+                "99.0" : 1101460.6860613693,
+                "99.9" : 1101460.6860613693,
+                "99.99" : 1101460.6860613693,
+                "99.999" : 1101460.6860613693,
+                "99.9999" : 1101460.6860613693,
+                "100.0" : 1101460.6860613693
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1061730.3265858474,
+                    1066046.4349567925,
+                    1068559.859967948,
+                    1057678.3879449707,
+                    1053025.9581077895,
+                    1054080.098027037,
+                    1073408.4008948398,
+                    1067793.0363319605,
+                    1068514.95892033,
+                    1059452.1997482546
+                ],
+                [
+                    1099521.0563205292,
+                    1101460.6860613693,
+                    1097236.748755804,
+                    1077995.1683750348,
+                    1098406.8367247293,
+                    1099856.884244192,
+                    1097104.640866655,
+                    1089900.4060325278,
+                    1092871.407092749,
+                    1089488.690699359
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsNoBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 8107954.959247798,
+            "scoreError" : 70384.98204635263,
+            "scoreConfidence" : [
+                8037569.977201445,
+                8178339.94129415
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7911288.657880082,
+                "50.0" : 8129805.5075462945,
+                "90.0" : 8180059.242290809,
+                "95.0" : 8215837.530288861,
+                "99.0" : 8217720.044774164,
+                "99.9" : 8217720.044774164,
+                "99.99" : 8217720.044774164,
+                "99.999" : 8217720.044774164,
+                "99.9999" : 8217720.044774164,
+                "100.0" : 8217720.044774164
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8180069.755068093,
+                    8179964.6272952575,
+                    8163208.206695017,
+                    8166528.064081687,
+                    8162411.958226553,
+                    8217720.044774164,
+                    8174164.803680852,
+                    8167256.87142338,
+                    8178792.558931559,
+                    8165103.185774779
+                ],
+                [
+                    8050080.854086708,
+                    8097199.056866035,
+                    7911288.657880082,
+                    8047457.574309714,
+                    8093901.010836303,
+                    8086471.848741153,
+                    7966090.543423352,
+                    8037797.041461001,
+                    8059796.734184385,
+                    8053795.787215891
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.kindlingsNoBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 7243747.430990523,
+            "scoreError" : 48146.5733234055,
+            "scoreConfidence" : [
+                7195600.857667117,
+                7291894.004313928
+            ],
+            "scorePercentiles" : {
+                "0.0" : 7153555.885029163,
+                "50.0" : 7246500.03316408,
+                "90.0" : 7364882.633576022,
+                "95.0" : 7379394.532820973,
+                "99.0" : 7379572.432184813,
+                "99.9" : 7379572.432184813,
+                "99.99" : 7379572.432184813,
+                "99.999" : 7379572.432184813,
+                "99.9999" : 7379572.432184813,
+                "100.0" : 7379572.432184813
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7235195.866465919,
+                    7153555.885029163,
+                    7244336.127206225,
+                    7225503.0553327985,
+                    7218748.878415433,
+                    7224896.845067568,
+                    7210302.440422164,
+                    7197205.746644013,
+                    7250199.937222268,
+                    7252010.725856955
+                ],
+                [
+                    7262560.960689686,
+                    7189271.839750194,
+                    7171437.9501259085,
+                    7253702.6862393115,
+                    7259467.117045371,
+                    7248663.939121935,
+                    7264696.331588029,
+                    7379572.432184813,
+                    7376014.444908022,
+                    7257605.410494679
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1181194.058633775,
+            "scoreError" : 7904.450363399693,
+            "scoreConfidence" : [
+                1173289.6082703753,
+                1189098.5089971747
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1163099.6951240366,
+                "50.0" : 1182185.5106528723,
+                "90.0" : 1194468.9747557456,
+                "95.0" : 1197692.8426367447,
+                "99.0" : 1197848.7855702257,
+                "99.9" : 1197848.7855702257,
+                "99.99" : 1197848.7855702257,
+                "99.999" : 1197848.7855702257,
+                "99.9999" : 1197848.7855702257,
+                "100.0" : 1197848.7855702257
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1184490.4185217277,
+                    1177228.074808766,
+                    1163099.6951240366,
+                    1178291.397773146,
+                    1183507.3093549835,
+                    1182888.109737886,
+                    1171706.7398892757,
+                    1181440.4747157616,
+                    1181482.9115678587,
+                    1173163.3201383015
+                ],
+                [
+                    1197848.7855702257,
+                    1164282.8307629554,
+                    1182901.6127111122,
+                    1188018.346966355,
+                    1189188.7162759807,
+                    1179462.2107978151,
+                    1173667.7515584873,
+                    1192120.4054519814,
+                    1194729.9269006082,
+                    1184362.1340482354
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1456970.3575108587,
+            "scoreError" : 20524.77173026858,
+            "scoreConfidence" : [
+                1436445.58578059,
+                1477495.1292411273
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1424275.419447847,
+                "50.0" : 1452607.0807513928,
+                "90.0" : 1487561.1988351233,
+                "95.0" : 1488985.0547540276,
+                "99.0" : 1489049.6707338784,
+                "99.9" : 1489049.6707338784,
+                "99.99" : 1489049.6707338784,
+                "99.999" : 1489049.6707338784,
+                "99.9999" : 1489049.6707338784,
+                "100.0" : 1489049.6707338784
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1429217.3060470999,
+                    1442371.5311645782,
+                    1427881.3930994472,
+                    1449462.5667939617,
+                    1431785.1450981612,
+                    1429047.7871569425,
+                    1448855.3964826823,
+                    1435367.7546912676,
+                    1444594.9258701096,
+                    1424275.419447847
+                ],
+                [
+                    1455751.5947088238,
+                    1456846.6832452812,
+                    1489049.6707338784,
+                    1482860.1803490622,
+                    1478681.7324496352,
+                    1480662.61413797,
+                    1475933.2548935716,
+                    1485795.8281194444,
+                    1487757.3511368653,
+                    1483209.0145905432
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1680153715625118E7,
+            "scoreError" : 443332.19219505735,
+            "scoreConfidence" : [
+                1.123682152343006E7,
+                1.2123485907820176E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1048664261930706E7,
+                "50.0" : 1.1615777446727037E7,
+                "90.0" : 1.2325582692120695E7,
+                "95.0" : 1.23764468620714E7,
+                "99.0" : 1.2378871988618307E7,
+                "99.9" : 1.2378871988618307E7,
+                "99.99" : 1.2378871988618307E7,
+                "99.999" : 1.2378871988618307E7,
+                "99.9999" : 1.2378871988618307E7,
+                "100.0" : 1.2378871988618307E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.2282501802085241E7,
+                    1.2121488398833735E7,
+                    1.2048250352697536E7,
+                    1.233036945768019E7,
+                    1.1925192684092926E7,
+                    1.222337061414816E7,
+                    1.2378871988618307E7,
+                    1.2212294844654478E7,
+                    1.1905705976922177E7,
+                    1.219515613721564E7
+                ],
+                [
+                    1.1163536108243423E7,
+                    1.1240652228513233E7,
+                    1.1091389171558214E7,
+                    1.13258489165319E7,
+                    1.1145336010940803E7,
+                    1.119603453284404E7,
+                    1.1215360827538785E7,
+                    1.1294515242491683E7,
+                    1.1048664261930706E7,
+                    1.1258534754961256E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.202678774830817E7,
+            "scoreError" : 198452.99465645803,
+            "scoreConfidence" : [
+                1.1828334753651712E7,
+                1.222524074296463E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1626741886414275E7,
+                "50.0" : 1.2028036411103861E7,
+                "90.0" : 1.227608525071052E7,
+                "95.0" : 1.2301246407842316E7,
+                "99.0" : 1.2302521542144774E7,
+                "99.9" : 1.2302521542144774E7,
+                "99.99" : 1.2302521542144774E7,
+                "99.999" : 1.2302521542144774E7,
+                "99.9999" : 1.2302521542144774E7,
+                "100.0" : 1.2302521542144774E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1871699256930582E7,
+                    1.1798825381865522E7,
+                    1.19124825273388E7,
+                    1.1867646054766407E7,
+                    1.1722626703200432E7,
+                    1.193085327015068E7,
+                    1.1957436224766979E7,
+                    1.1869746839690123E7,
+                    1.1626741886414275E7,
+                    1.1666001686985444E7
+                ],
+                [
+                    1.2245958252489308E7,
+                    1.2263599009772327E7,
+                    1.2231687804283205E7,
+                    1.224107597571648E7,
+                    1.2098636597440744E7,
+                    1.2127413462845042E7,
+                    1.2302521542144774E7,
+                    1.2267682802244605E7,
+                    1.2256100831022039E7,
+                    1.2277018856095623E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalNoBoosterEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 804671.4089809039,
+            "scoreError" : 5100.891959063271,
+            "scoreConfidence" : [
+                799570.5170218407,
+                809772.3009399672
+            ],
+            "scorePercentiles" : {
+                "0.0" : 789969.7618453976,
+                "50.0" : 807013.146840856,
+                "90.0" : 809647.7376567863,
+                "95.0" : 810823.5985587225,
+                "99.0" : 810884.6393538137,
+                "99.9" : 810884.6393538137,
+                "99.99" : 810884.6393538137,
+                "99.999" : 810884.6393538137,
+                "99.9999" : 810884.6393538137,
+                "100.0" : 810884.6393538137
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    797944.6978889279,
+                    806334.1300565931,
+                    809502.9654999583,
+                    806238.6180316614,
+                    807467.4351412487,
+                    804499.4925431478,
+                    809663.8234519894,
+                    789969.7618453976,
+                    794892.8921502128,
+                    794534.9705787261
+                ],
+                [
+                    807985.8796567109,
+                    809018.7361540775,
+                    801220.5183163205,
+                    803995.1138358765,
+                    807330.3531320746,
+                    806695.9405496373,
+                    807877.2387532997,
+                    808693.1098820134,
+                    810884.6393538137,
+                    808677.8627963889
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalNoBoosterPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 963846.4931473263,
+            "scoreError" : 14980.509175586003,
+            "scoreConfidence" : [
+                948865.9839717402,
+                978827.0023229123
+            ],
+            "scorePercentiles" : {
+                "0.0" : 934235.4352204284,
+                "50.0" : 964810.9322653341,
+                "90.0" : 983744.054734612,
+                "95.0" : 984112.2048393228,
+                "99.0" : 984123.4302143913,
+                "99.9" : 984123.4302143913,
+                "99.99" : 984123.4302143913,
+                "99.999" : 984123.4302143913,
+                "99.9999" : 984123.4302143913,
+                "100.0" : 984123.4302143913
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    942457.4002532653,
+                    947227.3454481189,
+                    948409.4844046672,
+                    954698.7833120204,
+                    948579.3391183631,
+                    949784.7837207628,
+                    934235.4352204284,
+                    948591.3716394055,
+                    948668.6465042032,
+                    953637.7678914894
+                ],
+                [
+                    984123.4302143913,
+                    980386.9715721512,
+                    979241.3663538664,
+                    974943.525317175,
+                    982350.2429289204,
+                    981878.33198975,
+                    983898.9227130222,
+                    979164.9841019592,
+                    979728.6490239179,
+                    974923.0812186477
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalNoBoosterSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6908115.15063836,
+            "scoreError" : 49263.0960769471,
+            "scoreConfidence" : [
+                6858852.054561413,
+                6957378.246715306
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6817824.254837292,
+                "50.0" : 6902907.10165371,
+                "90.0" : 6972282.104245774,
+                "95.0" : 6996599.261472516,
+                "99.0" : 6997865.488307068,
+                "99.9" : 6997865.488307068,
+                "99.99" : 6997865.488307068,
+                "99.999" : 6997865.488307068,
+                "99.9999" : 6997865.488307068,
+                "100.0" : 6997865.488307068
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6871757.394262593,
+                    6876001.957320609,
+                    6868214.414309074,
+                    6873408.775824392,
+                    6859742.609522136,
+                    6858266.628708105,
+                    6818215.624029846,
+                    6885680.670992965,
+                    6817824.254837292,
+                    6843142.216634267
+                ],
+                [
+                    6997865.488307068,
+                    6956978.487619622,
+                    6972540.951616021,
+                    6967258.610777366,
+                    6929428.541515255,
+                    6920133.532314456,
+                    6954863.10796507,
+                    6969952.47791356,
+                    6956873.081525431,
+                    6964154.186772075
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceBoosterEncodeBenchmark.originalNoBoosterSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6664586.065662352,
+            "scoreError" : 34042.5107172294,
+            "scoreConfidence" : [
+                6630543.554945123,
+                6698628.576379581
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6574021.940530579,
+                "50.0" : 6670319.677218365,
+                "90.0" : 6711151.542396994,
+                "95.0" : 6716797.8094604565,
+                "99.0" : 6717085.1460000025,
+                "99.9" : 6717085.1460000025,
+                "99.99" : 6717085.1460000025,
+                "99.999" : 6717085.1460000025,
+                "99.9999" : 6717085.1460000025,
+                "100.0" : 6717085.1460000025
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6660278.559647664,
+                    6642790.649886448,
+                    6681810.592505046,
+                    6664124.671400227,
+                    6647356.07148161,
+                    6574021.940530579,
+                    6610068.4150762325,
+                    6656937.1547726495,
+                    6657942.698822804,
+                    6599574.309032422
+                ],
+                [
+                    6709469.687088134,
+                    6625593.22486592,
+                    6717085.1460000025,
+                    6711338.415209089,
+                    6707499.045929705,
+                    6676514.683036502,
+                    6681675.929155832,
+                    6684244.450351359,
+                    6690884.997643405,
+                    6692510.670811427
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3337641.1869639857,
+            "scoreError" : 14274.661900071898,
+            "scoreConfidence" : [
+                3323366.525063914,
+                3351915.8488640576
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3294537.497681794,
+                "50.0" : 3341645.896236154,
+                "90.0" : 3354661.2178006116,
+                "95.0" : 3355193.9131438895,
+                "99.0" : 3355220.4114263672,
+                "99.9" : 3355220.4114263672,
+                "99.99" : 3355220.4114263672,
+                "99.999" : 3355220.4114263672,
+                "99.9999" : 3355220.4114263672,
+                "100.0" : 3355220.4114263672
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3346629.742898212,
+                    3355220.4114263672,
+                    3354690.445776815,
+                    3349679.201846118,
+                    3296311.9522074065,
+                    3340864.4987210454,
+                    3334606.3387841824,
+                    3294537.497681794,
+                    3354398.1660147817,
+                    3340588.5862203604
+                ],
+                [
+                    3324290.786474281,
+                    3343752.974047924,
+                    3334667.4246739233,
+                    3335163.5901782396,
+                    3345650.724697467,
+                    3334033.208374282,
+                    3342427.293751262,
+                    3346205.810138579,
+                    3336193.733581972,
+                    3342911.3517847
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5427945.1456673285,
+            "scoreError" : 17366.075135482446,
+            "scoreConfidence" : [
+                5410579.070531846,
+                5445311.220802811
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5383661.532746507,
+                "50.0" : 5428406.750557047,
+                "90.0" : 5458114.039747421,
+                "95.0" : 5459153.118298773,
+                "99.0" : 5459207.729749374,
+                "99.9" : 5459207.729749374,
+                "99.99" : 5459207.729749374,
+                "99.999" : 5459207.729749374,
+                "99.9999" : 5459207.729749374,
+                "100.0" : 5459207.729749374
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5444257.056729569,
+                    5437130.151237837,
+                    5459207.729749374,
+                    5414401.896135308,
+                    5383661.532746507,
+                    5411744.417861503,
+                    5418329.303564265,
+                    5428207.534069036,
+                    5428069.232986802,
+                    5390221.231869608
+                ],
+                [
+                    5417453.208673116,
+                    5428605.9670450585,
+                    5432731.429341878,
+                    5417249.674071056,
+                    5422829.227079709,
+                    5441145.334825345,
+                    5436381.4720165515,
+                    5458100.890838122,
+                    5458115.500737343,
+                    5431060.121768577
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.463950462767991E7,
+            "scoreError" : 2056508.7125616297,
+            "scoreConfidence" : [
+                5.258299591511828E7,
+                5.669601334024154E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.164801176113553E7,
+                "50.0" : 5.481466711916776E7,
+                "90.0" : 5.703218163551455E7,
+                "95.0" : 5.712157840927712E7,
+                "99.0" : 5.712595286318246E7,
+                "99.9" : 5.712595286318246E7,
+                "99.99" : 5.712595286318246E7,
+                "99.999" : 5.712595286318246E7,
+                "99.9999" : 5.712595286318246E7,
+                "100.0" : 5.712595286318246E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.241033900375392E7,
+                    5.235112773728748E7,
+                    5.2594396364650264E7,
+                    5.1796212692736454E7,
+                    5.290217023581338E7,
+                    5.224534533046961E7,
+                    5.242632552389673E7,
+                    5.232397795724112E7,
+                    5.277454468093868E7,
+                    5.164801176113553E7
+                ],
+                [
+                    5.691464806618959E7,
+                    5.68274111209573E7,
+                    5.6968047035069846E7,
+                    5.712595286318246E7,
+                    5.6975642289464705E7,
+                    5.692241773451549E7,
+                    5.685801671421257E7,
+                    5.69598776544853E7,
+                    5.703846378507564E7,
+                    5.672716400252213E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.207309372728357E7,
+            "scoreError" : 1829817.3441202596,
+            "scoreConfidence" : [
+                9.02432763831633E7,
+                9.390291107140383E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.917367540175082E7,
+                "50.0" : 9.180606823963067E7,
+                "90.0" : 9.44079526409002E7,
+                "95.0" : 9.455918695764731E7,
+                "99.0" : 9.456706211254992E7,
+                "99.9" : 9.456706211254992E7,
+                "99.99" : 9.456706211254992E7,
+                "99.999" : 9.456706211254992E7,
+                "99.9999" : 9.456706211254992E7,
+                "100.0" : 9.456706211254992E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.425655279628207E7,
+                    9.429862758893384E7,
+                    9.306219716433696E7,
+                    9.440955901449789E7,
+                    9.456706211254992E7,
+                    9.439349527852091E7,
+                    9.433802161257161E7,
+                    9.429618812098068E7,
+                    9.349293834712788E7,
+                    9.367520255656049E7
+                ],
+                [
+                    9.019999213083623E7,
+                    9.00300403432189E7,
+                    9.010938800830276E7,
+                    9.04054115229877E7,
+                    8.947795333451091E7,
+                    9.050751463155557E7,
+                    9.054993931492439E7,
+                    9.014913428984478E7,
+                    9.00689809753774E7,
+                    8.917367540175082E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3470746.8379123798,
+            "scoreError" : 91119.6347846513,
+            "scoreConfidence" : [
+                3379627.2031277283,
+                3561866.472697031
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3334728.763697198,
+                "50.0" : 3469251.415803482,
+                "90.0" : 3582971.074167216,
+                "95.0" : 3584739.1795203825,
+                "99.0" : 3584832.234420217,
+                "99.9" : 3584832.234420217,
+                "99.99" : 3584832.234420217,
+                "99.999" : 3584832.234420217,
+                "99.9999" : 3584832.234420217,
+                "100.0" : 3584832.234420217
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3375364.523492119,
+                    3334728.763697198,
+                    3373467.512909358,
+                    3381375.36691466,
+                    3370527.2069371627,
+                    3390514.5078929905,
+                    3386773.6214575986,
+                    3350462.1122611635,
+                    3345839.502665849,
+                    3387596.260525268
+                ],
+                [
+                    3584832.234420217,
+                    3574262.384635789,
+                    3566825.7388838693,
+                    3580988.4747605217,
+                    3582970.5138603877,
+                    3582971.1364235305,
+                    3570737.2127597043,
+                    3552803.784906417,
+                    3547988.323713973,
+                    3573907.5751298172
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5533766.904995682,
+            "scoreError" : 62787.76189215017,
+            "scoreConfidence" : [
+                5470979.143103532,
+                5596554.666887832
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5415684.497264864,
+                "50.0" : 5515910.69540306,
+                "90.0" : 5619054.318971513,
+                "95.0" : 5636924.851275942,
+                "99.0" : 5637860.688323004,
+                "99.9" : 5637860.688323004,
+                "99.99" : 5637860.688323004,
+                "99.999" : 5637860.688323004,
+                "99.9999" : 5637860.688323004,
+                "100.0" : 5637860.688323004
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5589492.9083661055,
+                    5574900.006947408,
+                    5609013.848185202,
+                    5615859.963390623,
+                    5608770.422175448,
+                    5618247.663279299,
+                    5619143.947381759,
+                    5541806.02640117,
+                    5585796.868359447,
+                    5637860.688323004
+                ],
+                [
+                    5480582.237433436,
+                    5490015.364404949,
+                    5415684.497264864,
+                    5456003.764591814,
+                    5469473.938313834,
+                    5479210.684958938,
+                    5476622.251061846,
+                    5478293.296266419,
+                    5446453.886178166,
+                    5482105.836629897
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5.827884719200752E7,
+            "scoreError" : 291885.4911402927,
+            "scoreConfidence" : [
+                5.798696170086723E7,
+                5.857073268314781E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.719238636561287E7,
+                "50.0" : 5.836913557947636E7,
+                "90.0" : 5.861852355238539E7,
+                "95.0" : 5.865006061329771E7,
+                "99.0" : 5.865136044168407E7,
+                "99.9" : 5.865136044168407E7,
+                "99.99" : 5.865136044168407E7,
+                "99.999" : 5.865136044168407E7,
+                "99.9999" : 5.865136044168407E7,
+                "100.0" : 5.865136044168407E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5.719238636561287E7,
+                    5.841529095288114E7,
+                    5.8045750486389995E7,
+                    5.815107122101393E7,
+                    5.842050649298869E7,
+                    5.82834057519928E7,
+                    5.787429528235417E7,
+                    5.7891469646139905E7,
+                    5.8233566565508254E7,
+                    5.851009302940996E7
+                ],
+                [
+                    5.848400532644262E7,
+                    5.8625363873956904E7,
+                    5.865136044168407E7,
+                    5.8364881285687484E7,
+                    5.8556960658241786E7,
+                    5.8532448759390764E7,
+                    5.826528607316319E7,
+                    5.825857474690663E7,
+                    5.837338987326524E7,
+                    5.84468370071201E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.kindlingsSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.193258522936651E7,
+            "scoreError" : 2115323.5875833738,
+            "scoreConfidence" : [
+                8.981726164178313E7,
+                9.404790881694989E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.861133419909844E7,
+                "50.0" : 9.217992446982214E7,
+                "90.0" : 9.447804965008596E7,
+                "95.0" : 9.449594649769862E7,
+                "99.0" : 9.449620516031863E7,
+                "99.9" : 9.449620516031863E7,
+                "99.99" : 9.449620516031863E7,
+                "99.999" : 9.449620516031863E7,
+                "99.9999" : 9.449620516031863E7,
+                "100.0" : 9.449620516031863E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.032411937576523E7,
+                    9.011371215156393E7,
+                    8.946499831261797E7,
+                    8.995816149373169E7,
+                    8.861133419909844E7,
+                    8.924051676506126E7,
+                    8.94655141251041E7,
+                    9.026782826708525E7,
+                    8.987463957011819E7,
+                    8.865599072760828E7
+                ],
+                [
+                    9.432948122515208E7,
+                    9.42216503427045E7,
+                    9.43332079665923E7,
+                    9.436120932959367E7,
+                    9.406481938857868E7,
+                    9.411443672143166E7,
+                    9.422711799340704E7,
+                    9.449103190791842E7,
+                    9.449620516031863E7,
+                    9.403572956387903E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2202588.0426990585,
+            "scoreError" : 15500.138169757947,
+            "scoreConfidence" : [
+                2187087.9045293005,
+                2218088.1808688166
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2179414.128853306,
+                "50.0" : 2194625.5024703587,
+                "90.0" : 2225031.876844848,
+                "95.0" : 2230110.911133161,
+                "99.0" : 2230377.9859613646,
+                "99.9" : 2230377.9859613646,
+                "99.99" : 2230377.9859613646,
+                "99.999" : 2230377.9859613646,
+                "99.9999" : 2230377.9859613646,
+                "100.0" : 2230377.9859613646
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2230377.9859613646,
+                    2214721.222551465,
+                    2224372.606702017,
+                    2225036.489397292,
+                    2219059.7532214485,
+                    2190170.709872743,
+                    2221343.625288454,
+                    2223986.627166718,
+                    2224990.3638728503,
+                    2194532.54484862
+                ],
+                [
+                    2191877.8037775275,
+                    2195547.60020797,
+                    2191771.0396179804,
+                    2192400.6290576956,
+                    2181354.3858711175,
+                    2179414.128853306,
+                    2182293.2051493516,
+                    2194718.4600920975,
+                    2189599.4231351097,
+                    2184192.249336043
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2587539.301198421,
+            "scoreError" : 45872.0651471702,
+            "scoreConfidence" : [
+                2541667.2360512507,
+                2633411.3663455914
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2524596.3223498124,
+                "50.0" : 2569831.606179701,
+                "90.0" : 2649744.982579858,
+                "95.0" : 2650956.3195806653,
+                "99.0" : 2651009.185809595,
+                "99.9" : 2651009.185809595,
+                "99.99" : 2651009.185809595,
+                "99.999" : 2651009.185809595,
+                "99.9999" : 2651009.185809595,
+                "100.0" : 2651009.185809595
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2647883.07471961,
+                    2641855.3137010075,
+                    2649951.861230997,
+                    2651009.185809595,
+                    2610238.1598894475,
+                    2593717.345521515,
+                    2641593.747776234,
+                    2642278.792850616,
+                    2646218.949456944,
+                    2647379.682307805
+                ],
+                [
+                    2536094.5223862147,
+                    2545945.866837887,
+                    2536806.3072359012,
+                    2542618.617245839,
+                    2542820.9138236325,
+                    2524596.3223498124,
+                    2537176.88941063,
+                    2538629.123794006,
+                    2532466.9442536575,
+                    2541504.403367066
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.8000828634740405E7,
+            "scoreError" : 477957.0776455634,
+            "scoreConfidence" : [
+                2.7522871557094842E7,
+                2.8478785712385967E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.726104827954828E7,
+                "50.0" : 2.790777951209608E7,
+                "90.0" : 2.867685688022089E7,
+                "95.0" : 2.8681737838939335E7,
+                "99.0" : 2.8681746372137558E7,
+                "99.9" : 2.8681746372137558E7,
+                "99.99" : 2.8681746372137558E7,
+                "99.999" : 2.8681746372137558E7,
+                "99.9999" : 2.8681746372137558E7,
+                "100.0" : 2.8681746372137558E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.84125177182671E7,
+                    2.8681746372137558E7,
+                    2.8629693318286218E7,
+                    2.8360441952375133E7,
+                    2.8410341234774005E7,
+                    2.855120660008029E7,
+                    2.861229545079904E7,
+                    2.8681575708173078E7,
+                    2.8282179505750734E7,
+                    2.8634387428651184E7
+                ],
+                [
+                    2.74823459486032E7,
+                    2.7513583346374627E7,
+                    2.7533379518441427E7,
+                    2.7477258195291962E7,
+                    2.726104827954828E7,
+                    2.7529950182653703E7,
+                    2.748474504953099E7,
+                    2.747950490176569E7,
+                    2.7515160897337794E7,
+                    2.7483211085966006E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1215920977207385E7,
+            "scoreError" : 70548.55940415604,
+            "scoreConfidence" : [
+                2.1145372417803228E7,
+                2.1286469536611542E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.100686593924016E7,
+                "50.0" : 2.122625566607254E7,
+                "90.0" : 2.1318325768466156E7,
+                "95.0" : 2.1322511380023584E7,
+                "99.0" : 2.1322675261773832E7,
+                "99.9" : 2.1322675261773832E7,
+                "99.99" : 2.1322675261773832E7,
+                "99.999" : 2.1322675261773832E7,
+                "99.9999" : 2.1322675261773832E7,
+                "100.0" : 2.1322675261773832E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.123717502482852E7,
+                    2.1276533476575468E7,
+                    2.1242144721885502E7,
+                    2.100686593924016E7,
+                    2.1279013439225055E7,
+                    2.1322675261773832E7,
+                    2.1257489627207465E7,
+                    2.1319397626768835E7,
+                    2.130867904374206E7,
+                    2.130446571894032E7
+                ],
+                [
+                    2.1228358619147193E7,
+                    2.1179520693195414E7,
+                    2.1176776565451585E7,
+                    2.118825855843068E7,
+                    2.115391269460387E7,
+                    2.1224152712997887E7,
+                    2.1090370483179808E7,
+                    2.1127143436191887E7,
+                    2.1179835293876108E7,
+                    2.1215650606886085E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2147316.9178606854,
+            "scoreError" : 39608.15882704115,
+            "scoreConfidence" : [
+                2107708.759033644,
+                2186925.0766877267
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2094547.1143911367,
+                "50.0" : 2136775.7210914004,
+                "90.0" : 2202061.540965248,
+                "95.0" : 2203145.5777713424,
+                "99.0" : 2203195.592121463,
+                "99.9" : 2203195.592121463,
+                "99.99" : 2203195.592121463,
+                "99.999" : 2203195.592121463,
+                "99.9999" : 2203195.592121463,
+                "100.0" : 2203195.592121463
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2202195.30511905,
+                    2189400.2424391494,
+                    2174890.4216984836,
+                    2180756.666147938,
+                    2200857.6635810286,
+                    2199317.9198047738,
+                    2157712.3175845235,
+                    2199624.8773337645,
+                    2196309.8301194203,
+                    2203195.592121463
+                ],
+                [
+                    2112168.9754640586,
+                    2103103.528068049,
+                    2100352.829991589,
+                    2100103.7602477754,
+                    2103964.9810062177,
+                    2103075.757788006,
+                    2101230.7757455697,
+                    2107690.673963429,
+                    2094547.1143911367,
+                    2115839.1245982773
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2700154.651742297,
+            "scoreError" : 19306.903203173435,
+            "scoreConfidence" : [
+                2680847.7485391237,
+                2719461.5549454708
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2664752.3423554176,
+                "50.0" : 2693867.6978093702,
+                "90.0" : 2729745.5000807364,
+                "95.0" : 2730162.1935964664,
+                "99.0" : 2730183.180546446,
+                "99.9" : 2730183.180546446,
+                "99.99" : 2730183.180546446,
+                "99.999" : 2730183.180546446,
+                "99.9999" : 2730183.180546446,
+                "100.0" : 2730183.180546446
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2730183.180546446,
+                    2694993.4502597027,
+                    2696325.0905730305,
+                    2713267.19695528,
+                    2729763.4415468615,
+                    2729584.02688561,
+                    2728885.627947307,
+                    2721093.5567658287,
+                    2721359.82851113,
+                    2722344.0478110192
+                ],
+                [
+                    2670041.7617273475,
+                    2689204.8747970276,
+                    2664752.3423554176,
+                    2685363.4186853245,
+                    2687700.772902432,
+                    2692741.9453590373,
+                    2687394.4168557334,
+                    2675435.595634454,
+                    2689617.8414992555,
+                    2673040.6172277103
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.792739475600512E7,
+            "scoreError" : 106848.66480755786,
+            "scoreConfidence" : [
+                2.782054609119756E7,
+                2.8034243420812678E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.76704093202601E7,
+                "50.0" : 2.7955315158959344E7,
+                "90.0" : 2.8076703800907604E7,
+                "95.0" : 2.813667625542879E7,
+                "99.0" : 2.813974170783456E7,
+                "99.9" : 2.813974170783456E7,
+                "99.99" : 2.813974170783456E7,
+                "99.999" : 2.813974170783456E7,
+                "99.9999" : 2.813974170783456E7,
+                "100.0" : 2.813974170783456E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.7712657449859943E7,
+                    2.7832065495237578E7,
+                    2.7978392521307245E7,
+                    2.8061144071603537E7,
+                    2.7877948313328646E7,
+                    2.76704093202601E7,
+                    2.8012061872041944E7,
+                    2.7862342592411943E7,
+                    2.8008040599646553E7,
+                    2.79974907397083E7
+                ],
+                [
+                    2.813974170783456E7,
+                    2.7747200901243925E7,
+                    2.793528410353791E7,
+                    2.7995174172349066E7,
+                    2.8008217847966842E7,
+                    2.7975346214380775E7,
+                    2.8078432659719165E7,
+                    2.7870272449739363E7,
+                    2.7916967219525523E7,
+                    2.7868704868399557E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceDecodeBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.0533572425679073E7,
+            "scoreError" : 575947.4176756277,
+            "scoreConfidence" : [
+                1.9957625008003443E7,
+                2.1109519843354702E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.96166099104807E7,
+                "50.0" : 2.037041320548051E7,
+                "90.0" : 2.124515267720038E7,
+                "95.0" : 2.125555197746273E7,
+                "99.0" : 2.125603274524592E7,
+                "99.9" : 2.125603274524592E7,
+                "99.99" : 2.125603274524592E7,
+                "99.999" : 2.125603274524592E7,
+                "99.9999" : 2.125603274524592E7,
+                "100.0" : 2.125603274524592E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.0768135245333474E7,
+                    2.1176737510976225E7,
+                    2.1230203394249015E7,
+                    2.123377026576404E7,
+                    2.1246417389582198E7,
+                    2.125603274524592E7,
+                    2.1185851653264496E7,
+                    2.122446431103884E7,
+                    2.1168634096051168E7,
+                    2.12005576489607E7
+                ],
+                [
+                    1.9923290668707523E7,
+                    1.987386054533714E7,
+                    1.9953828293592256E7,
+                    1.990550211797156E7,
+                    1.994238092301735E7,
+                    1.992675367597506E7,
+                    1.9972691165627543E7,
+                    1.9931726378140256E7,
+                    1.96166099104807E7,
+                    1.9934000574266035E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3380007.7323056636,
+            "scoreError" : 19648.557037544146,
+            "scoreConfidence" : [
+                3360359.1752681197,
+                3399656.2893432076
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3318588.1903087315,
+                "50.0" : 3383792.84694832,
+                "90.0" : 3399909.4046474425,
+                "95.0" : 3401163.514910446,
+                "99.0" : 3401228.836793151,
+                "99.9" : 3401228.836793151,
+                "99.99" : 3401228.836793151,
+                "99.999" : 3401228.836793151,
+                "99.9999" : 3401228.836793151,
+                "100.0" : 3401228.836793151
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3363341.7400640096,
+                    3383155.179112024,
+                    3381793.232821078,
+                    3334932.5380744296,
+                    3380164.1350829722,
+                    3384430.5147846155,
+                    3398289.451105339,
+                    3397363.8766885716,
+                    3393890.814595668,
+                    3397495.192574925
+                ],
+                [
+                    3318588.1903087315,
+                    3390101.1089003077,
+                    3399792.454223036,
+                    3399922.3991390434,
+                    3391015.5120726456,
+                    3401228.836793151,
+                    3383058.838564779,
+                    3376625.6989112683,
+                    3348645.921687785,
+                    3376319.010608903
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4460498.752114221,
+            "scoreError" : 80318.18073498187,
+            "scoreConfidence" : [
+                4380180.57137924,
+                4540816.932849203
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4353564.2624202855,
+                "50.0" : 4437098.099481704,
+                "90.0" : 4567366.67929591,
+                "95.0" : 4576049.943914035,
+                "99.0" : 4576492.395547843,
+                "99.9" : 4576492.395547843,
+                "99.99" : 4576492.395547843,
+                "99.999" : 4576492.395547843,
+                "99.9999" : 4576492.395547843,
+                "100.0" : 4576492.395547843
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4370264.556957761,
+                    4379173.605619805,
+                    4379438.582890963,
+                    4375400.48221957,
+                    4353564.2624202855,
+                    4371320.6176645085,
+                    4371951.111556268,
+                    4372744.307692316,
+                    4373663.240886053,
+                    4370726.130662297
+                ],
+                [
+                    4532132.136294513,
+                    4576492.395547843,
+                    4556653.4046282545,
+                    4552817.601427686,
+                    4548706.802421926,
+                    4557939.670721429,
+                    4564876.527113839,
+                    4494757.616072444,
+                    4567643.362871695,
+                    4539708.626614951
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.5730473001931347E7,
+            "scoreError" : 130371.38914332287,
+            "scoreConfidence" : [
+                2.5600101612788025E7,
+                2.586084439107467E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.5446607467420246E7,
+                "50.0" : 2.5724481615453854E7,
+                "90.0" : 2.593936656259392E7,
+                "95.0" : 2.594321120567273E7,
+                "99.0" : 2.5943310462706964E7,
+                "99.9" : 2.5943310462706964E7,
+                "99.99" : 2.5943310462706964E7,
+                "99.999" : 2.5943310462706964E7,
+                "99.9999" : 2.5943310462706964E7,
+                "100.0" : 2.5943310462706964E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.5446607467420246E7,
+                    2.5943310462706964E7,
+                    2.562669281995927E7,
+                    2.582139006527851E7,
+                    2.5798555248187006E7,
+                    2.5839982052389275E7,
+                    2.583630659221294E7,
+                    2.59413253220223E7,
+                    2.5921737727738462E7,
+                    2.5917913433947407E7
+                ],
+                [
+                    2.556276331184142E7,
+                    2.566649371834539E7,
+                    2.5722600376720052E7,
+                    2.569838298897094E7,
+                    2.573218761036615E7,
+                    2.5567397954940047E7,
+                    2.5457553827316407E7,
+                    2.5660765347015798E7,
+                    2.572113085706067E7,
+                    2.5726362854187652E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.1175414322644997E7,
+            "scoreError" : 158250.08201588286,
+            "scoreConfidence" : [
+                3.1017164240629114E7,
+                3.133366440466088E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.079060724412026E7,
+                "50.0" : 3.1222461471095353E7,
+                "90.0" : 3.1369247860606514E7,
+                "95.0" : 3.1501735743256476E7,
+                "99.0" : 3.1508402243571155E7,
+                "99.9" : 3.1508402243571155E7,
+                "99.99" : 3.1508402243571155E7,
+                "99.999" : 3.1508402243571155E7,
+                "99.9999" : 3.1508402243571155E7,
+                "100.0" : 3.1508402243571155E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.105120943621721E7,
+                    3.0874934573533792E7,
+                    3.125556074211771E7,
+                    3.1154162634666562E7,
+                    3.129246262162372E7,
+                    3.120541721858429E7,
+                    3.105527731125572E7,
+                    3.113259205854706E7,
+                    3.123950572360641E7,
+                    3.108843635767438E7
+                ],
+                [
+                    3.084258072113817E7,
+                    3.1276865935512196E7,
+                    3.1284178584126856E7,
+                    3.120244756491681E7,
+                    3.1316828470567122E7,
+                    3.1305382170059193E7,
+                    3.079060724412026E7,
+                    3.1508402243571155E7,
+                    3.1375072237277556E7,
+                    3.125636260378381E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3301872.0337552293,
+            "scoreError" : 25994.422197725078,
+            "scoreConfidence" : [
+                3275877.611557504,
+                3327866.4559529545
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3201844.1857115207,
+                "50.0" : 3309218.0563352136,
+                "90.0" : 3328547.014418092,
+                "95.0" : 3332957.1791149736,
+                "99.0" : 3333182.0461260867,
+                "99.9" : 3333182.0461260867,
+                "99.99" : 3333182.0461260867,
+                "99.999" : 3333182.0461260867,
+                "99.9999" : 3333182.0461260867,
+                "100.0" : 3333182.0461260867
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3328684.7059038226,
+                    3256691.370504534,
+                    3333182.0461260867,
+                    3313055.2382371076,
+                    3323439.6459160876,
+                    3322517.021206087,
+                    3201844.1857115207,
+                    3287352.426981978,
+                    3322374.856133978,
+                    3327307.791046516
+                ],
+                [
+                    3294247.671438434,
+                    3303536.679841998,
+                    3311102.7368605523,
+                    3304600.527252664,
+                    3307333.375809875,
+                    3277559.3487782944,
+                    3300169.0915489146,
+                    3298803.6041536373,
+                    3311174.8589568124,
+                    3312463.49269568
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4388469.233362643,
+            "scoreError" : 17571.750642237992,
+            "scoreConfidence" : [
+                4370897.482720405,
+                4406040.984004881
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4324529.590191478,
+                "50.0" : 4390719.655093076,
+                "90.0" : 4413214.93911903,
+                "95.0" : 4419615.698918561,
+                "99.0" : 4419906.303031597,
+                "99.9" : 4419906.303031597,
+                "99.99" : 4419906.303031597,
+                "99.999" : 4419906.303031597,
+                "99.9999" : 4419906.303031597,
+                "100.0" : 4419906.303031597
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4373828.187376935,
+                    4388427.5062400345,
+                    4371699.510604923,
+                    4383810.717494811,
+                    4377153.88027661,
+                    4394231.226055559,
+                    4391792.332686654,
+                    4380886.158469259,
+                    4389646.977499498,
+                    4378626.044255761
+                ],
+                [
+                    4400094.089288926,
+                    4405036.472027324,
+                    4393762.713286377,
+                    4414094.22077089,
+                    4401862.270217289,
+                    4324529.590191478,
+                    4405301.404252288,
+                    4399569.539836116,
+                    4375125.523390511,
+                    4419906.303031597
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.677637716637971E7,
+            "scoreError" : 355523.21575753484,
+            "scoreConfidence" : [
+                2.6420853950622175E7,
+                2.7131900382137243E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.6111374655680794E7,
+                "50.0" : 2.664199726320472E7,
+                "90.0" : 2.7298132999900185E7,
+                "95.0" : 2.7305878458204318E7,
+                "99.0" : 2.730600899521497E7,
+                "99.9" : 2.730600899521497E7,
+                "99.99" : 2.730600899521497E7,
+                "99.999" : 2.730600899521497E7,
+                "99.9999" : 2.730600899521497E7,
+                "100.0" : 2.730600899521497E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.6710969233131737E7,
+                    2.709536027503389E7,
+                    2.7150017094184775E7,
+                    2.712977636979931E7,
+                    2.715150041663771E7,
+                    2.718606661484574E7,
+                    2.730600899521497E7,
+                    2.7303398255001977E7,
+                    2.7180154521479674E7,
+                    2.7250745703984052E7
+                ],
+                [
+                    2.651790029861666E7,
+                    2.6206594426014155E7,
+                    2.646213563206967E7,
+                    2.63395567189769E7,
+                    2.6111374655680794E7,
+                    2.6422473109856136E7,
+                    2.6487229267419253E7,
+                    2.6459936057933055E7,
+                    2.6483320388436023E7,
+                    2.6573025293277703E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.kindlingsSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.1174599868776895E7,
+            "scoreError" : 240064.0208774096,
+            "scoreConfidence" : [
+                3.0934535847899485E7,
+                3.1414663889654305E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.052340868657008E7,
+                "50.0" : 3.115795539983195E7,
+                "90.0" : 3.148143785279436E7,
+                "95.0" : 3.1672668745747153E7,
+                "99.0" : 3.1682617917749424E7,
+                "99.9" : 3.1682617917749424E7,
+                "99.99" : 3.1682617917749424E7,
+                "99.999" : 3.1682617917749424E7,
+                "99.9999" : 3.1682617917749424E7,
+                "100.0" : 3.1682617917749424E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.118317879191621E7,
+                    3.104082383294671E7,
+                    3.130703892936595E7,
+                    3.105235431587732E7,
+                    3.085708099244473E7,
+                    3.095994569024308E7,
+                    3.099570499375569E7,
+                    3.1003987577411253E7,
+                    3.0944532270498063E7,
+                    3.095361425196393E7
+                ],
+                [
+                    3.1483634477704037E7,
+                    3.1682617917749424E7,
+                    3.1428697074527495E7,
+                    3.135775670370294E7,
+                    3.052340868657008E7,
+                    3.1420843506142054E7,
+                    3.1284048370308556E7,
+                    3.1132732007747695E7,
+                    3.1418328756055348E7,
+                    3.146166822860728E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2318004.6411510757,
+            "scoreError" : 22846.050751769486,
+            "scoreConfidence" : [
+                2295158.5903993063,
+                2340850.691902845
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2262541.110902981,
+                "50.0" : 2324100.326702873,
+                "90.0" : 2344732.844680776,
+                "95.0" : 2353287.90178875,
+                "99.0" : 2353724.7687889924,
+                "99.9" : 2353724.7687889924,
+                "99.99" : 2353724.7687889924,
+                "99.999" : 2353724.7687889924,
+                "99.9999" : 2353724.7687889924,
+                "100.0" : 2353724.7687889924
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2342287.177195704,
+                    2336847.383654365,
+                    2344987.428784149,
+                    2341363.7660529525,
+                    2340156.953492092,
+                    2353724.7687889924,
+                    2337694.0951071065,
+                    2337925.8920251313,
+                    2342441.587750418,
+                    2335609.2495722864
+                ],
+                [
+                    2298630.702539049,
+                    2293847.9896783866,
+                    2284329.057989103,
+                    2262541.110902981,
+                    2292587.666788428,
+                    2300841.236763774,
+                    2306056.608650399,
+                    2312591.4038334605,
+                    2311559.7905492345,
+                    2284068.952903498
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3161103.622474811,
+            "scoreError" : 25525.02086285244,
+            "scoreConfidence" : [
+                3135578.601611959,
+                3186628.6433376633
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3123958.947373017,
+                "50.0" : 3147002.6501007993,
+                "90.0" : 3203508.7422150667,
+                "95.0" : 3213499.7545913644,
+                "99.0" : 3213983.7112797727,
+                "99.9" : 3213983.7112797727,
+                "99.99" : 3213983.7112797727,
+                "99.999" : 3213983.7112797727,
+                "99.9999" : 3213983.7112797727,
+                "100.0" : 3213983.7112797727
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3123958.947373017,
+                    3149366.245178262,
+                    3143382.820042443,
+                    3140154.5159158683,
+                    3142798.7405919814,
+                    3126493.8344110698,
+                    3135450.6403775066,
+                    3141768.0148742967,
+                    3148641.009792542,
+                    3135819.5781323668
+                ],
+                [
+                    3179610.351043633,
+                    3196346.224546205,
+                    3195292.064257272,
+                    3133631.994413737,
+                    3213983.7112797727,
+                    3204304.5775116067,
+                    3180196.2051807875,
+                    3193273.1696307776,
+                    3192235.5145340124,
+                    3145364.2904090565
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.713514343078991E7,
+            "scoreError" : 150363.41572281483,
+            "scoreConfidence" : [
+                2.6984780015067097E7,
+                2.7285506846512724E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.686834770242385E7,
+                "50.0" : 2.7060056416711677E7,
+                "90.0" : 2.743871985819198E7,
+                "95.0" : 2.746220262891783E7,
+                "99.0" : 2.7463198598881297E7,
+                "99.9" : 2.7463198598881297E7,
+                "99.99" : 2.7463198598881297E7,
+                "99.999" : 2.7463198598881297E7,
+                "99.9999" : 2.7463198598881297E7,
+                "100.0" : 2.7463198598881297E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.7003745685412746E7,
+                    2.7007021498088304E7,
+                    2.7036723311281137E7,
+                    2.706042758144546E7,
+                    2.7058464681083605E7,
+                    2.7061472810557827E7,
+                    2.689738879493807E7,
+                    2.705501107072629E7,
+                    2.705320895048259E7,
+                    2.704990557044389E7
+                ],
+                [
+                    2.7384435452355888E7,
+                    2.7198784024682064E7,
+                    2.686834770242385E7,
+                    2.7203993821419735E7,
+                    2.7463198598881297E7,
+                    2.744327919961195E7,
+                    2.7248930460592173E7,
+                    2.739768578541222E7,
+                    2.7151158363981277E7,
+                    2.7059685251977894E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.085420050299214E7,
+            "scoreError" : 755460.8173513542,
+            "scoreConfidence" : [
+                2.0098739685640786E7,
+                2.160966132034349E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.9839592891919736E7,
+                "50.0" : 2.0834240976320297E7,
+                "90.0" : 2.176354758195306E7,
+                "95.0" : 2.1812249428779572E7,
+                "99.0" : 2.1814791119541988E7,
+                "99.9" : 2.1814791119541988E7,
+                "99.99" : 2.1814791119541988E7,
+                "99.999" : 2.1814791119541988E7,
+                "99.9999" : 2.1814791119541988E7,
+                "100.0" : 2.1814791119541988E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.1744505630919293E7,
+                    2.1763957304293662E7,
+                    2.165678905069385E7,
+                    2.1658151719772846E7,
+                    2.175986008088762E7,
+                    2.172617069277489E7,
+                    2.1709714842216015E7,
+                    2.1814791119541988E7,
+                    2.1602573461058058E7,
+                    2.154573414471271E7
+                ],
+                [
+                    2.0070086264453985E7,
+                    1.999854275369456E7,
+                    1.9839592891919736E7,
+                    2.0021170251908664E7,
+                    2.00669610415326E7,
+                    1.9945872990271557E7,
+                    2.011826360871249E7,
+                    2.012274780792788E7,
+                    1.9921239142489247E7,
+                    1.9997285260061096E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2388444.019948096,
+            "scoreError" : 49729.68340090453,
+            "scoreConfidence" : [
+                2338714.3365471913,
+                2438173.703349001
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2324974.947097841,
+                "50.0" : 2369091.7181589203,
+                "90.0" : 2456155.337712484,
+                "95.0" : 2470394.6527063893,
+                "99.0" : 2471142.86605779,
+                "99.9" : 2471142.86605779,
+                "99.99" : 2471142.86605779,
+                "99.999" : 2471142.86605779,
+                "99.9999" : 2471142.86605779,
+                "100.0" : 2471142.86605779
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2353390.2323882068,
+                    2349024.415959567,
+                    2335366.32100227,
+                    2336494.337214412,
+                    2327805.4175095046,
+                    2337973.053906685,
+                    2335687.3287597094,
+                    2328954.6362944925,
+                    2324974.947097841,
+                    2326256.8816135908
+                ],
+                [
+                    2471142.86605779,
+                    2384793.203929634,
+                    2450707.774396,
+                    2450280.877085057,
+                    2443590.8374778135,
+                    2456178.599029778,
+                    2455050.9135685125,
+                    2428156.3209048505,
+                    2417105.4489093665,
+                    2455945.985856835
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3145978.110518839,
+            "scoreError" : 55113.249253199014,
+            "scoreConfidence" : [
+                3090864.8612656402,
+                3201091.359772038
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3063527.303917017,
+                "50.0" : 3139107.9241905436,
+                "90.0" : 3234072.50377336,
+                "95.0" : 3239423.9839177267,
+                "99.0" : 3239682.2955132267,
+                "99.9" : 3239682.2955132267,
+                "99.99" : 3239682.2955132267,
+                "99.999" : 3239682.2955132267,
+                "99.9999" : 3239682.2955132267,
+                "100.0" : 3239682.2955132267
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3106400.9339549537,
+                    3093846.5241086874,
+                    3094228.663786162,
+                    3079851.8418267663,
+                    3063527.303917017,
+                    3097172.666139327,
+                    3109778.344564897,
+                    3074749.5831598616,
+                    3071747.3407469513,
+                    3086278.166851553
+                ],
+                [
+                    3221818.932610613,
+                    3169479.8217856847,
+                    3211302.8020342523,
+                    3230080.4653045675,
+                    3186374.175558291,
+                    3201589.453561945,
+                    3239682.2955132267,
+                    3178699.327532616,
+                    3168437.5038161906,
+                    3234516.0636032256
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.657690293824068E7,
+            "scoreError" : 670561.1326491069,
+            "scoreConfidence" : [
+                2.5906341805591576E7,
+                2.7247464070889786E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.552053780048315E7,
+                "50.0" : 2.6518036791277602E7,
+                "90.0" : 2.7430339153916687E7,
+                "95.0" : 2.7444982421684336E7,
+                "99.0" : 2.7445454424421668E7,
+                "99.9" : 2.7445454424421668E7,
+                "99.99" : 2.7445454424421668E7,
+                "99.999" : 2.7445454424421668E7,
+                "99.9999" : 2.7445454424421668E7,
+                "100.0" : 2.7445454424421668E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.7290268469339147E7,
+                    2.7357262408599027E7,
+                    2.7445454424421668E7,
+                    2.7378014640537564E7,
+                    2.737926221209169E7,
+                    2.7436014369675018E7,
+                    2.7357487863077536E7,
+                    2.7343719856773578E7,
+                    2.7004536653910026E7,
+                    2.714610288387952E7
+                ],
+                [
+                    2.552053780048315E7,
+                    2.587499179256391E7,
+                    2.5905258500695962E7,
+                    2.6031536928645182E7,
+                    2.596600238703063E7,
+                    2.5896435289294913E7,
+                    2.5651620293351773E7,
+                    2.5592244410127323E7,
+                    2.5981712467796348E7,
+                    2.5979595112519693E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.CirceEncodeBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.183366024944752E7,
+            "scoreError" : 506060.9734418696,
+            "scoreConfidence" : [
+                2.132759927600565E7,
+                2.233972122288939E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.1211629062783346E7,
+                "50.0" : 2.170853244669521E7,
+                "90.0" : 2.255518796468729E7,
+                "95.0" : 2.261119553848306E7,
+                "99.0" : 2.2613834308083925E7,
+                "99.9" : 2.2613834308083925E7,
+                "99.99" : 2.2613834308083925E7,
+                "99.999" : 2.2613834308083925E7,
+                "99.9999" : 2.2613834308083925E7,
+                "100.0" : 2.2613834308083925E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.1384598909698687E7,
+                    2.1211629062783346E7,
+                    2.1243891108650733E7,
+                    2.1382471607894752E7,
+                    2.1236357980603106E7,
+                    2.1335988439735655E7,
+                    2.124205930909384E7,
+                    2.1235629101594787E7,
+                    2.1282538921078473E7,
+                    2.1238586193475492E7
+                ],
+                [
+                    2.2032465983691726E7,
+                    2.2359310199576993E7,
+                    2.2449864913180217E7,
+                    2.2319761698323067E7,
+                    2.2469639035704408E7,
+                    2.250234940227301E7,
+                    2.2203657887280863E7,
+                    2.236751201016066E7,
+                    2.2561058916066658E7,
+                    2.2613834308083925E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.FastShowPrettyBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 971929.4056267606,
+            "scoreError" : 7755.137473015854,
+            "scoreConfidence" : [
+                964174.2681537447,
+                979684.5430997764
+            ],
+            "scorePercentiles" : {
+                "0.0" : 954763.4360475934,
+                "50.0" : 973080.1544743823,
+                "90.0" : 987919.2485127649,
+                "95.0" : 988530.6387848431,
+                "99.0" : 988536.845464915,
+                "99.9" : 988536.845464915,
+                "99.99" : 988536.845464915,
+                "99.999" : 988536.845464915,
+                "99.9999" : 988536.845464915,
+                "100.0" : 988536.845464915
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    959548.4903276366,
+                    962160.8053969175,
+                    964098.7826263447,
+                    977052.2431374291,
+                    978675.3413639766,
+                    972520.2213282554,
+                    976570.2875422864,
+                    968237.2775816391,
+                    974002.6578624303,
+                    966917.378364503
+                ],
+                [
+                    965872.1529821391,
+                    973735.7306750559,
+                    975206.9245137764,
+                    988536.845464915,
+                    988412.7118634763,
+                    968500.5794288388,
+                    954763.4360475934,
+                    966658.0800511277,
+                    983478.0783563618,
+                    973640.0876205091
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.FastShowPrettyBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1332326.9497461277,
+            "scoreError" : 12852.779998162127,
+            "scoreConfidence" : [
+                1319474.1697479656,
+                1345179.7297442898
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1313718.475056335,
+                "50.0" : 1328360.2334441086,
+                "90.0" : 1358295.5538962535,
+                "95.0" : 1358500.7395516844,
+                "99.0" : 1358511.300387342,
+                "99.9" : 1358511.300387342,
+                "99.99" : 1358511.300387342,
+                "99.999" : 1358511.300387342,
+                "99.9999" : 1358511.300387342,
+                "100.0" : 1358511.300387342
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1321729.0697166203,
+                    1322400.741358246,
+                    1326477.4589378287,
+                    1327110.9586290757,
+                    1329609.5082591418,
+                    1316802.4544243189,
+                    1313718.475056335,
+                    1320258.734022849,
+                    1334877.5251786383,
+                    1325230.745938933
+                ],
+                [
+                    1352896.0288582088,
+                    1340801.326374518,
+                    1330974.920669332,
+                    1358300.0836741896,
+                    1358254.7858948284,
+                    1317285.3734309147,
+                    1316119.9491802065,
+                    1334465.5140191913,
+                    1358511.300387342,
+                    1340714.040911836
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.FastShowPrettyBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.464381295852251E7,
+            "scoreError" : 1757649.2025397902,
+            "scoreConfidence" : [
+                1.288616375598272E7,
+                1.64014621610623E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1600665703061815E7,
+                "50.0" : 1.4756691342563216E7,
+                "90.0" : 1.875967294121899E7,
+                "95.0" : 1.9136593191694427E7,
+                "99.0" : 1.9139632773753896E7,
+                "99.9" : 1.9139632773753896E7,
+                "99.99" : 1.9139632773753896E7,
+                "99.999" : 1.9139632773753896E7,
+                "99.9999" : 1.9139632773753896E7,
+                "100.0" : 1.9139632773753896E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.218938155586192E7,
+                    1.4863607284324931E7,
+                    1.424607720085299E7,
+                    1.1708527851677181E7,
+                    1.411502087644539E7,
+                    1.187030126354626E7,
+                    1.5887159219109125E7,
+                    1.4985074684046423E7,
+                    1.9139632773753896E7,
+                    1.3852730970263531E7
+                ],
+                [
+                    1.4827539716900917E7,
+                    1.1600665703061815E7,
+                    1.5451771725134172E7,
+                    1.4685842968225513E7,
+                    1.5173823648323065E7,
+                    1.9078841132564522E7,
+                    1.4251139225151308E7,
+                    1.5752475472740145E7,
+                    1.3811747925334362E7,
+                    1.5384897973132763E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.FastShowPrettyBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.7916255900277916E7,
+            "scoreError" : 161698.67761376567,
+            "scoreConfidence" : [
+                1.775455722266415E7,
+                1.807795457789168E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.7625647430976905E7,
+                "50.0" : 1.7867156184590094E7,
+                "90.0" : 1.8190192524784643E7,
+                "95.0" : 1.8246007378396142E7,
+                "99.0" : 1.824882994029854E7,
+                "99.9" : 1.824882994029854E7,
+                "99.99" : 1.824882994029854E7,
+                "99.999" : 1.824882994029854E7,
+                "99.9999" : 1.824882994029854E7,
+                "100.0" : 1.824882994029854E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7829108003142934E7,
+                    1.811253653598444E7,
+                    1.780891896631462E7,
+                    1.7625647430976905E7,
+                    1.8154404607886076E7,
+                    1.775747831145362E7,
+                    1.7760467947717886E7,
+                    1.8170516927591085E7,
+                    1.806646735352912E7,
+                    1.7817388623149768E7
+                ],
+                [
+                    1.7722654324798252E7,
+                    1.8192378702250592E7,
+                    1.797797031486454E7,
+                    1.7956584070459943E7,
+                    1.772107731259035E7,
+                    1.7946119375171345E7,
+                    1.782644063046062E7,
+                    1.824882994029854E7,
+                    1.772492426088033E7,
+                    1.7905204366037253E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3330429.8724147445,
+            "scoreError" : 16874.796499161752,
+            "scoreConfidence" : [
+                3313555.0759155825,
+                3347304.6689139064
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3288639.4234687607,
+                "50.0" : 3337034.751358599,
+                "90.0" : 3350409.370503689,
+                "95.0" : 3354130.369056955,
+                "99.0" : 3354325.4971301323,
+                "99.9" : 3354325.4971301323,
+                "99.99" : 3354325.4971301323,
+                "99.999" : 3354325.4971301323,
+                "99.9999" : 3354325.4971301323,
+                "100.0" : 3354325.4971301323
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3331110.379738277,
+                    3350287.284037619,
+                    3341455.531203771,
+                    3335542.647508407,
+                    3330646.0381830614,
+                    3312617.2688512523,
+                    3299298.5315208742,
+                    3340837.7591526136,
+                    3320123.268754956,
+                    3354325.4971301323
+                ],
+                [
+                    3335757.0848416113,
+                    3342853.716524817,
+                    3346126.6220266167,
+                    3288639.4234687607,
+                    3296068.972964459,
+                    3338312.4178755865,
+                    3342550.7687665885,
+                    3350422.935666586,
+                    3309182.269055774,
+                    3342439.031023129
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3682727.8061706023,
+            "scoreError" : 38384.90988101625,
+            "scoreConfidence" : [
+                3644342.896289586,
+                3721112.7160516186
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3609649.9646137157,
+                "50.0" : 3664717.9352681926,
+                "90.0" : 3744611.993525439,
+                "95.0" : 3751189.0937775164,
+                "99.0" : 3751498.3243302074,
+                "99.9" : 3751498.3243302074,
+                "99.99" : 3751498.3243302074,
+                "99.999" : 3751498.3243302074,
+                "99.9999" : 3751498.3243302074,
+                "100.0" : 3751498.3243302074
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3663813.6451758663,
+                    3751498.3243302074,
+                    3738296.5157668856,
+                    3713167.1602521185,
+                    3711714.4522004086,
+                    3724945.0888817706,
+                    3713644.9930318594,
+                    3724833.5510287024,
+                    3720590.683147929,
+                    3745313.713276389
+                ],
+                [
+                    3647162.080482593,
+                    3654310.305277411,
+                    3657750.525993059,
+                    3609649.9646137157,
+                    3654446.0016068206,
+                    3655153.1948971734,
+                    3665622.2253605193,
+                    3630688.845108547,
+                    3649278.7232506634,
+                    3622676.129729401
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5654740420403799E7,
+            "scoreError" : 749274.0531868986,
+            "scoreConfidence" : [
+                1.49054663672169E7,
+                1.6404014473590698E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.4208161940493392E7,
+                "50.0" : 1.5631298781399155E7,
+                "90.0" : 1.7262689380322244E7,
+                "95.0" : 1.748177872591757E7,
+                "99.0" : 1.748831067164526E7,
+                "99.9" : 1.748831067164526E7,
+                "99.99" : 1.748831067164526E7,
+                "99.999" : 1.748831067164526E7,
+                "99.9999" : 1.748831067164526E7,
+                "100.0" : 1.748831067164526E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.6349250391403586E7,
+                    1.5632267289626257E7,
+                    1.5534195879275894E7,
+                    1.4512868579832098E7,
+                    1.566352397951365E7,
+                    1.6230437131015917E7,
+                    1.5361705081973238E7,
+                    1.4208161940493392E7,
+                    1.4890868015489059E7,
+                    1.5938226706547016E7
+                ],
+                [
+                    1.5064769492836963E7,
+                    1.617496999044473E7,
+                    1.6407847989399124E7,
+                    1.748831067164526E7,
+                    1.5910757438334249E7,
+                    1.7357671757091478E7,
+                    1.496477450251659E7,
+                    1.4855031965621239E7,
+                    1.4918839331844155E7,
+                    1.5630330273172053E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.639556116894549E7,
+            "scoreError" : 127617.08847053694,
+            "scoreConfidence" : [
+                3.626794408047496E7,
+                3.6523178257416025E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.605404876502538E7,
+                "50.0" : 3.641933798097791E7,
+                "90.0" : 3.6570771658886574E7,
+                "95.0" : 3.658815041655519E7,
+                "99.0" : 3.65890071510038E7,
+                "99.9" : 3.65890071510038E7,
+                "99.99" : 3.65890071510038E7,
+                "99.999" : 3.65890071510038E7,
+                "99.9999" : 3.65890071510038E7,
+                "100.0" : 3.65890071510038E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.657187246203157E7,
+                    3.646850506729934E7,
+                    3.633386504916112E7,
+                    3.632062852159636E7,
+                    3.634644675923307E7,
+                    3.643774463426454E7,
+                    3.6497558186590634E7,
+                    3.639904893737201E7,
+                    3.640093132769127E7,
+                    3.65890071510038E7
+                ],
+                [
+                    3.637163439364853E7,
+                    3.605404876502538E7,
+                    3.608909985019038E7,
+                    3.650475200669342E7,
+                    3.6560864430581555E7,
+                    3.639131214421992E7,
+                    3.617900664071105E7,
+                    3.646636833448035E7,
+                    3.648359685625553E7,
+                    3.644493186085995E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3339519.744321321,
+            "scoreError" : 34067.58716520728,
+            "scoreConfidence" : [
+                3305452.157156114,
+                3373587.3314865283
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3271627.2479567397,
+                "50.0" : 3339489.759601104,
+                "90.0" : 3396043.9203595463,
+                "95.0" : 3406625.2251950093,
+                "99.0" : 3407108.0249823397,
+                "99.9" : 3407108.0249823397,
+                "99.99" : 3407108.0249823397,
+                "99.999" : 3407108.0249823397,
+                "99.9999" : 3407108.0249823397,
+                "100.0" : 3407108.0249823397
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3335685.785403453,
+                    3321901.030124945,
+                    3295424.316047642,
+                    3289552.4262509905,
+                    3300241.12704422,
+                    3271627.2479567397,
+                    3345725.4386339677,
+                    3313231.683908515,
+                    3327711.9602599307,
+                    3300276.955409859
+                ],
+                [
+                    3378720.139444571,
+                    3308619.2893137094,
+                    3343293.733798756,
+                    3382270.413661133,
+                    3383370.940473876,
+                    3354491.0710241497,
+                    3369898.8568491163,
+                    3397452.029235732,
+                    3407108.0249823397,
+                    3363792.416602766
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3627228.817209547,
+            "scoreError" : 17287.59099663007,
+            "scoreConfidence" : [
+                3609941.226212917,
+                3644516.408206177
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3589380.0826439704,
+                "50.0" : 3629102.9629603806,
+                "90.0" : 3651286.180528609,
+                "95.0" : 3665530.638776811,
+                "99.0" : 3666267.9403230976,
+                "99.9" : 3666267.9403230976,
+                "99.99" : 3666267.9403230976,
+                "99.999" : 3666267.9403230976,
+                "99.9999" : 3666267.9403230976,
+                "100.0" : 3666267.9403230976
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3617248.067301403,
+                    3631685.669858464,
+                    3589627.341323385,
+                    3643093.1401826967,
+                    3620123.609564572,
+                    3619733.418021077,
+                    3614121.911399001,
+                    3636866.4680178016,
+                    3627389.707543024,
+                    3589380.0826439704
+                ],
+                [
+                    3608318.5120036295,
+                    3605001.6101559405,
+                    3645850.260361204,
+                    3629830.7097259206,
+                    3634198.2227936364,
+                    3649164.6207098453,
+                    3636777.926670076,
+                    3651521.9093973604,
+                    3666267.9403230976,
+                    3628375.2161948406
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.5849831187708627E7,
+            "scoreError" : 608238.7762202775,
+            "scoreConfidence" : [
+                1.524159241148835E7,
+                1.6458069963928904E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.466617517185024E7,
+                "50.0" : 1.5906290904231735E7,
+                "90.0" : 1.6785612276158497E7,
+                "95.0" : 1.7034362430727206E7,
+                "99.0" : 1.7046763661007084E7,
+                "99.9" : 1.7046763661007084E7,
+                "99.99" : 1.7046763661007084E7,
+                "99.999" : 1.7046763661007084E7,
+                "99.9999" : 1.7046763661007084E7,
+                "100.0" : 1.7046763661007084E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.5712309348310107E7,
+                    1.595095198773327E7,
+                    1.546388717588108E7,
+                    1.6554417703011101E7,
+                    1.6667471262898862E7,
+                    1.58616298207302E7,
+                    1.632896961602707E7,
+                    1.6043581584610093E7,
+                    1.6290324302828275E7,
+                    1.7046763661007084E7
+                ],
+                [
+                    1.6619382823217886E7,
+                    1.6798739055409566E7,
+                    1.598392025676029E7,
+                    1.466617517185024E7,
+                    1.4765739446569772E7,
+                    1.4972562996735191E7,
+                    1.523989632189635E7,
+                    1.5131701195592446E7,
+                    1.5350298849577265E7,
+                    1.5547901173526408E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.kindlingsSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.641355276402895E7,
+            "scoreError" : 314676.3032811904,
+            "scoreConfidence" : [
+                3.609887646074776E7,
+                3.672822906731014E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.583199992877249E7,
+                "50.0" : 3.630965810243325E7,
+                "90.0" : 3.6959967299992874E7,
+                "95.0" : 3.701943468946123E7,
+                "99.0" : 3.7021961318772234E7,
+                "99.9" : 3.7021961318772234E7,
+                "99.99" : 3.7021961318772234E7,
+                "99.999" : 3.7021961318772234E7,
+                "99.9999" : 3.7021961318772234E7,
+                "100.0" : 3.7021961318772234E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.626802156010257E7,
+                    3.598235518045545E7,
+                    3.624684007478187E7,
+                    3.6198285433790974E7,
+                    3.625383217212404E7,
+                    3.6331696327258505E7,
+                    3.628761987760799E7,
+                    3.611249322521306E7,
+                    3.583199992877249E7,
+                    3.589358229055466E7
+                ],
+                [
+                    3.678994112940631E7,
+                    3.6828772111752234E7,
+                    3.671951820940585E7,
+                    3.612289107454601E7,
+                    3.642274723904545E7,
+                    3.640624177188117E7,
+                    3.685681440695869E7,
+                    3.672401321559704E7,
+                    3.697142873255223E7,
+                    3.7021961318772234E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3760077.5163279762,
+            "scoreError" : 48303.958312793264,
+            "scoreConfidence" : [
+                3711773.558015183,
+                3808381.4746407694
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3653098.6669219583,
+                "50.0" : 3755297.0313193123,
+                "90.0" : 3822843.6860134066,
+                "95.0" : 3825695.483117065,
+                "99.0" : 3825816.4707391523,
+                "99.9" : 3825816.4707391523,
+                "99.99" : 3825816.4707391523,
+                "99.999" : 3825816.4707391523,
+                "99.9999" : 3825816.4707391523,
+                "100.0" : 3825816.4707391523
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3730691.9209445287,
+                    3701506.9152962225,
+                    3710562.7459827815,
+                    3710772.919916859,
+                    3716845.8301702794,
+                    3698700.964079962,
+                    3725116.8131202618,
+                    3653098.6669219583,
+                    3720032.4733184166,
+                    3718887.5931597725
+                ],
+                [
+                    3801414.691989835,
+                    3814721.1696884725,
+                    3808685.590486479,
+                    3817866.3954574266,
+                    3813179.806109242,
+                    3814577.684879385,
+                    3779902.141694096,
+                    3823396.7182974042,
+                    3825816.4707391523,
+                    3815772.814307007
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterReadBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.505999964120264E7,
+            "scoreError" : 353004.3758697428,
+            "scoreConfidence" : [
+                3.47069952653329E7,
+                3.541300401707239E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.437425351964183E7,
+                "50.0" : 3.4976554207046814E7,
+                "90.0" : 3.554849348802389E7,
+                "95.0" : 3.56283387240189E7,
+                "99.0" : 3.563252094902065E7,
+                "99.9" : 3.563252094902065E7,
+                "99.99" : 3.563252094902065E7,
+                "99.999" : 3.563252094902065E7,
+                "99.9999" : 3.563252094902065E7,
+                "100.0" : 3.563252094902065E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.475387180099847E7,
+                    3.470191071798513E7,
+                    3.468837131692584E7,
+                    3.478752015543409E7,
+                    3.480588208624385E7,
+                    3.466677524196161E7,
+                    3.437425351964183E7,
+                    3.4580785463386275E7,
+                    3.4740606059827246E7,
+                    3.4751877170146175E7
+                ],
+                [
+                    3.554887644898575E7,
+                    3.529724794869168E7,
+                    3.5147226327849776E7,
+                    3.5354104310565494E7,
+                    3.5531580454389185E7,
+                    3.554504683936716E7,
+                    3.563252094902065E7,
+                    3.547351429151217E7,
+                    3.540093019432213E7,
+                    3.5417091526798375E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4824558.168245368,
+            "scoreError" : 69933.88072648634,
+            "scoreConfidence" : [
+                4754624.287518881,
+                4894492.048971854
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4644410.628862812,
+                "50.0" : 4864683.5474603865,
+                "90.0" : 4894015.505492656,
+                "95.0" : 4899856.279718325,
+                "99.0" : 4900136.825806257,
+                "99.9" : 4900136.825806257,
+                "99.99" : 4900136.825806257,
+                "99.999" : 4900136.825806257,
+                "99.9999" : 4900136.825806257,
+                "100.0" : 4900136.825806257
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4889421.918498199,
+                    4768254.276269218,
+                    4900136.825806257,
+                    4668768.5002161665,
+                    4894525.904047595,
+                    4768415.945013949,
+                    4762825.413884111,
+                    4873265.722049209,
+                    4644410.628862812,
+                    4882139.183475659
+                ],
+                [
+                    4871814.9337442545,
+                    4871892.638639264,
+                    4864849.3935464,
+                    4852343.566954556,
+                    4678445.9601067435,
+                    4881234.459485883,
+                    4864517.701374374,
+                    4872935.049669127,
+                    4841145.434551896,
+                    4839819.908711662
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5413071.759263849,
+            "scoreError" : 102836.98620991352,
+            "scoreConfidence" : [
+                5310234.773053936,
+                5515908.745473762
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5058878.112633271,
+                "50.0" : 5446514.948967357,
+                "90.0" : 5527504.171410306,
+                "95.0" : 5531814.970600309,
+                "99.0" : 5531938.02224762,
+                "99.9" : 5531938.02224762,
+                "99.99" : 5531938.02224762,
+                "99.999" : 5531938.02224762,
+                "99.9999" : 5531938.02224762,
+                "100.0" : 5531938.02224762
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5418806.987651182,
+                    5464900.300770713,
+                    5476885.922216541,
+                    5432946.2199516855,
+                    5413068.59623544,
+                    5058878.112633271,
+                    5424587.821718581,
+                    5451621.279473034,
+                    5441408.618461681,
+                    5215537.7310218485
+                ],
+                [
+                    5300551.7261574315,
+                    5440500.997236297,
+                    5453905.51452992,
+                    5531938.02224762,
+                    5482250.199066403,
+                    5509748.8103905525,
+                    5254485.6158667505,
+                    5453485.875381093,
+                    5529476.98930139,
+                    5506449.844965542
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.567423547705795E7,
+            "scoreError" : 406751.85986421845,
+            "scoreConfidence" : [
+                6.526748361719373E7,
+                6.608098733692217E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.433591831145455E7,
+                "50.0" : 6.585845329051773E7,
+                "90.0" : 6.6224994766279094E7,
+                "95.0" : 6.625340145303517E7,
+                "99.0" : 6.6253514712401345E7,
+                "99.9" : 6.6253514712401345E7,
+                "99.99" : 6.6253514712401345E7,
+                "99.999" : 6.6253514712401345E7,
+                "99.9999" : 6.6253514712401345E7,
+                "100.0" : 6.6253514712401345E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.593580431480169E7,
+                    6.545935547629037E7,
+                    6.589197089728402E7,
+                    6.5433927240020044E7,
+                    6.433591831145455E7,
+                    6.59010737689335E7,
+                    6.6253514712401345E7,
+                    6.625124952507775E7,
+                    6.522577881936574E7,
+                    6.573098164603755E7
+                ],
+                [
+                    6.598870193709119E7,
+                    6.5961498716199785E7,
+                    6.5909930505495824E7,
+                    6.545127230383073E7,
+                    6.541613757660209E7,
+                    6.5832509215863004E7,
+                    6.5850684623956084E7,
+                    6.586622195707939E7,
+                    6.595552549279815E7,
+                    6.483265250057593E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.3885381386227384E7,
+            "scoreError" : 604759.7702682407,
+            "scoreConfidence" : [
+                6.3280621615959145E7,
+                6.449014115649562E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.200399176102109E7,
+                "50.0" : 6.399112809504457E7,
+                "90.0" : 6.457276710909377E7,
+                "95.0" : 6.4618622279612646E7,
+                "99.0" : 6.4620896260590576E7,
+                "99.9" : 6.4620896260590576E7,
+                "99.99" : 6.4620896260590576E7,
+                "99.999" : 6.4620896260590576E7,
+                "99.9999" : 6.4620896260590576E7,
+                "100.0" : 6.4620896260590576E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.422947327963265E7,
+                    6.4295746977182806E7,
+                    6.386012355971451E7,
+                    6.3711622125233695E7,
+                    6.200399176102109E7,
+                    6.392938618273938E7,
+                    6.452844631323623E7,
+                    6.405287000734977E7,
+                    6.348887695449815E7,
+                    6.358775458253914E7
+                ],
+                [
+                    6.301749149581684E7,
+                    6.432858711190188E7,
+                    6.4620896260590576E7,
+                    6.378659673443345E7,
+                    6.348681276484546E7,
+                    6.27036127836968E7,
+                    6.448724024142539E7,
+                    6.457541664103195E7,
+                    6.454892132165015E7,
+                    6.446376062600784E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4786694.7730222745,
+            "scoreError" : 55802.43102248528,
+            "scoreConfidence" : [
+                4730892.341999789,
+                4842497.20404476
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4674459.606822272,
+                "50.0" : 4805586.544580238,
+                "90.0" : 4879353.007667015,
+                "95.0" : 4886910.203073824,
+                "99.0" : 4887116.449166037,
+                "99.9" : 4887116.449166037,
+                "99.99" : 4887116.449166037,
+                "99.999" : 4887116.449166037,
+                "99.9999" : 4887116.449166037,
+                "100.0" : 4887116.449166037
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4804763.261722693,
+                    4705087.080491413,
+                    4777076.265104627,
+                    4774362.734633389,
+                    4768346.801421445,
+                    4813712.578035971,
+                    4882991.527321769,
+                    4674459.606822272,
+                    4887116.449166037,
+                    4824538.104407948
+                ],
+                [
+                    4825618.844496363,
+                    4809484.885202984,
+                    4695655.04278105,
+                    4703623.587743058,
+                    4846606.330774228,
+                    4835606.579682774,
+                    4806409.827437783,
+                    4819118.800387625,
+                    4677574.473923438,
+                    4801742.678888619
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5508864.207958619,
+            "scoreError" : 89679.71060279608,
+            "scoreConfidence" : [
+                5419184.497355823,
+                5598543.918561415
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5232182.167406419,
+                "50.0" : 5561385.70415931,
+                "90.0" : 5579959.608418858,
+                "95.0" : 5582495.488001361,
+                "99.0" : 5582626.617591861,
+                "99.9" : 5582626.617591861,
+                "99.99" : 5582626.617591861,
+                "99.999" : 5582626.617591861,
+                "99.9999" : 5582626.617591861,
+                "100.0" : 5582626.617591861
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5582626.617591861,
+                    5568643.056404222,
+                    5551105.808103807,
+                    5232182.167406419,
+                    5508075.399089444,
+                    5579559.85215181,
+                    5565674.594190905,
+                    5455280.547939512,
+                    5406647.131109623,
+                    5374483.728415203
+                ],
+                [
+                    5562547.149299877,
+                    5572824.243186755,
+                    5571395.261385848,
+                    5580004.025781862,
+                    5554977.656431205,
+                    5291543.696595914,
+                    5560224.2590187425,
+                    5573964.666927704,
+                    5567482.277536541,
+                    5518042.020605132
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.591487352598969E7,
+            "scoreError" : 443306.3577053762,
+            "scoreConfidence" : [
+                6.547156716828431E7,
+                6.6358179883695066E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.4727493653803E7,
+                "50.0" : 6.59777383524957E7,
+                "90.0" : 6.6565846500700295E7,
+                "95.0" : 6.670178722475951E7,
+                "99.0" : 6.6707821335019864E7,
+                "99.9" : 6.6707821335019864E7,
+                "99.99" : 6.6707821335019864E7,
+                "99.999" : 6.6707821335019864E7,
+                "99.9999" : 6.6707821335019864E7,
+                "100.0" : 6.6707821335019864E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.570199471047274E7,
+                    6.6707821335019864E7,
+                    6.4727493653803E7,
+                    6.607521423738719E7,
+                    6.6005086084586814E7,
+                    6.594710047900113E7,
+                    6.637140596832587E7,
+                    6.617982122022682E7,
+                    6.556256671695856E7,
+                    6.541398468520912E7
+                ],
+                [
+                    6.6164175962069385E7,
+                    6.6587139129812755E7,
+                    6.481197324904945E7,
+                    6.59615893944325E7,
+                    6.5975532411286876E7,
+                    6.6244700577361934E7,
+                    6.637421283868812E7,
+                    6.5935213502514966E7,
+                    6.557050006988217E7,
+                    6.597994429370453E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.kindlingsSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.3603343288424745E7,
+            "scoreError" : 460114.0809829891,
+            "scoreConfidence" : [
+                6.3143229207441755E7,
+                6.4063457369407736E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.267159874406576E7,
+                "50.0" : 6.356978818228031E7,
+                "90.0" : 6.445103809275545E7,
+                "95.0" : 6.45041583859384E7,
+                "99.0" : 6.4505757691002175E7,
+                "99.9" : 6.4505757691002175E7,
+                "99.99" : 6.4505757691002175E7,
+                "99.999" : 6.4505757691002175E7,
+                "99.9999" : 6.4505757691002175E7,
+                "100.0" : 6.4505757691002175E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.405504344649989E7,
+                    6.329174992791868E7,
+                    6.3531588418160744E7,
+                    6.277171845943742E7,
+                    6.4505757691002175E7,
+                    6.447377158972666E7,
+                    6.4135029574773096E7,
+                    6.4171738394083545E7,
+                    6.267159874406576E7,
+                    6.424643662001463E7
+                ],
+                [
+                    6.3572868434637785E7,
+                    6.3660522643770926E7,
+                    6.368936045086897E7,
+                    6.322512661296068E7,
+                    6.2885417937584996E7,
+                    6.356754312290507E7,
+                    6.357203324165555E7,
+                    6.341422826199509E7,
+                    6.3315735150670774E7,
+                    6.330959704576251E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4948784.21851504,
+            "scoreError" : 76276.8737700003,
+            "scoreConfidence" : [
+                4872507.34474504,
+                5025061.092285041
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4658166.316705394,
+                "50.0" : 4978575.589474958,
+                "90.0" : 5023146.715069768,
+                "95.0" : 5044075.387404326,
+                "99.0" : 5045144.550354546,
+                "99.9" : 5045144.550354546,
+                "99.99" : 5045144.550354546,
+                "99.999" : 5045144.550354546,
+                "99.9999" : 5045144.550354546,
+                "100.0" : 5045144.550354546
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4950354.238950753,
+                    4828364.673923388,
+                    4930767.462769722,
+                    5023761.291350155,
+                    4994494.186373259,
+                    5045144.550354546,
+                    4943900.353287742,
+                    4919802.046035678,
+                    4926975.044947338,
+                    5005969.627825696
+                ],
+                [
+                    4992117.623297825,
+                    4876661.118408482,
+                    4895161.964354813,
+                    4995508.884472551,
+                    5008675.212484152,
+                    5017615.528546285,
+                    5001738.821228286,
+                    4658166.316705394,
+                    4965033.555652091,
+                    4995471.869332645
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5399822.428735773,
+            "scoreError" : 109786.5853731379,
+            "scoreConfidence" : [
+                5290035.843362635,
+                5509609.014108911
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5200594.095524306,
+                "50.0" : 5372066.270751393,
+                "90.0" : 5556344.490727373,
+                "95.0" : 5560145.490266337,
+                "99.0" : 5560336.818035224,
+                "99.9" : 5560336.818035224,
+                "99.99" : 5560336.818035224,
+                "99.999" : 5560336.818035224,
+                "99.9999" : 5560336.818035224,
+                "100.0" : 5560336.818035224
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5321570.569308158,
+                    5304177.530451149,
+                    5200594.095524306,
+                    5323621.394019844,
+                    5389469.474060593,
+                    5369897.232209937,
+                    5307021.400646309,
+                    5230687.349986335,
+                    5369738.993689242,
+                    5215495.117224857
+                ],
+                [
+                    5554852.543356411,
+                    5556510.26265748,
+                    5550090.930969376,
+                    5374235.30929285,
+                    5526632.104973318,
+                    5560336.818035224,
+                    5542814.12364222,
+                    5542825.68316221,
+                    5462540.257271983,
+                    5293337.384233657
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.originalSemiAutoSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 7.193737126885799E7,
+            "scoreError" : 1404715.2906955606,
+            "scoreConfidence" : [
+                7.053265597816242E7,
+                7.334208655955355E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.968201588549721E7,
+                "50.0" : 7.156830887181139E7,
+                "90.0" : 7.393888762019804E7,
+                "95.0" : 7.405803018254337E7,
+                "99.0" : 7.406403734226367E7,
+                "99.9" : 7.406403734226367E7,
+                "99.99" : 7.406403734226367E7,
+                "99.999" : 7.406403734226367E7,
+                "99.9999" : 7.406403734226367E7,
+                "100.0" : 7.406403734226367E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    7.211572804048462E7,
+                    7.360064441415988E7,
+                    7.406403734226367E7,
+                    7.384197025080095E7,
+                    7.37747037838515E7,
+                    7.319505897700372E7,
+                    7.299575625500983E7,
+                    7.297746480025677E7,
+                    7.394389414785756E7,
+                    7.38938288712623E7
+                ],
+                [
+                    7.055440512368843E7,
+                    7.043538161679304E7,
+                    7.056666038925172E7,
+                    7.102088970313817E7,
+                    6.968201588549721E7,
+                    7.017873794525366E7,
+                    7.055763415510981E7,
+                    7.03472505009461E7,
+                    7.075702126685324E7,
+                    7.024434190767738E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.JsoniterWriteBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.3845589768248126E7,
+            "scoreError" : 677282.7841650489,
+            "scoreConfidence" : [
+                6.316830698408308E7,
+                6.452287255241317E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6.17704736354015E7,
+                "50.0" : 6.415439987852536E7,
+                "90.0" : 6.448696232152421E7,
+                "95.0" : 6.455602013369867E7,
+                "99.0" : 6.455956931666049E7,
+                "99.9" : 6.455956931666049E7,
+                "99.99" : 6.455956931666049E7,
+                "99.999" : 6.455956931666049E7,
+                "99.9999" : 6.455956931666049E7,
+                "100.0" : 6.455956931666049E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.333101816140289E7,
+                    6.34795996911714E7,
+                    6.404727531717454E7,
+                    6.446299330652482E7,
+                    6.3857489049137644E7,
+                    6.4212533295159265E7,
+                    6.17704736354015E7,
+                    6.335594261474379E7,
+                    6.409626646189145E7,
+                    6.4378869738994144E7
+                ],
+                [
+                    6.441503717520687E7,
+                    6.455956931666049E7,
+                    6.268587051003007E7,
+                    6.4448240621035E7,
+                    6.448858565742412E7,
+                    6.427170713461954E7,
+                    6.447235229842503E7,
+                    6.386011779227006E7,
+                    6.2435341667198144E7,
+                    6.42825119204919E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.handWrittenDeepName",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.322590953463319E7,
+            "scoreError" : 2984912.3343229066,
+            "scoreConfidence" : [
+                9.024099720031029E7,
+                9.621082186895609E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 8.902966606976593E7,
+                "50.0" : 9.291854425028563E7,
+                "90.0" : 9.80683298783055E7,
+                "95.0" : 9.878455044563606E7,
+                "99.0" : 9.881856110557985E7,
+                "99.9" : 9.881856110557985E7,
+                "99.99" : 9.881856110557985E7,
+                "99.999" : 9.881856110557985E7,
+                "99.9999" : 9.881856110557985E7,
+                "100.0" : 9.881856110557985E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    8.990101375654984E7,
+                    8.95414811020768E7,
+                    9.003159326778269E7,
+                    9.010174772194737E7,
+                    9.011882654102756E7,
+                    8.902966606976593E7,
+                    8.969236583336982E7,
+                    9.116547004478034E7,
+                    9.064268194836318E7,
+                    9.008646631185111E7
+                ],
+                [
+                    9.663611235593285E7,
+                    9.516810084298183E7,
+                    9.525727329632041E7,
+                    9.531215889030755E7,
+                    9.467161845579089E7,
+                    9.881856110557985E7,
+                    9.743816762271729E7,
+                    9.678594076480056E7,
+                    9.813834790670419E7,
+                    9.598059685401322E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.handWrittenEachSalary",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1859569159896452E7,
+            "scoreError" : 117836.39098959288,
+            "scoreConfidence" : [
+                2.1741732768906858E7,
+                2.1977405550886046E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.151989308171591E7,
+                "50.0" : 2.1909904687735714E7,
+                "90.0" : 2.2003182418166824E7,
+                "95.0" : 2.201668199904014E7,
+                "99.0" : 2.2017272526551075E7,
+                "99.9" : 2.2017272526551075E7,
+                "99.99" : 2.2017272526551075E7,
+                "99.999" : 2.2017272526551075E7,
+                "99.9999" : 2.2017272526551075E7,
+                "100.0" : 2.2017272526551075E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.190574592750251E7,
+                    2.1704282041274864E7,
+                    2.1843678288939998E7,
+                    2.1793905015122432E7,
+                    2.151989308171591E7,
+                    2.167277328699348E7,
+                    2.200546197633243E7,
+                    2.176264928048341E7,
+                    2.1982666394676372E7,
+                    2.1654385479886513E7
+                ],
+                [
+                    2.2017272526551075E7,
+                    2.1959631428909108E7,
+                    2.1914063447968923E7,
+                    2.1928443364597417E7,
+                    2.1958407567024387E7,
+                    2.1981386841370825E7,
+                    2.193046967490362E7,
+                    2.187484515366137E7,
+                    2.183388260286323E7,
+                    2.194753981715112E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.kindlingsDeepName",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.917763116687594E7,
+            "scoreError" : 1070403.8360190971,
+            "scoreConfidence" : [
+                9.810722733085684E7,
+                1.0024803500289504E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.745343493231207E7,
+                "50.0" : 9.88896340083796E7,
+                "90.0" : 1.0109426936172205E8,
+                "95.0" : 1.0118292212551409E8,
+                "99.0" : 1.0118633185326467E8,
+                "99.9" : 1.0118633185326467E8,
+                "99.99" : 1.0118633185326467E8,
+                "99.999" : 1.0118633185326467E8,
+                "99.9999" : 1.0118633185326467E8,
+                "100.0" : 1.0118633185326467E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.83726881014217E7,
+                    9.790254404062276E7,
+                    9.811902820991123E7,
+                    9.807941806502761E7,
+                    9.75144273435892E7,
+                    9.745343493231207E7,
+                    9.846693827573901E7,
+                    9.821400342359096E7,
+                    9.816902240056641E7,
+                    9.85683558777638E7
+                ],
+                [
+                    1.0087945793294251E8,
+                    1.011181372982531E8,
+                    1.0016046036897583E8,
+                    1.0025056752254792E8,
+                    1.0118633185326467E8,
+                    1.0000019600393853E8,
+                    1.0015076254299498E8,
+                    9.92109121389954E7,
+                    9.946982643296987E7,
+                    1.0026611057209179E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.kindlingsEachSalary",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.1181729066346735E7,
+            "scoreError" : 301643.39775748487,
+            "scoreConfidence" : [
+                2.088008566858925E7,
+                2.148337246410422E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.0654060855251554E7,
+                "50.0" : 2.120451301555648E7,
+                "90.0" : 2.1584815455889013E7,
+                "95.0" : 2.160813078464575E7,
+                "99.0" : 2.1609338719033927E7,
+                "99.9" : 2.1609338719033927E7,
+                "99.99" : 2.1609338719033927E7,
+                "99.999" : 2.1609338719033927E7,
+                "99.9999" : 2.1609338719033927E7,
+                "100.0" : 2.1609338719033927E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.095376690738048E7,
+                    2.0995676568051185E7,
+                    2.0800987808701135E7,
+                    2.068209318303066E7,
+                    2.068896321028513E7,
+                    2.095822782516493E7,
+                    2.0990398094147857E7,
+                    2.0985870402023423E7,
+                    2.0654060855251554E7,
+                    2.088639498538179E7
+                ],
+                [
+                    2.1473962413866185E7,
+                    2.1492836821674623E7,
+                    2.1609338719033927E7,
+                    2.147753291258428E7,
+                    2.1421766167171832E7,
+                    2.1491280726546235E7,
+                    2.1585180031270392E7,
+                    2.1413349463061776E7,
+                    2.1581534277456604E7,
+                    2.149135995485071E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.quicklensDeepName",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 9.908004839818957E7,
+            "scoreError" : 911808.1536296664,
+            "scoreConfidence" : [
+                9.816824024455991E7,
+                9.999185655181924E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9.734118906327027E7,
+                "50.0" : 9.914557103901756E7,
+                "90.0" : 1.0039950337283188E8,
+                "95.0" : 1.0056878902488676E8,
+                "99.0" : 1.0057696004995018E8,
+                "99.9" : 1.0057696004995018E8,
+                "99.99" : 1.0057696004995018E8,
+                "99.999" : 1.0057696004995018E8,
+                "99.9999" : 1.0057696004995018E8,
+                "100.0" : 1.0057696004995018E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    9.96916031445533E7,
+                    1.0041353954868163E8,
+                    9.995715161557107E7,
+                    9.90919550045184E7,
+                    9.919918707351673E7,
+                    1.0057696004995018E8,
+                    1.0027317779018405E8,
+                    1.0011579863562621E8,
+                    1.0009330927216196E8,
+                    9.998335716520639E7
+                ],
+                [
+                    9.921421150509273E7,
+                    9.88561316943316E7,
+                    9.846058140031745E7,
+                    9.896430738063443E7,
+                    9.763833224397328E7,
+                    9.768381520884924E7,
+                    9.75332083129798E7,
+                    9.734118906327027E7,
+                    9.79670538608504E7,
+                    9.854609799352254E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.OpticsBenchmark.quicklensEachSalary",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2.083169350177682E7,
+            "scoreError" : 117298.32165471358,
+            "scoreConfidence" : [
+                2.0714395180122104E7,
+                2.0948991823431533E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.048302934355437E7,
+                "50.0" : 2.0825559665858313E7,
+                "90.0" : 2.100271947006452E7,
+                "95.0" : 2.1057259981663413E7,
+                "99.0" : 2.106012872299508E7,
+                "99.9" : 2.106012872299508E7,
+                "99.99" : 2.106012872299508E7,
+                "99.999" : 2.106012872299508E7,
+                "99.9999" : 2.106012872299508E7,
+                "100.0" : 2.106012872299508E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2.0983880890798148E7,
+                    2.070808141253507E7,
+                    2.082591491960796E7,
+                    2.073101978079829E7,
+                    2.0978805137491155E7,
+                    2.082520441210867E7,
+                    2.106012872299508E7,
+                    2.048302934355437E7,
+                    2.1002753896361772E7,
+                    2.1002409633389242E7
+                ],
+                [
+                    2.0774734689808648E7,
+                    2.0892519126259383E7,
+                    2.076235848476859E7,
+                    2.071907592973727E7,
+                    2.087664508694098E7,
+                    2.073771001631953E7,
+                    2.0745936843107473E7,
+                    2.085132857252161E7,
+                    2.081193491132493E7,
+                    2.086039822510819E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigReadBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1042251.4985486155,
+            "scoreError" : 14498.417450052817,
+            "scoreConfidence" : [
+                1027753.0810985627,
+                1056749.9159986684
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1018264.8808290047,
+                "50.0" : 1037114.962132683,
+                "90.0" : 1062534.4065979754,
+                "95.0" : 1063714.0004654964,
+                "99.0" : 1063761.0855581476,
+                "99.9" : 1063761.0855581476,
+                "99.99" : 1063761.0855581476,
+                "99.999" : 1063761.0855581476,
+                "99.9999" : 1063761.0855581476,
+                "100.0" : 1063761.0855581476
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1025157.4633708202,
+                    1026253.9565128464,
+                    1019295.9095522306,
+                    1018264.8808290047,
+                    1028343.4078323186,
+                    1029008.7387460108,
+                    1026634.3825665859,
+                    1031871.2156620965,
+                    1031516.6386806734,
+                    1032629.4302714206
+                ],
+                [
+                    1059823.2997307165,
+                    1041600.4939939455,
+                    1063761.0855581476,
+                    1053246.0958122746,
+                    1059302.7249084364,
+                    1059006.4840576632,
+                    1056842.2666579473,
+                    1059969.6126336227,
+                    1062819.3837051257,
+                    1059682.4998904227
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigReadBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.7202386001299635E7,
+            "scoreError" : 98249.95110024759,
+            "scoreConfidence" : [
+                1.7104136050199386E7,
+                1.7300635952399883E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.707274051149241E7,
+                "50.0" : 1.7173973833951868E7,
+                "90.0" : 1.738945887406309E7,
+                "95.0" : 1.744225247121942E7,
+                "99.0" : 1.744489351006248E7,
+                "99.9" : 1.744489351006248E7,
+                "99.99" : 1.744489351006248E7,
+                "99.999" : 1.744489351006248E7,
+                "99.9999" : 1.744489351006248E7,
+                "100.0" : 1.744489351006248E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.7210298660484985E7,
+                    1.7131119036186323E7,
+                    1.7254357880873874E7,
+                    1.736593414181926E7,
+                    1.7330402126032837E7,
+                    1.7075681412873063E7,
+                    1.7151600420783248E7,
+                    1.7323210945074916E7,
+                    1.744489351006248E7,
+                    1.739207273320129E7
+                ],
+                [
+                    1.7115487874429997E7,
+                    1.7105461933553517E7,
+                    1.7113762701244522E7,
+                    1.7190968433835134E7,
+                    1.7095948290270198E7,
+                    1.7219634934767157E7,
+                    1.7106196811103776E7,
+                    1.7174253182548013E7,
+                    1.717369448535572E7,
+                    1.707274051149241E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigReadBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 197051.60685355935,
+            "scoreError" : 1474.404688793434,
+            "scoreConfidence" : [
+                195577.2021647659,
+                198526.0115423528
+            ],
+            "scorePercentiles" : {
+                "0.0" : 193922.99682237164,
+                "50.0" : 196668.08833962886,
+                "90.0" : 199033.0995442146,
+                "95.0" : 199574.27621259584,
+                "99.0" : 199602.15967585065,
+                "99.9" : 199602.15967585065,
+                "99.99" : 199602.15967585065,
+                "99.999" : 199602.15967585065,
+                "99.9999" : 199602.15967585065,
+                "100.0" : 199602.15967585065
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    195092.42220415044,
+                    193922.99682237164,
+                    195411.66521413787,
+                    196563.5939480796,
+                    194470.80334709218,
+                    196772.58273117812,
+                    196347.10234792923,
+                    196058.7787270277,
+                    195983.15025212572,
+                    196336.7605483036
+                ],
+                [
+                    198930.58174535402,
+                    198053.7607818334,
+                    198762.33911076724,
+                    199602.15967585065,
+                    198727.81656400755,
+                    198472.3856689158,
+                    199044.49041075466,
+                    198469.81435895216,
+                    198339.85286016515,
+                    195669.07975219056
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigReadBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1378102.9113608233,
+            "scoreError" : 8241.194209517396,
+            "scoreConfidence" : [
+                1369861.7171513059,
+                1386344.1055703408
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1354762.3713822968,
+                "50.0" : 1378674.2204865902,
+                "90.0" : 1390337.9201616247,
+                "95.0" : 1392630.7724805814,
+                "99.0" : 1392746.8214780246,
+                "99.9" : 1392746.8214780246,
+                "99.99" : 1392746.8214780246,
+                "99.999" : 1392746.8214780246,
+                "99.9999" : 1392746.8214780246,
+                "100.0" : 1392746.8214780246
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1354762.3713822968,
+                    1375082.7456680113,
+                    1378684.784750161,
+                    1378379.3550507724,
+                    1364039.2919011323,
+                    1378623.0825643023,
+                    1381473.681005365,
+                    1379004.4446434618,
+                    1377806.105355702,
+                    1381263.2864050046
+                ],
+                [
+                    1390425.841529163,
+                    1382517.702555969,
+                    1381183.9712257697,
+                    1375874.8527420654,
+                    1378663.6562230194,
+                    1392746.8214780246,
+                    1387191.0930546785,
+                    1389546.627853779,
+                    1360565.6794145398,
+                    1374222.8324132566
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigWriteBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1180302.3588377894,
+            "scoreError" : 35868.569649483674,
+            "scoreConfidence" : [
+                1144433.7891883056,
+                1216170.9284872732
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1125523.9777360202,
+                "50.0" : 1176499.3844001144,
+                "90.0" : 1224518.7286541571,
+                "95.0" : 1231547.6313751976,
+                "99.0" : 1231913.78295933,
+                "99.9" : 1231913.78295933,
+                "99.99" : 1231913.78295933,
+                "99.999" : 1231913.78295933,
+                "99.9999" : 1231913.78295933,
+                "100.0" : 1231913.78295933
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1206585.3644773657,
+                    1224590.7512766828,
+                    1215480.8596155716,
+                    1213425.228160226,
+                    1219149.5624489733,
+                    1223870.5250514252,
+                    1231913.78295933,
+                    1221349.7106098493,
+                    1221400.8362831662,
+                    1223059.7849079908
+                ],
+                [
+                    1138511.2482004766,
+                    1145817.6304376854,
+                    1144165.7945946592,
+                    1138553.386138447,
+                    1137801.1383753628,
+                    1141961.4319218583,
+                    1143035.1403333705,
+                    1146413.404322863,
+                    1125523.9777360202,
+                    1143437.6189044688
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigWriteBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1111135579944227E7,
+            "scoreError" : 665995.056626385,
+            "scoreConfidence" : [
+                1.0445140523317842E7,
+                1.1777130636570612E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0146805840040337E7,
+                "50.0" : 1.1094059276471581E7,
+                "90.0" : 1.1906641853072539E7,
+                "95.0" : 1.1923130201349912E7,
+                "99.0" : 1.19239389137579E7,
+                "99.9" : 1.19239389137579E7,
+                "99.99" : 1.19239389137579E7,
+                "99.999" : 1.19239389137579E7,
+                "99.9999" : 1.19239389137579E7,
+                "100.0" : 1.19239389137579E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.1779063124649448E7,
+                    1.189653654034218E7,
+                    1.184638770999414E7,
+                    1.1634133578139488E7,
+                    1.1890114999104185E7,
+                    1.1871247175863901E7,
+                    1.1893179668640157E7,
+                    1.1907764665598134E7,
+                    1.1877489307879545E7,
+                    1.19239389137579E7
+                ],
+                [
+                    1.0314888124660084E7,
+                    1.038760484100334E7,
+                    1.0379057879828641E7,
+                    1.0500572470348235E7,
+                    1.0407993512405494E7,
+                    1.0435886617291125E7,
+                    1.022262096460386E7,
+                    1.0146805840040337E7,
+                    1.0353440689930651E7,
+                    1.0553984974803673E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigWriteBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 248443.34533721526,
+            "scoreError" : 4698.285809301127,
+            "scoreConfidence" : [
+                243745.05952791413,
+                253141.6311465164
+            ],
+            "scorePercentiles" : {
+                "0.0" : 241825.5724687732,
+                "50.0" : 247763.14902280108,
+                "90.0" : 254635.98750214372,
+                "95.0" : 255074.00472858505,
+                "99.0" : 255092.82990436952,
+                "99.9" : 255092.82990436952,
+                "99.99" : 255092.82990436952,
+                "99.999" : 255092.82990436952,
+                "99.9999" : 255092.82990436952,
+                "100.0" : 255092.82990436952
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    242717.7586103062,
+                    243150.2428881294,
+                    243264.82809708943,
+                    242338.9045539235,
+                    244699.7870255892,
+                    244140.66148549694,
+                    243606.10513442018,
+                    243381.88640045087,
+                    243417.53992656726,
+                    241825.5724687732
+                ],
+                [
+                    253815.56720232166,
+                    253912.93752331412,
+                    253848.10227899527,
+                    254716.32638868035,
+                    253700.1631687536,
+                    255092.82990436952,
+                    253297.726453048,
+                    250826.51102001296,
+                    253590.72392883024,
+                    253522.7322852324
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.PureconfigWriteBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1674027.827892695,
+            "scoreError" : 63881.37327025649,
+            "scoreConfidence" : [
+                1610146.4546224386,
+                1737909.2011629515
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1584617.6685984845,
+                "50.0" : 1667620.7889737352,
+                "90.0" : 1753038.4842541302,
+                "95.0" : 1756364.5680189922,
+                "99.0" : 1756523.4989522125,
+                "99.9" : 1756523.4989522125,
+                "99.99" : 1756523.4989522125,
+                "99.999" : 1756523.4989522125,
+                "99.9999" : 1756523.4989522125,
+                "100.0" : 1756523.4989522125
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1594297.1423507947,
+                    1609175.9269655072,
+                    1584617.6685984845,
+                    1599368.0179417473,
+                    1607973.5858223818,
+                    1599615.7474639989,
+                    1599767.3115131382,
+                    1608375.9053494055,
+                    1612694.2686171217,
+                    1612619.5402341753
+                ],
+                [
+                    1745982.8570034662,
+                    1740497.883628202,
+                    1756523.4989522125,
+                    1753344.8802878086,
+                    1748345.844953469,
+                    1743628.736221945,
+                    1722547.3093303486,
+                    1743566.601237244,
+                    1747332.9114314269,
+                    1750280.919951024
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckArbitraryBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3855.8144503403155,
+            "scoreError" : 61.506458891136084,
+            "scoreConfidence" : [
+                3794.3079914491796,
+                3917.3209092314514
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3747.9321424101586,
+                "50.0" : 3838.321845504728,
+                "90.0" : 3945.6144318262545,
+                "95.0" : 3973.4890297696174,
+                "99.0" : 3974.878569439718,
+                "99.9" : 3974.878569439718,
+                "99.99" : 3974.878569439718,
+                "99.999" : 3974.878569439718,
+                "99.9999" : 3974.878569439718,
+                "100.0" : 3974.878569439718
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3781.6122229599105,
+                    3802.780516482314,
+                    3800.6652211572246,
+                    3764.5339916730845,
+                    3803.177404791603,
+                    3747.9321424101586,
+                    3798.296407650826,
+                    3795.5762308255935,
+                    3824.2720747331864,
+                    3799.550578256108
+                ],
+                [
+                    3906.81869399818,
+                    3947.0877760377107,
+                    3929.6806862486715,
+                    3917.7156987315157,
+                    3974.878569439718,
+                    3909.5842142917377,
+                    3852.3716162762703,
+                    3902.1882482785627,
+                    3925.2123786407765,
+                    3932.354333923151
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckArbitraryBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1934544.974518561,
+            "scoreError" : 6124.580103375125,
+            "scoreConfidence" : [
+                1928420.394415186,
+                1940669.554621936
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1910260.2435117331,
+                "50.0" : 1936258.7822652485,
+                "90.0" : 1940391.9457723668,
+                "95.0" : 1942056.9923589833,
+                "99.0" : 1942143.5901023257,
+                "99.9" : 1942143.5901023257,
+                "99.99" : 1942143.5901023257,
+                "99.999" : 1942143.5901023257,
+                "99.9999" : 1942143.5901023257,
+                "100.0" : 1942143.5901023257
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1936702.1756882619,
+                    1910260.2435117331,
+                    1936646.1608944705,
+                    1933396.050332341,
+                    1933192.2885161166,
+                    1931625.8067464877,
+                    1933423.426109234,
+                    1930216.9281821763,
+                    1936207.2704398455,
+                    1936936.2858178176
+                ],
+                [
+                    1934905.0906822158,
+                    1938924.4347356998,
+                    1939444.4239469755,
+                    1935332.8760428978,
+                    1940411.6352354784,
+                    1924403.383518048,
+                    1940202.3851740852,
+                    1936310.2940906514,
+                    1942143.5901023257,
+                    1940214.740604362
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckArbitraryBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 741106.7725194523,
+            "scoreError" : 2418.5630188999685,
+            "scoreConfidence" : [
+                738688.2095005523,
+                743525.3355383523
+            ],
+            "scorePercentiles" : {
+                "0.0" : 737243.1936184142,
+                "50.0" : 740475.3618055935,
+                "90.0" : 745735.291600192,
+                "95.0" : 746050.3833305143,
+                "99.0" : 746065.2623765201,
+                "99.9" : 746065.2623765201,
+                "99.99" : 746065.2623765201,
+                "99.999" : 746065.2623765201,
+                "99.9999" : 746065.2623765201,
+                "100.0" : 746065.2623765201
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    738709.8107332777,
+                    739720.8682841229,
+                    737253.1983102136,
+                    741139.6743349681,
+                    738979.2618699569,
+                    740680.5216048232,
+                    739520.7126177507,
+                    737243.1936184142,
+                    740270.2020063638,
+                    739330.0008508855
+                ],
+                [
+                    745767.6814564038,
+                    741604.6633899197,
+                    742476.1974880176,
+                    745443.7828942848,
+                    741447.6173173907,
+                    738027.7890402587,
+                    740014.284006796,
+                    743370.5240136825,
+                    745070.2041749912,
+                    746065.2623765201
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckShrinkBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5236245.771366023,
+            "scoreError" : 35147.45891432973,
+            "scoreConfidence" : [
+                5201098.312451694,
+                5271393.230280353
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5150057.392592393,
+                "50.0" : 5232313.9649023935,
+                "90.0" : 5279643.8955796,
+                "95.0" : 5290818.61654803,
+                "99.0" : 5291405.726743366,
+                "99.9" : 5291405.726743366,
+                "99.99" : 5291405.726743366,
+                "99.999" : 5291405.726743366,
+                "99.9999" : 5291405.726743366,
+                "100.0" : 5291405.726743366
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5150057.392592393,
+                    5205542.295940591,
+                    5188796.142718227,
+                    5224607.001641374,
+                    5233829.932079706,
+                    5225240.683753764,
+                    5230797.997725081,
+                    5215814.787959008,
+                    5184773.711315634,
+                    5214016.318743685
+                ],
+                [
+                    5276627.771901072,
+                    5279663.522836644,
+                    5279467.250266201,
+                    5245594.286234768,
+                    5185390.8502235105,
+                    5277172.152395843,
+                    5270767.7048121,
+                    5268742.189439491,
+                    5276607.707998002,
+                    5291405.726743366
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.ScalacheckShrinkBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6884787.739685607,
+            "scoreError" : 66431.21173830169,
+            "scoreConfidence" : [
+                6818356.527947306,
+                6951218.951423909
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6697218.866049272,
+                "50.0" : 6884554.907862492,
+                "90.0" : 6977533.250322431,
+                "95.0" : 6999396.247454558,
+                "99.0" : 7000505.080969293,
+                "99.9" : 7000505.080969293,
+                "99.99" : 7000505.080969293,
+                "99.999" : 7000505.080969293,
+                "99.9999" : 7000505.080969293,
+                "100.0" : 7000505.080969293
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6934271.387861435,
+                    6950659.578598005,
+                    6978328.410674592,
+                    6925852.0947736455,
+                    7000505.080969293,
+                    6970376.807152988,
+                    6934396.745712413,
+                    6843565.861657932,
+                    6858180.165151464,
+                    6946414.765941053
+                ],
+                [
+                    6885729.91368826,
+                    6872139.703867304,
+                    6873742.030701545,
+                    6769002.000340548,
+                    6784001.921518587,
+                    6875866.22209254,
+                    6899835.831405539,
+                    6883379.902036725,
+                    6812287.503518997,
+                    6697218.866049272
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigReadBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2793303.997664613,
+            "scoreError" : 14779.025255365377,
+            "scoreConfidence" : [
+                2778524.972409248,
+                2808083.0229199785
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2748199.5521911266,
+                "50.0" : 2798475.243844017,
+                "90.0" : 2808893.9768109345,
+                "95.0" : 2812064.7686475147,
+                "99.0" : 2812228.5949961357,
+                "99.9" : 2812228.5949961357,
+                "99.99" : 2812228.5949961357,
+                "99.999" : 2812228.5949961357,
+                "99.9999" : 2812228.5949961357,
+                "100.0" : 2812228.5949961357
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2780999.493235604,
+                    2778840.7025707504,
+                    2793007.165746785,
+                    2806533.472717649,
+                    2802830.023445585,
+                    2812228.5949961357,
+                    2808146.8388586533,
+                    2803662.145248886,
+                    2801499.5626694174,
+                    2783359.4747728393
+                ],
+                [
+                    2789364.841242981,
+                    2802127.8487492735,
+                    2795650.7625860474,
+                    2756626.2474648887,
+                    2788729.5151880104,
+                    2798999.0487796613,
+                    2808371.1558958837,
+                    2808952.068023718,
+                    2797951.4389083725,
+                    2748199.5521911266
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigReadBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4731303.745404565,
+            "scoreError" : 39788.209453902775,
+            "scoreConfidence" : [
+                4691515.535950662,
+                4771091.954858468
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4654359.4124790905,
+                "50.0" : 4729669.841286432,
+                "90.0" : 4793345.494007825,
+                "95.0" : 4799037.837077322,
+                "99.0" : 4799328.354214562,
+                "99.9" : 4799328.354214562,
+                "99.99" : 4799328.354214562,
+                "99.999" : 4799328.354214562,
+                "99.9999" : 4799328.354214562,
+                "100.0" : 4799328.354214562
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4720860.144623914,
+                    4710859.364562765,
+                    4740900.55752032,
+                    4743542.754601755,
+                    4716229.019284468,
+                    4673280.798944706,
+                    4736203.994437205,
+                    4697261.891478612,
+                    4723135.688135659,
+                    4676183.899380797
+                ],
+                [
+                    4791792.836850258,
+                    4780875.112666072,
+                    4686933.533886199,
+                    4793518.011469777,
+                    4799328.354214562,
+                    4769538.961890101,
+                    4775419.1459723795,
+                    4767776.666777316,
+                    4654359.4124790905,
+                    4668074.758915343
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigReadBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.1759055932507932E7,
+            "scoreError" : 129580.70530074698,
+            "scoreConfidence" : [
+                1.1629475227207186E7,
+                1.1888636637808679E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.1309402551785637E7,
+                "50.0" : 1.180509475909372E7,
+                "90.0" : 1.1879599568649488E7,
+                "95.0" : 1.198175564628295E7,
+                "99.0" : 1.198710610578585E7,
+                "99.9" : 1.198710610578585E7,
+                "99.99" : 1.198710610578585E7,
+                "99.999" : 1.198710610578585E7,
+                "99.9999" : 1.198710610578585E7,
+                "100.0" : 1.198710610578585E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.173590628325969E7,
+                    1.1309402551785637E7,
+                    1.1845762868656877E7,
+                    1.198710610578585E7,
+                    1.1880096915727856E7,
+                    1.181237744897843E7,
+                    1.1720436561540145E7,
+                    1.1692620640554795E7,
+                    1.1808003632387275E7,
+                    1.1802185885800166E7
+                ],
+                [
+                    1.1875123444944182E7,
+                    1.1754467168760948E7,
+                    1.157129802358569E7,
+                    1.1823627540131416E7,
+                    1.1843551476592867E7,
+                    1.1872585239962785E7,
+                    1.177775464383714E7,
+                    1.1811506489482021E7,
+                    1.1521095424276548E7,
+                    1.1736210304108288E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigReadBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6.091883903696233E7,
+            "scoreError" : 559792.4610972882,
+            "scoreConfidence" : [
+                6.0359046575865045E7,
+                6.1478631498059615E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 5.9278664684210844E7,
+                "50.0" : 6.111139835096228E7,
+                "90.0" : 6.156933770138555E7,
+                "95.0" : 6.1592283959475204E7,
+                "99.0" : 6.159340012284829E7,
+                "99.9" : 6.159340012284829E7,
+                "99.99" : 6.159340012284829E7,
+                "99.999" : 6.159340012284829E7,
+                "99.9999" : 6.159340012284829E7,
+                "100.0" : 6.159340012284829E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6.133753345445385E7,
+                    6.1553685315376274E7,
+                    6.157107685538658E7,
+                    6.159340012284829E7,
+                    6.143771637746579E7,
+                    6.143165216177339E7,
+                    6.133442947010224E7,
+                    6.1427492601589024E7,
+                    6.1446331719930016E7,
+                    6.129734915159556E7
+                ],
+                [
+                    6.086334113042722E7,
+                    5.9278664684210844E7,
+                    6.0531982292401396E7,
+                    6.0533291775306664E7,
+                    6.074801470879753E7,
+                    6.092544755032899E7,
+                    6.0723885287292816E7,
+                    5.9986534290898435E7,
+                    6.006585909551858E7,
+                    6.0289092693542846E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigWriteBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 648359.5836761966,
+            "scoreError" : 21822.246051111306,
+            "scoreConfidence" : [
+                626537.3376250854,
+                670181.8297273079
+            ],
+            "scorePercentiles" : {
+                "0.0" : 616396.4825786313,
+                "50.0" : 649649.0500610458,
+                "90.0" : 675808.0873788118,
+                "95.0" : 676557.4105212895,
+                "99.0" : 676587.0002647788,
+                "99.9" : 676587.0002647788,
+                "99.99" : 676587.0002647788,
+                "99.999" : 676587.0002647788,
+                "99.9999" : 676587.0002647788,
+                "100.0" : 676587.0002647788
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    675995.2053949912,
+                    674124.0252331973,
+                    674032.64048423,
+                    671587.0232687918,
+                    671753.1684083202,
+                    676587.0002647788,
+                    673388.3308883625,
+                    670125.5451883567,
+                    669384.3007987718,
+                    669538.1715269551
+                ],
+                [
+                    616396.4825786313,
+                    624302.1364651351,
+                    626901.5116696275,
+                    625531.2871579244,
+                    624024.1411572673,
+                    624722.9187902095,
+                    622434.9854940536,
+                    619377.5522518328,
+                    627071.4471791737,
+                    629913.7993233198
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigWriteBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1303175.9963961884,
+            "scoreError" : 49364.748892233096,
+            "scoreConfidence" : [
+                1253811.2475039554,
+                1352540.7452884214
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1229980.8422815853,
+                "50.0" : 1305349.5445058811,
+                "90.0" : 1361784.1773923999,
+                "95.0" : 1365064.1226004742,
+                "99.0" : 1365234.5565606318,
+                "99.9" : 1365234.5565606318,
+                "99.99" : 1365234.5565606318,
+                "99.999" : 1365234.5565606318,
+                "99.9999" : 1365234.5565606318,
+                "100.0" : 1365234.5565606318
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1354686.057430734,
+                    1359560.6092773257,
+                    1365234.5565606318,
+                    1358478.8686080687,
+                    1353093.9706205432,
+                    1361825.877357479,
+                    1361408.8777066888,
+                    1359433.917781847,
+                    1344517.1313237625,
+                    1359229.636590622
+                ],
+                [
+                    1233379.5505926462,
+                    1260574.894893349,
+                    1255484.0504709135,
+                    1253220.981762347,
+                    1249347.1104499637,
+                    1247052.527129845,
+                    1230928.6527068058,
+                    1229980.8422815853,
+                    1266181.957688,
+                    1259899.8566906175
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigWriteBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6259544.4320381265,
+            "scoreError" : 42411.69219620903,
+            "scoreConfidence" : [
+                6217132.7398419175,
+                6301956.1242343355
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6152144.734529983,
+                "50.0" : 6277447.191437355,
+                "90.0" : 6320163.516773513,
+                "95.0" : 6331268.111168451,
+                "99.0" : 6331780.357319365,
+                "99.9" : 6331780.357319365,
+                "99.99" : 6331780.357319365,
+                "99.999" : 6331780.357319365,
+                "99.9999" : 6331780.357319365,
+                "100.0" : 6331780.357319365
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6279980.001509377,
+                    6270345.750618584,
+                    6264457.428748787,
+                    6277529.925431083,
+                    6208181.952115954,
+                    6215841.607484054,
+                    6285038.490310188,
+                    6204985.696877979,
+                    6201211.320660418,
+                    6277364.4574436275
+                ],
+                [
+                    6307816.259025418,
+                    6331780.357319365,
+                    6321535.434301078,
+                    6284748.3970280625,
+                    6247644.392895848,
+                    6152144.734529983,
+                    6184383.4234736515,
+                    6289986.623202771,
+                    6288711.475892693,
+                    6297200.911893585
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.SconfigWriteBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0854481230274048E7,
+            "scoreError" : 671413.1103913668,
+            "scoreConfidence" : [
+                1.018306811988268E7,
+                1.1525894340665415E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9868779.687624918,
+                "50.0" : 1.083260879396553E7,
+                "90.0" : 1.1717734996277804E7,
+                "95.0" : 1.173310896456758E7,
+                "99.0" : 1.1733911065201825E7,
+                "99.9" : 1.1733911065201825E7,
+                "99.99" : 1.1733911065201825E7,
+                "99.999" : 1.1733911065201825E7,
+                "99.9999" : 1.1733911065201825E7,
+                "100.0" : 1.1733911065201825E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0205587569588136E7,
+                    1.015370473118432E7,
+                    1.0226790902605172E7,
+                    1.0258379425562508E7,
+                    1.014286356055111E7,
+                    9919921.646236962,
+                    1.0248674048926657E7,
+                    9868779.687624918,
+                    1.0094588433537168E7,
+                    9990447.522519575
+                ],
+                [
+                    1.1521747669585364E7,
+                    1.1717869052516911E7,
+                    1.1733911065201825E7,
+                    1.1657244396055268E7,
+                    1.1544077274785485E7,
+                    1.1406838162368549E7,
+                    1.1570667100637777E7,
+                    1.1716528490125831E7,
+                    1.1671677578102939E7,
+                    1.1439326287764452E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirOpenApiJsoniterBenchmark.circeDecode",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 5065.266592126603,
+            "scoreError" : 66.54264505392727,
+            "scoreConfidence" : [
+                4998.723947072676,
+                5131.8092371805305
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4918.060196078578,
+                "50.0" : 5053.751496649727,
+                "90.0" : 5161.042173845205,
+                "95.0" : 5165.994953203848,
+                "99.0" : 5166.231237427114,
+                "99.9" : 5166.231237427114,
+                "99.99" : 5166.231237427114,
+                "99.999" : 5166.231237427114,
+                "99.9999" : 5166.231237427114,
+                "100.0" : 5166.231237427114
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5166.231237427114,
+                    5123.353830067963,
+                    5146.087836160273,
+                    5156.871761795886,
+                    5058.8539344807805,
+                    5135.659309167686,
+                    5116.891580682362,
+                    5161.505552961796,
+                    5154.4439146771965,
+                    5079.219160499643
+                ],
+                [
+                    4998.104977716734,
+                    5036.838760890517,
+                    5044.854293037753,
+                    5048.649058818675,
+                    4918.060196078578,
+                    4948.913803952587,
+                    5002.260147463396,
+                    5028.547897908599,
+                    4998.38118876772,
+                    4981.603399976792
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirOpenApiJsoniterBenchmark.circeEncode",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 23729.249858603107,
+            "scoreError" : 714.7009389976058,
+            "scoreConfidence" : [
+                23014.548919605502,
+                24443.95079760071
+            ],
+            "scorePercentiles" : {
+                "0.0" : 22642.46114870321,
+                "50.0" : 23742.785960335852,
+                "90.0" : 24635.677477283498,
+                "95.0" : 24643.77045805911,
+                "99.0" : 24644.03418465086,
+                "99.9" : 24644.03418465086,
+                "99.99" : 24644.03418465086,
+                "99.999" : 24644.03418465086,
+                "99.9999" : 24644.03418465086,
+                "100.0" : 24644.03418465086
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    24540.69061174964,
+                    24638.759652815857,
+                    24511.734191822947,
+                    24491.398851764778,
+                    24407.173779471843,
+                    24324.30057673561,
+                    24411.69413526928,
+                    24607.937897492244,
+                    24597.800440817547,
+                    24644.03418465086
+                ],
+                [
+                    22909.464918211157,
+                    23062.142212882198,
+                    23161.271343936096,
+                    23141.818198816705,
+                    22646.922410040926,
+                    22789.953045881037,
+                    23068.099073643487,
+                    23066.08399601314,
+                    22642.46114870321,
+                    22921.25650134358
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirOpenApiJsoniterBenchmark.kindlingsDecode",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 21110.119201635807,
+            "scoreError" : 1220.1635382710328,
+            "scoreConfidence" : [
+                19889.955663364773,
+                22330.28273990684
+            ],
+            "scorePercentiles" : {
+                "0.0" : 19627.235970362628,
+                "50.0" : 21056.94253284208,
+                "90.0" : 22577.746256338105,
+                "95.0" : 22607.502496396213,
+                "99.0" : 22609.056541850456,
+                "99.9" : 22609.056541850456,
+                "99.99" : 22609.056541850456,
+                "99.999" : 22609.056541850456,
+                "99.9999" : 22609.056541850456,
+                "100.0" : 22609.056541850456
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    19781.14626485431,
+                    19724.793250727704,
+                    19682.231082046474,
+                    19769.58502616366,
+                    19740.674506109182,
+                    19800.865391082534,
+                    19794.665901356344,
+                    19627.235970362628,
+                    19707.159705607428,
+                    19799.522981543585
+                ],
+                [
+                    22415.664000033892,
+                    22609.056541850456,
+                    22575.68186849076,
+                    22313.019674601626,
+                    22402.5772884399,
+                    22577.97563276559,
+                    22562.581405038713,
+                    22374.79305395499,
+                    22452.97264948241,
+                    22490.18183820389
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirOpenApiJsoniterBenchmark.kindlingsEncode",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 55959.59036405476,
+            "scoreError" : 880.8530830070782,
+            "scoreConfidence" : [
+                55078.73728104768,
+                56840.44344706184
+            ],
+            "scorePercentiles" : {
+                "0.0" : 54642.13442105447,
+                "50.0" : 55797.29122193395,
+                "90.0" : 57199.21444970331,
+                "95.0" : 57256.535935137435,
+                "99.0" : 57259.35687341893,
+                "99.9" : 57259.35687341893,
+                "99.99" : 57259.35687341893,
+                "99.999" : 57259.35687341893,
+                "99.9999" : 57259.35687341893,
+                "100.0" : 57259.35687341893
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    55213.39076848633,
+                    54642.13442105447,
+                    54881.81539258996,
+                    54972.57280371823,
+                    55069.788874299484,
+                    54879.121271161974,
+                    54878.918209678835,
+                    55048.97567827903,
+                    55227.78390445086,
+                    55318.229311616116
+                ],
+                [
+                    57153.943527508556,
+                    57085.19621939475,
+                    57165.701526931574,
+                    56276.35313225179,
+                    56602.35542067421,
+                    57259.35687341893,
+                    57080.330802723816,
+                    56297.51172740748,
+                    56935.38930766004,
+                    57202.93810778906
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8068672708634543E9,
+            "scoreError" : 1.9089731910652872E7,
+            "scoreConfidence" : [
+                3.7877775389528017E9,
+                3.825957002774107E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.758475681343135E9,
+                "50.0" : 3.8106489471481805E9,
+                "90.0" : 3.8290377941693087E9,
+                "95.0" : 3.83387203677153E9,
+                "99.0" : 3.8341205047308455E9,
+                "99.9" : 3.8341205047308455E9,
+                "99.99" : 3.8341205047308455E9,
+                "99.999" : 3.8341205047308455E9,
+                "99.9999" : 3.8341205047308455E9,
+                "100.0" : 3.8341205047308455E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.820046291001874E9,
+                    3.811206948034274E9,
+                    3.791847744065155E9,
+                    3.8159126500246396E9,
+                    3.809690348976E9,
+                    3.8056404200767813E9,
+                    3.7948433226240673E9,
+                    3.7638872413566146E9,
+                    3.8008750696252894E9,
+                    3.8096156366441054E9
+                ],
+                [
+                    3.829151145544537E9,
+                    3.8123783508251E9,
+                    3.758475681343135E9,
+                    3.767110245690339E9,
+                    3.810090946262087E9,
+                    3.8275902480739822E9,
+                    3.825696526248188E9,
+                    3.8211484643298154E9,
+                    3.828017631792255E9,
+                    3.8341205047308455E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.771987031487232E9,
+            "scoreError" : 1.6904870329251394E8,
+            "scoreConfidence" : [
+                3.6029383281947184E9,
+                3.941035734779746E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9508130253245187E9,
+                "50.0" : 3.823087094921217E9,
+                "90.0" : 3.8388611576032853E9,
+                "95.0" : 3.8424151794395065E9,
+                "99.0" : 3.842594553688951E9,
+                "99.9" : 3.842594553688951E9,
+                "99.99" : 3.842594553688951E9,
+                "99.999" : 3.842594553688951E9,
+                "99.9999" : 3.842594553688951E9,
+                "100.0" : 3.842594553688951E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.814613049035385E9,
+                    3.82292309097638E9,
+                    3.8145611554197445E9,
+                    3.826489819701081E9,
+                    3.8363045357296114E9,
+                    3.8375479577322993E9,
+                    3.8275154009453444E9,
+                    2.9508130253245187E9,
+                    3.804438610667659E9,
+                    3.8234043568872433E9
+                ],
+                [
+                    3.8308315824919243E9,
+                    3.8390070687000613E9,
+                    3.773132932946373E9,
+                    3.7617950332909617E9,
+                    3.8256939720341763E9,
+                    3.8118865489038343E9,
+                    3.7667673640857677E9,
+                    3.823251098866054E9,
+                    3.8061694723172727E9,
+                    3.842594553688951E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7764066178922715E9,
+            "scoreError" : 1.6967491087126523E8,
+            "scoreConfidence" : [
+                3.606731707021006E9,
+                3.946081528763537E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9491938560451818E9,
+                "50.0" : 3.8207058328137836E9,
+                "90.0" : 3.8418405455538483E9,
+                "95.0" : 3.848212793501327E9,
+                "99.0" : 3.848530867206009E9,
+                "99.9" : 3.848530867206009E9,
+                "99.99" : 3.848530867206009E9,
+                "99.999" : 3.848530867206009E9,
+                "99.9999" : 3.848530867206009E9,
+                "100.0" : 3.848530867206009E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8052694074934936E9,
+                    3.8130343804140043E9,
+                    3.8190195857424765E9,
+                    3.7951935050244517E9,
+                    3.8388809175270963E9,
+                    3.833426418769619E9,
+                    3.842169393112376E9,
+                    3.8203123361065683E9,
+                    3.80661393608489E9,
+                    3.848530867206009E9
+                ],
+                [
+                    3.8347225615503926E9,
+                    3.7885763886130505E9,
+                    3.805123994447982E9,
+                    2.9491938560451818E9,
+                    3.8380153484256306E9,
+                    3.823592598674567E9,
+                    3.821099329520999E9,
+                    3.8232334643718276E9,
+                    3.82316279304074E9,
+                    3.7989612756740685E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8261812430707426E9,
+            "scoreError" : 1.7210881755545843E7,
+            "scoreConfidence" : [
+                3.808970361315197E9,
+                3.843392124826288E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.77142045252828E9,
+                "50.0" : 3.827431900321103E9,
+                "90.0" : 3.8489543751843667E9,
+                "95.0" : 3.856018305830678E9,
+                "99.0" : 3.856386195400234E9,
+                "99.9" : 3.856386195400234E9,
+                "99.99" : 3.856386195400234E9,
+                "99.999" : 3.856386195400234E9,
+                "99.9999" : 3.856386195400234E9,
+                "100.0" : 3.856386195400234E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.849028404009107E9,
+                    3.8329601084524775E9,
+                    3.810761874424072E9,
+                    3.8182773486445384E9,
+                    3.8090143040002646E9,
+                    3.8188146945273676E9,
+                    3.827764072538136E9,
+                    3.8482881157617025E9,
+                    3.846170762685785E9,
+                    3.8275458848825545E9
+                ],
+                [
+                    3.8208830474636564E9,
+                    3.77142045252828E9,
+                    3.810093619924533E9,
+                    3.856386195400234E9,
+                    3.8273179157596517E9,
+                    3.809816435844282E9,
+                    3.8476113985910788E9,
+                    3.8422794406489253E9,
+                    3.833638873066327E9,
+                    3.8155519122618823E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.7793417876581383E9,
+            "scoreError" : 1.707331452238212E8,
+            "scoreConfidence" : [
+                3.608608642434317E9,
+                3.9500749328819594E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9514729151685653E9,
+                "50.0" : 3.830213605194783E9,
+                "90.0" : 3.8502293104094625E9,
+                "95.0" : 3.851966864607737E9,
+                "99.0" : 3.8520507408162713E9,
+                "99.9" : 3.8520507408162713E9,
+                "99.99" : 3.8520507408162713E9,
+                "99.999" : 3.8520507408162713E9,
+                "99.9999" : 3.8520507408162713E9,
+                "100.0" : 3.8520507408162713E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.830180278301134E9,
+                    3.8489341542843614E9,
+                    3.836601848891866E9,
+                    3.8448557588405986E9,
+                    3.8186218575944977E9,
+                    3.8206034025237684E9,
+                    3.7991390433070617E9,
+                    3.830246932088433E9,
+                    2.9514729151685653E9,
+                    3.7721865975120287E9
+                ],
+                [
+                    3.7699663497273035E9,
+                    3.771435837252102E9,
+                    3.818325607888443E9,
+                    3.8316909370045896E9,
+                    3.8329384320763726E9,
+                    3.814158818212451E9,
+                    3.8520507408162713E9,
+                    3.845303876089387E9,
+                    3.8477491489379606E9,
+                    3.8503732166455846E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8261858331442657E9,
+            "scoreError" : 2.280467317761917E7,
+            "scoreConfidence" : [
+                3.8033811599666467E9,
+                3.8489905063218846E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.771833233277129E9,
+                "50.0" : 3.8286131971626053E9,
+                "90.0" : 3.8542289383500695E9,
+                "95.0" : 3.8545589145028152E9,
+                "99.0" : 3.854567144963983E9,
+                "99.9" : 3.854567144963983E9,
+                "99.99" : 3.854567144963983E9,
+                "99.999" : 3.854567144963983E9,
+                "99.9999" : 3.854567144963983E9,
+                "100.0" : 3.854567144963983E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.8038120701115375E9,
+                    3.8214809980378237E9,
+                    3.8443362009735103E9,
+                    3.8483994454006767E9,
+                    3.8526665618350534E9,
+                    3.824288855650636E9,
+                    3.8497034449838514E9,
+                    3.854567144963983E9,
+                    3.8144943827918034E9,
+                    3.775018897922936E9
+                ],
+                [
+                    3.771833233277129E9,
+                    3.805242330640711E9,
+                    3.8524916844528627E9,
+                    3.842399076791862E9,
+                    3.7903337717325263E9,
+                    3.827216971153186E9,
+                    3.8153775125126767E9,
+                    3.830009423172025E9,
+                    3.8456421207398973E9,
+                    3.854402535740627E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalSemiAutoEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.781262386183673E9,
+            "scoreError" : 1.9794320138320538E8,
+            "scoreConfidence" : [
+                3.5833191848004675E9,
+                3.9792055875668783E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.816153299764638E9,
+                "50.0" : 3.8336902287201443E9,
+                "90.0" : 3.8556418025884333E9,
+                "95.0" : 3.8619832730837445E9,
+                "99.0" : 3.8623161196302094E9,
+                "99.9" : 3.8623161196302094E9,
+                "99.99" : 3.8623161196302094E9,
+                "99.999" : 3.8623161196302094E9,
+                "99.9999" : 3.8623161196302094E9,
+                "100.0" : 3.8623161196302094E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.824974156853273E9,
+                    3.802210879643691E9,
+                    3.8351231770786815E9,
+                    3.8233977162441535E9,
+                    3.8623161196302094E9,
+                    3.838427446752152E9,
+                    3.8269240589344897E9,
+                    3.8556591887009087E9,
+                    3.784665972456566E9,
+                    3.833130014512819E9
+                ],
+                [
+                    3.8180235228729706E9,
+                    3.834454640116568E9,
+                    3.846480214570646E9,
+                    3.8538089106832757E9,
+                    3.8554853275761557E9,
+                    3.8400456611442327E9,
+                    3.80966104939918E9,
+                    3.83425044292747E9,
+                    2.816153299764638E9,
+                    3.83005592381139E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalSemiAutoPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.736663568891736E9,
+            "scoreError" : 1.7224827577568638E8,
+            "scoreConfidence" : [
+                3.56441529311605E9,
+                3.9089118446674223E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2.9129061571523466E9,
+                "50.0" : 3.7775698764299974E9,
+                "90.0" : 3.8322036848206573E9,
+                "95.0" : 3.8333125673990583E9,
+                "99.0" : 3.8333614330799704E9,
+                "99.9" : 3.8333614330799704E9,
+                "99.99" : 3.8333614330799704E9,
+                "99.999" : 3.8333614330799704E9,
+                "99.9999" : 3.8333614330799704E9,
+                "100.0" : 3.8333614330799704E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.7148435487478905E9,
+                    3.6837789201340046E9,
+                    3.76183329981246E9,
+                    3.8252843797730713E9,
+                    3.830579773050966E9,
+                    3.8333614330799704E9,
+                    3.832384119461734E9,
+                    3.8064512112570767E9,
+                    3.7514231217859015E9,
+                    3.808373476391444E9
+                ],
+                [
+                    3.7786051379968247E9,
+                    3.817798617456025E9,
+                    3.75711578274488E9,
+                    3.723983500311054E9,
+                    2.9129061571523466E9,
+                    3.7587872279066405E9,
+                    3.8032250929575467E9,
+                    3.757394580263249E9,
+                    3.77653461486317E9,
+                    3.798607382688464E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.TapirSchemaBenchmark.originalSemiAutoSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.778348885759492E9,
+            "scoreError" : 2.7772621830205224E7,
+            "scoreConfidence" : [
+                3.7505762639292865E9,
+                3.8061215075896974E9
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.706318094154069E9,
+                "50.0" : 3.7806735498546543E9,
+                "90.0" : 3.818170882458527E9,
+                "95.0" : 3.8188600761097903E9,
+                "99.0" : 3.818870681747757E9,
+                "99.9" : 3.818870681747757E9,
+                "99.99" : 3.818870681747757E9,
+                "99.999" : 3.818870681747757E9,
+                "99.9999" : 3.818870681747757E9,
+                "100.0" : 3.818870681747757E9
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.7833385113620305E9,
+                    3.8100990158920097E9,
+                    3.791406100726449E9,
+                    3.818870681747757E9,
+                    3.797303833447089E9,
+                    3.818658568988423E9,
+                    3.8137817036894627E9,
+                    3.7322583611803036E9,
+                    3.7752801461979594E9,
+                    3.7730925960427456E9
+                ],
+                [
+                    3.777187227886708E9,
+                    3.801511557410234E9,
+                    3.768530028416553E9,
+                    3.778008588347278E9,
+                    3.7954024342369475E9,
+                    3.7953609503778024E9,
+                    3.7709739956518407E9,
+                    3.7268875310456014E9,
+                    3.706318094154069E9,
+                    3.732707788388577E9
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonReadBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1245837.3177703307,
+            "scoreError" : 24546.954004068546,
+            "scoreConfidence" : [
+                1221290.363766262,
+                1270384.2717743993
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1192114.794462001,
+                "50.0" : 1239244.9867535448,
+                "90.0" : 1280808.4565829847,
+                "95.0" : 1281778.5422634822,
+                "99.0" : 1281825.111861566,
+                "99.9" : 1281825.111861566,
+                "99.99" : 1281825.111861566,
+                "99.999" : 1281825.111861566,
+                "99.9999" : 1281825.111861566,
+                "100.0" : 1281825.111861566
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1210909.048188484,
+                    1192114.794462001,
+                    1207296.9245714429,
+                    1221140.6632900622,
+                    1235207.4147325,
+                    1236589.9178190464,
+                    1225687.1866950942,
+                    1213881.5905952924,
+                    1238626.3999764456,
+                    1235358.1177519406
+                ],
+                [
+                    1270737.727529273,
+                    1265506.9950725553,
+                    1239863.5735306437,
+                    1277453.6222453695,
+                    1280893.7198998914,
+                    1281825.111861566,
+                    1280041.0867308248,
+                    1267905.4813740165,
+                    1267031.6816431803,
+                    1268675.297436986
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonReadBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1390354.118260333,
+            "scoreError" : 10300.012125571457,
+            "scoreConfidence" : [
+                1380054.1061347616,
+                1400654.1303859046
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1369226.6417979174,
+                "50.0" : 1391661.949051004,
+                "90.0" : 1408242.0185790493,
+                "95.0" : 1416462.5040865692,
+                "99.0" : 1416870.0397724577,
+                "99.9" : 1416870.0397724577,
+                "99.99" : 1416870.0397724577,
+                "99.999" : 1416870.0397724577,
+                "99.9999" : 1416870.0397724577,
+                "100.0" : 1416870.0397724577
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1380304.8953508355,
+                    1397204.3476197764,
+                    1383074.845696294,
+                    1369372.1778254737,
+                    1384306.0035914113,
+                    1393771.8143068303,
+                    1383109.6253281056,
+                    1393026.8846649798,
+                    1398597.3075167155,
+                    1392787.4231173494
+                ],
+                [
+                    1408719.3260546874,
+                    1389135.3708010511,
+                    1390536.4749846582,
+                    1380839.0938257112,
+                    1403946.2512983058,
+                    1416870.0397724577,
+                    1393037.9171359881,
+                    1369226.6417979174,
+                    1395870.9805346604,
+                    1383344.9439834536
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonReadBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.3645886873954345E7,
+            "scoreError" : 148872.2586604192,
+            "scoreConfidence" : [
+                1.3497014615293926E7,
+                1.3794759132614763E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.3316045064448755E7,
+                "50.0" : 1.3697179982657515E7,
+                "90.0" : 1.3829615367881222E7,
+                "95.0" : 1.3849067051971566E7,
+                "99.0" : 1.3850021628739294E7,
+                "99.9" : 1.3850021628739294E7,
+                "99.99" : 1.3850021628739294E7,
+                "99.999" : 1.3850021628739294E7,
+                "99.9999" : 1.3850021628739294E7,
+                "100.0" : 1.3850021628739294E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.3749739063298443E7,
+                    1.338437673964525E7,
+                    1.3742630641745111E7,
+                    1.3742595217877457E7,
+                    1.3810267706444971E7,
+                    1.3780126809906973E7,
+                    1.3543577271110594E7,
+                    1.363019046823321E7,
+                    1.34907202398195E7,
+                    1.3484732171271408E7
+                ],
+                [
+                    1.3572176427659072E7,
+                    1.3329781310431113E7,
+                    1.3767190370200017E7,
+                    1.3788296278131288E7,
+                    1.3634792390952675E7,
+                    1.3830930093384752E7,
+                    1.3850021628739294E7,
+                    1.3651764747437574E7,
+                    1.381778283834945E7,
+                    1.3316045064448755E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonReadBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0438343020859241E7,
+            "scoreError" : 83225.66234868325,
+            "scoreConfidence" : [
+                1.0355117358510558E7,
+                1.0521568683207925E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0196089323872916E7,
+                "50.0" : 1.0450182287026484E7,
+                "90.0" : 1.0557519494530119E7,
+                "95.0" : 1.0576932508158287E7,
+                "99.0" : 1.0577929288160466E7,
+                "99.9" : 1.0577929288160466E7,
+                "99.99" : 1.0577929288160466E7,
+                "99.999" : 1.0577929288160466E7,
+                "99.9999" : 1.0577929288160466E7,
+                "100.0" : 1.0577929288160466E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.039319900445423E7,
+                    1.0385534108040072E7,
+                    1.043842234706886E7,
+                    1.023551145693829E7,
+                    1.0453096370444324E7,
+                    1.0352806625004241E7,
+                    1.0479032443021346E7,
+                    1.0577929288160466E7,
+                    1.0480547287451774E7,
+                    1.0557993688116884E7
+                ],
+                [
+                    1.0415113369923096E7,
+                    1.042451033310433E7,
+                    1.055325175224924E7,
+                    1.0447268203608643E7,
+                    1.0460751034001218E7,
+                    1.049968551705357E7,
+                    1.0505440261631655E7,
+                    1.0484883273770714E7,
+                    1.0196089323872916E7,
+                    1.0425794729268946E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonWriteBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1249371.535193442,
+            "scoreError" : 8843.305193936541,
+            "scoreConfidence" : [
+                1240528.2299995054,
+                1258214.8403873784
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1228364.1789861738,
+                "50.0" : 1252464.4835540191,
+                "90.0" : 1261726.8565098064,
+                "95.0" : 1264182.8956857112,
+                "99.0" : 1264302.9635087461,
+                "99.9" : 1264302.9635087461,
+                "99.99" : 1264302.9635087461,
+                "99.999" : 1264302.9635087461,
+                "99.9999" : 1264302.9635087461,
+                "100.0" : 1264302.9635087461
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1253717.0047670824,
+                    1251211.9623409556,
+                    1254744.1747750596,
+                    1254916.7811174593,
+                    1249826.926858243,
+                    1243218.884179417,
+                    1250410.78528705,
+                    1254338.2471628203,
+                    1255417.0358363672,
+                    1255413.3627332968
+                ],
+                [
+                    1230603.5571379648,
+                    1228364.1789861738,
+                    1236299.6112691907,
+                    1258647.1274322828,
+                    1243900.9447723012,
+                    1261901.6070480484,
+                    1260154.101665627,
+                    1264302.9635087461,
+                    1240424.9289393807,
+                    1239616.5180513673
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonWriteBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1377854.9634523112,
+            "scoreError" : 11342.63560313267,
+            "scoreConfidence" : [
+                1366512.3278491786,
+                1389197.599055444
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1344724.910063877,
+                "50.0" : 1379873.06007727,
+                "90.0" : 1397683.2739010258,
+                "95.0" : 1399590.4976430566,
+                "99.0" : 1399659.8947257122,
+                "99.9" : 1399659.8947257122,
+                "99.99" : 1399659.8947257122,
+                "99.999" : 1399659.8947257122,
+                "99.9999" : 1399659.8947257122,
+                "100.0" : 1399659.8947257122
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1367824.369460058,
+                    1367073.5704397042,
+                    1382361.97832267,
+                    1382879.793301216,
+                    1372742.1890749454,
+                    1399659.8947257122,
+                    1381603.8269892319,
+                    1379591.4437712447,
+                    1375263.4717045845,
+                    1385195.6685705946
+                ],
+                [
+                    1344724.910063877,
+                    1371158.1951817425,
+                    1367239.1228277348,
+                    1398271.9530725996,
+                    1383505.5647909006,
+                    1362859.721960697,
+                    1380154.6763832953,
+                    1392052.6309234651,
+                    1392385.161356861,
+                    1370551.1261250854
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonWriteBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.324483368472648E7,
+            "scoreError" : 114171.78816032149,
+            "scoreConfidence" : [
+                1.3130661896566158E7,
+                1.3359005472886803E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.300355101142154E7,
+                "50.0" : 1.3274169732006038E7,
+                "90.0" : 1.3413697674187412E7,
+                "95.0" : 1.344225667148655E7,
+                "99.0" : 1.3443671782364294E7,
+                "99.9" : 1.3443671782364294E7,
+                "99.99" : 1.3443671782364294E7,
+                "99.999" : 1.3443671782364294E7,
+                "99.9999" : 1.3443671782364294E7,
+                "100.0" : 1.3443671782364294E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.319452598100695E7,
+                    1.3335377242686916E7,
+                    1.3269729297754752E7,
+                    1.3415369564809395E7,
+                    1.3296726963749101E7,
+                    1.3398650658589574E7,
+                    1.3200131482747424E7,
+                    1.313801412758614E7,
+                    1.327006613321314E7,
+                    1.3329505661674984E7
+                ],
+                [
+                    1.3298670313747354E7,
+                    1.3346343414554305E7,
+                    1.3443671782364294E7,
+                    1.3232901180274973E7,
+                    1.3278273330798935E7,
+                    1.3316969645182434E7,
+                    1.300355101142154E7,
+                    1.304645441509463E7,
+                    1.3056353470740465E7,
+                    1.3025388016532343E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.UbjsonWriteBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.102695817518017E7,
+            "scoreError" : 284850.71996693243,
+            "scoreConfidence" : [
+                1.0742107455213238E7,
+                1.1311808895147104E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 9755866.272634245,
+                "50.0" : 1.1114209255011644E7,
+                "90.0" : 1.122138904691307E7,
+                "95.0" : 1.122653688363213E7,
+                "99.0" : 1.1226785758674195E7,
+                "99.9" : 1.1226785758674195E7,
+                "99.99" : 1.1226785758674195E7,
+                "99.999" : 1.1226785758674195E7,
+                "99.9999" : 1.1226785758674195E7,
+                "100.0" : 1.1226785758674195E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0993323745904243E7,
+                    9755866.272634245,
+                    1.1132978216489462E7,
+                    1.1147796075927902E7,
+                    1.1195086562320396E7,
+                    1.1217616148634395E7,
+                    1.1226785758674195E7,
+                    1.1205196842155907E7,
+                    1.1221808257832924E7,
+                    1.1194345289199002E7
+                ],
+                [
+                    1.109988440063744E7,
+                    1.1087271208687799E7,
+                    1.112853410938585E7,
+                    1.0972982378780337E7,
+                    1.1036849104844067E7,
+                    1.1092297234855387E7,
+                    1.1047887300087653E7,
+                    1.0624861255256884E7,
+                    1.1026425792037306E7,
+                    1.1131367549257994E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.XmlDecodeBenchmark.kindlingsAddress",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3409620.72843215,
+            "scoreError" : 148179.25996240118,
+            "scoreConfidence" : [
+                3261441.4684697487,
+                3557799.9883945514
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3193035.516097134,
+                "50.0" : 3351591.3924778006,
+                "90.0" : 3612810.9261887055,
+                "95.0" : 3632599.3873542654,
+                "99.0" : 3633628.4390621595,
+                "99.9" : 3633628.4390621595,
+                "99.99" : 3633628.4390621595,
+                "99.999" : 3633628.4390621595,
+                "99.9999" : 3633628.4390621595,
+                "100.0" : 3633628.4390621595
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3221719.3670351473,
+                    3233838.497933951,
+                    3260342.1719690473,
+                    3193035.516097134,
+                    3222567.4134606007,
+                    3252080.411837938,
+                    3269198.518617684,
+                    3288533.8232422965,
+                    3321264.390153759,
+                    3269410.7729643644
+                ],
+                [
+                    3610682.6177485194,
+                    3613047.4049042817,
+                    3587765.1578302616,
+                    3593659.3011720013,
+                    3381918.394801842,
+                    3488182.7552564624,
+                    3633628.4390621595,
+                    3602890.0631969674,
+                    3580255.8748520236,
+                    3568393.6765065645
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.XmlDecodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4971964.72264031,
+            "scoreError" : 143733.13714449975,
+            "scoreConfidence" : [
+                4828231.585495811,
+                5115697.85978481
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4729833.741925103,
+                "50.0" : 4983451.640036052,
+                "90.0" : 5178991.328125154,
+                "95.0" : 5185916.552851069,
+                "99.0" : 5186253.5867998395,
+                "99.9" : 5186253.5867998395,
+                "99.99" : 5186253.5867998395,
+                "99.999" : 5186253.5867998395,
+                "99.9999" : 5186253.5867998395,
+                "100.0" : 5186253.5867998395
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    5152271.304108707,
+                    5186253.5867998395,
+                    5083848.472057837,
+                    5152487.1223243205,
+                    5179512.907824429,
+                    5174297.110831676,
+                    5095061.029258836,
+                    5094373.571505584,
+                    5045661.996117969,
+                    5086183.428398951
+                ],
+                [
+                    4819929.754792468,
+                    4789943.9745994685,
+                    4784840.486652716,
+                    4787099.648124704,
+                    4729833.741925103,
+                    4842590.986683649,
+                    4769617.815474836,
+                    4863734.72593451,
+                    4880511.505436463,
+                    4921241.283954136
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.XmlEncodeBenchmark.kindlingsAddress",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 3.8839894552354045E7,
+            "scoreError" : 552793.0509425715,
+            "scoreConfidence" : [
+                3.8287101501411475E7,
+                3.9392687603296615E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 3.816560154186964E7,
+                "50.0" : 3.8622555761438504E7,
+                "90.0" : 3.979558965994081E7,
+                "95.0" : 3.983595739891092E7,
+                "99.0" : 3.983767819986001E7,
+                "99.9" : 3.983767819986001E7,
+                "99.99" : 3.983767819986001E7,
+                "99.999" : 3.983767819986001E7,
+                "99.9999" : 3.983767819986001E7,
+                "100.0" : 3.983767819986001E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    3.969010575662965E7,
+                    3.983767819986001E7,
+                    3.883097585843631E7,
+                    3.939692210341257E7,
+                    3.980326218087822E7,
+                    3.961799717127348E7,
+                    3.972653697150407E7,
+                    3.918359203009154E7,
+                    3.8932507945219114E7,
+                    3.8980063892454915E7
+                ],
+                [
+                    3.816560154186964E7,
+                    3.817934510814549E7,
+                    3.836620136039682E7,
+                    3.8389161470744945E7,
+                    3.841413566444069E7,
+                    3.830929351175274E7,
+                    3.825236998303927E7,
+                    3.8270733426188044E7,
+                    3.823364837701434E7,
+                    3.821775849372897E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.XmlEncodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 4.523723114469485E7,
+            "scoreError" : 271971.7710245963,
+            "scoreConfidence" : [
+                4.496525937367025E7,
+                4.550920291571945E7
+            ],
+            "scorePercentiles" : {
+                "0.0" : 4.438571561503272E7,
+                "50.0" : 4.532911008893707E7,
+                "90.0" : 4.550907091719431E7,
+                "95.0" : 4.5597960466195405E7,
+                "99.0" : 4.5602599102063246E7,
+                "99.9" : 4.5602599102063246E7,
+                "99.99" : 4.5602599102063246E7,
+                "99.999" : 4.5602599102063246E7,
+                "99.9999" : 4.5602599102063246E7,
+                "100.0" : 4.5602599102063246E7
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    4.497635471684004E7,
+                    4.454305360744262E7,
+                    4.501413099432069E7,
+                    4.550227170958493E7,
+                    4.537381501365794E7,
+                    4.54120168810548E7,
+                    4.529574733794138E7,
+                    4.523444669800171E7,
+                    4.438571561503272E7,
+                    4.550982638470646E7
+                ],
+                [
+                    4.514276930118252E7,
+                    4.542516774767333E7,
+                    4.529404254064838E7,
+                    4.543312578053966E7,
+                    4.5389789693429805E7,
+                    4.549435162648201E7,
+                    4.5602599102063246E7,
+                    4.5247346181375414E7,
+                    4.5362472839932755E7,
+                    4.51055791219866E7
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlDecodeBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 629257.5534623719,
+            "scoreError" : 4493.3948273810975,
+            "scoreConfidence" : [
+                624764.1586349908,
+                633750.948289753
+            ],
+            "scorePercentiles" : {
+                "0.0" : 614171.1813549048,
+                "50.0" : 630586.1459787488,
+                "90.0" : 633875.3186754127,
+                "95.0" : 634455.6823703302,
+                "99.0" : 634481.1342163592,
+                "99.9" : 634481.1342163592,
+                "99.99" : 634481.1342163592,
+                "99.999" : 634481.1342163592,
+                "99.9999" : 634481.1342163592,
+                "100.0" : 634481.1342163592
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    630138.9647689972,
+                    614171.1813549048,
+                    629860.2015283693,
+                    630670.2830862266,
+                    630348.8929198862,
+                    631048.6203386129,
+                    629409.3797004953,
+                    619588.5738526455,
+                    620440.1322463788,
+                    628213.1843665235
+                ],
+                [
+                    633004.3110921102,
+                    631991.2916275486,
+                    632702.7666026694,
+                    630861.1429222745,
+                    631063.6356992429,
+                    633972.0972957796,
+                    632415.7278540967,
+                    634481.1342163592,
+                    630502.008871271,
+                    630267.5389030471
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlDecodeBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 762996.5199772627,
+            "scoreError" : 9082.941488390234,
+            "scoreConfidence" : [
+                753913.5784888725,
+                772079.4614656529
+            ],
+            "scorePercentiles" : {
+                "0.0" : 747972.3118679615,
+                "50.0" : 760325.6171291282,
+                "90.0" : 776526.6116214241,
+                "95.0" : 776737.3860912679,
+                "99.0" : 776744.4266226107,
+                "99.9" : 776744.4266226107,
+                "99.99" : 776744.4266226107,
+                "99.999" : 776744.4266226107,
+                "99.9999" : 776744.4266226107,
+                "100.0" : 776744.4266226107
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    763931.1657238163,
+                    772274.9619169765,
+                    776603.6159957552,
+                    773809.8209047574,
+                    776744.4266226107,
+                    774951.7200994003,
+                    773898.0724422248,
+                    763188.247799324,
+                    773519.6259747815,
+                    775833.5722524446
+                ],
+                [
+                    754782.2677717534,
+                    755930.4868468267,
+                    754814.8145951816,
+                    752293.4633671019,
+                    753732.0496682212,
+                    750719.7727266728,
+                    753664.5012178352,
+                    757462.9864589323,
+                    747972.3118679615,
+                    753802.5152926742
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlDecodeBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1.0413158646653108E8,
+            "scoreError" : 889337.3515427845,
+            "scoreConfidence" : [
+                1.032422491149883E8,
+                1.0502092381807387E8
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1.0114950552241333E8,
+                "50.0" : 1.0439766238394512E8,
+                "90.0" : 1.0500626794048314E8,
+                "95.0" : 1.0530686205926983E8,
+                "99.0" : 1.0532257893621652E8,
+                "99.9" : 1.0532257893621652E8,
+                "99.99" : 1.0532257893621652E8,
+                "99.999" : 1.0532257893621652E8,
+                "99.9999" : 1.0532257893621652E8,
+                "100.0" : 1.0532257893621652E8
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1.0352619427369879E8,
+                    1.040046803792958E8,
+                    1.0500824139728267E8,
+                    1.0371801976713963E8,
+                    1.0290983117569996E8,
+                    1.0405577417646341E8,
+                    1.042462001828431E8,
+                    1.0412009262807345E8,
+                    1.049885068292873E8,
+                    1.0241728035142797E8
+                ],
+                [
+                    1.0486904682446893E8,
+                    1.0454912458504714E8,
+                    1.049637337108276E8,
+                    1.0496286933382621E8,
+                    1.0459871401879963E8,
+                    1.0114950552241333E8,
+                    1.0381599899261326E8,
+                    1.048426727937105E8,
+                    1.0532257893621652E8,
+                    1.0456266345148656E8
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlDecodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 6983024.065578493,
+            "scoreError" : 271306.65485257434,
+            "scoreConfidence" : [
+                6711717.410725919,
+                7254330.720431068
+            ],
+            "scorePercentiles" : {
+                "0.0" : 6436927.973034227,
+                "50.0" : 6974266.523548186,
+                "90.0" : 7312915.436292814,
+                "95.0" : 7320456.115149168,
+                "99.0" : 7320779.818256649,
+                "99.9" : 7320779.818256649,
+                "99.99" : 7320779.818256649,
+                "99.999" : 7320779.818256649,
+                "99.9999" : 7320779.818256649,
+                "100.0" : 7320779.818256649
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    6735094.848110999,
+                    6705684.1123751355,
+                    6705323.96426927,
+                    6436927.973034227,
+                    6607777.104178015,
+                    6659853.636991248,
+                    6650285.40055095,
+                    6782053.336419442,
+                    6807895.715463707,
+                    6807655.699245397
+                ],
+                [
+                    7284205.87542185,
+                    7263852.001873557,
+                    7297576.028725058,
+                    7293494.202232344,
+                    7300402.557964907,
+                    7260131.802168777,
+                    7140637.331632665,
+                    7286544.146548672,
+                    7320779.818256649,
+                    7314305.756107026
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlEncodeBenchmark.kindlingsEvent",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 148294.60909331293,
+            "scoreError" : 1905.6318432098083,
+            "scoreConfidence" : [
+                146388.9772501031,
+                150200.24093652275
+            ],
+            "scorePercentiles" : {
+                "0.0" : 144905.3653238443,
+                "50.0" : 147620.8270253296,
+                "90.0" : 151394.64169475617,
+                "95.0" : 151432.6663895446,
+                "99.0" : 151433.70153933376,
+                "99.9" : 151433.70153933376,
+                "99.99" : 151433.70153933376,
+                "99.999" : 151433.70153933376,
+                "99.9999" : 151433.70153933376,
+                "100.0" : 151433.70153933376
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    151160.08108892027,
+                    148038.92231580763,
+                    151229.43005560656,
+                    151412.99854355058,
+                    151433.70153933376,
+                    149539.15133708864,
+                    148977.4465368942,
+                    151218.76358194093,
+                    149665.60617384114,
+                    149403.42136822245
+                ],
+                [
+                    145583.5594500126,
+                    146798.8630944471,
+                    146957.7447279461,
+                    146908.64280797087,
+                    146430.6643043809,
+                    146568.31794452047,
+                    144905.3653238443,
+                    147202.73173485158,
+                    146671.79506882833,
+                    145784.97486824988
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlEncodeBenchmark.kindlingsPerson",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 164461.51495929147,
+            "scoreError" : 624.3948202046977,
+            "scoreConfidence" : [
+                163837.12013908676,
+                165085.90977949617
+            ],
+            "scorePercentiles" : {
+                "0.0" : 162915.42394612468,
+                "50.0" : 164634.21877243096,
+                "90.0" : 165206.8724815414,
+                "95.0" : 165261.93927641129,
+                "99.0" : 165264.4161707353,
+                "99.9" : 165264.4161707353,
+                "99.99" : 165264.4161707353,
+                "99.999" : 165264.4161707353,
+                "99.9999" : 165264.4161707353,
+                "100.0" : 165264.4161707353
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    165129.51588816388,
+                    162919.57060290224,
+                    165134.8202571191,
+                    164516.26223143574,
+                    163371.32329623232,
+                    162915.42394612468,
+                    164514.28623015774,
+                    165264.4161707353,
+                    164897.3276209498,
+                    164919.28131880105
+                ],
+                [
+                    165214.87828425498,
+                    164619.57517216823,
+                    164194.87058046059,
+                    164760.20570042988,
+                    164317.86704452062,
+                    164280.83548633257,
+                    163716.47599528663,
+                    165104.65413351113,
+                    164789.84685354846,
+                    164648.8623726937
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlEncodeBenchmark.kindlingsSimpleADT",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 2330393.756403197,
+            "scoreError" : 22692.89047747903,
+            "scoreConfidence" : [
+                2307700.865925718,
+                2353086.646880676
+            ],
+            "scorePercentiles" : {
+                "0.0" : 2275596.6767362207,
+                "50.0" : 2336888.1670291917,
+                "90.0" : 2358165.893708698,
+                "95.0" : 2362216.92679158,
+                "99.0" : 2362405.122549056,
+                "99.9" : 2362405.122549056,
+                "99.99" : 2362405.122549056,
+                "99.999" : 2362405.122549056,
+                "99.9999" : 2362405.122549056,
+                "100.0" : 2362405.122549056
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    2336474.4608467096,
+                    2275596.6767362207,
+                    2340550.388473467,
+                    2334500.6242737845,
+                    2297466.0289265346,
+                    2282245.5431654407,
+                    2337301.873211674,
+                    2332475.564620997,
+                    2319384.5837650914,
+                    2337368.417309937
+                ],
+                [
+                    2358641.2073995355,
+                    2353888.0704911603,
+                    2335740.385955049,
+                    2341588.20138631,
+                    2349632.2000154597,
+                    2346266.9541947464,
+                    2280420.8053102293,
+                    2332289.9273822736,
+                    2353638.0920502604,
+                    2362405.122549056
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    },
+    {
+        "jmhVersion" : "1.37",
+        "benchmark" : "hearth.kindlings.benchmarks.YamlEncodeBenchmark.kindlingsSimpleCC",
+        "mode" : "thrpt",
+        "threads" : 1,
+        "forks" : 2,
+        "jvm" : "/Users/dev/.sdkman/candidates/java/25.0.1-graalce/bin/java",
+        "jvmArgs" : [
+            "-XX:ThreadPriorityPolicy=1",
+            "-XX:+UnlockExperimentalVMOptions",
+            "-XX:+EnableJVMCIProduct",
+            "-XX:+EnableJVMCI",
+            "-XX:-UnlockExperimentalVMOptions"
+        ],
+        "jdkVersion" : "25.0.1",
+        "vmName" : "OpenJDK 64-Bit Server VM",
+        "vmVersion" : "25.0.1+8-jvmci-b01",
+        "warmupIterations" : 5,
+        "warmupTime" : "1 s",
+        "warmupBatchSize" : 1,
+        "measurementIterations" : 10,
+        "measurementTime" : "1 s",
+        "measurementBatchSize" : 1,
+        "primaryMetric" : {
+            "score" : 1424881.4885212702,
+            "scoreError" : 9816.953372249996,
+            "scoreConfidence" : [
+                1415064.5351490201,
+                1434698.4418935203
+            ],
+            "scorePercentiles" : {
+                "0.0" : 1404824.979660071,
+                "50.0" : 1426083.0108222687,
+                "90.0" : 1442700.68996202,
+                "95.0" : 1443537.5626653144,
+                "99.0" : 1443555.8092027511,
+                "99.9" : 1443555.8092027511,
+                "99.99" : 1443555.8092027511,
+                "99.999" : 1443555.8092027511,
+                "99.9999" : 1443555.8092027511,
+                "100.0" : 1443555.8092027511
+            },
+            "scoreUnit" : "ops/s",
+            "rawData" : [
+                [
+                    1427388.2577689113,
+                    1416026.4707462108,
+                    1430165.2037082866,
+                    1434487.0476626875,
+                    1404824.979660071,
+                    1435104.6413677386,
+                    1443555.8092027511,
+                    1443190.8784540165,
+                    1430289.4201834162,
+                    1438288.9935340502
+                ],
+                [
+                    1411135.0592854598,
+                    1424777.7638756258,
+                    1418926.039609238,
+                    1417489.5004190074,
+                    1409826.654109644,
+                    1416466.5620861903,
+                    1429953.2350562424,
+                    1411183.2189137067,
+                    1423931.51094797,
+                    1430618.5238341752
+                ]
+            ]
+        },
+        "secondaryMetrics" : {
+        }
+    }
+]
+
+

--- a/docs/research/benchmark-runs/2026-06-17-master/summary.md
+++ b/docs/research/benchmark-runs/2026-06-17-master/summary.md
@@ -1,0 +1,374 @@
+
+### AnonVsLambdaCodecReadBenchmark
+method                                              2.13         3
+anonSimpleCC                                       11.0M     10.9M
+factorySimpleCC                                    10.7M     10.3M
+
+### AnonVsLambdaCodecWriteBenchmark
+method                                              2.13         3
+anonSimpleCC                                       58.8M     64.6M
+factorySimpleCC                                    60.1M     65.1M
+
+### AnonVsLambdaCreationBenchmark
+method                                              2.13         3
+anonCodecCreation                                 335.5M    329.2M
+anonHashCreation                                  326.7M    328.9M
+anonShowCreation                                  329.0M    331.8M
+factoryCodecCreation                              844.0M    874.7M
+factoryHashCreation                               843.9M    862.0M
+factoryShowCreation                               996.6M      1.0B
+
+### AnonVsLambdaEncoderBenchmark
+method                                              2.13         3
+anonPerson                                          3.7M      3.7M
+anonSimpleCC                                       34.1M     31.5M
+factoryPerson                                       3.6M      3.8M
+factorySimpleCC                                    33.3M     32.0M
+
+### AnonVsLambdaFunctorBenchmark
+method                                              2.13         3
+anonMapSimpleCCBox                                273.6M    277.9M
+factoryMapSimpleCCBox                             273.3M    272.6M
+
+### AnonVsLambdaHashBenchmark
+method                                              2.13         3
+anonEqvPerson                                       3.7B      3.7B
+anonEqvSimpleCC                                     1.3B      1.3B
+anonHashPerson                                     16.5M     18.9M
+anonHashSimpleCC                                    3.7B      3.8B
+factoryEqvPerson                                    3.8B      3.7B
+factoryEqvSimpleCC                                  1.3B      1.3B
+factoryHashPerson                                  16.2M     18.4M
+factoryHashSimpleCC                                 3.8B      3.8B
+
+### AnonVsLambdaShowBenchmark
+method                                              2.13         3
+anonEvent                                           2.7M      2.8M
+anonPerson                                          3.0M      3.1M
+anonSimpleCC                                      124.7M    125.9M
+factoryEvent                                        2.8M      2.8M
+factoryPerson                                       3.1M      3.1M
+factorySimpleCC                                   125.6M    124.7M
+
+### AvroDecodeBenchmark
+method                                              2.13         3
+kindlingsEvent                                      8.5M      8.6M
+kindlingsPerson                                     9.8M      9.3M
+kindlingsSimpleADT                                168.0M    167.0M
+kindlingsSimpleCC                                 119.2M    127.2M
+originalAutoPerson                                  3.7M      4.4M
+originalAutoSimpleCC                               17.7M     83.9M
+originalSemiAutoPerson                                 —      3.1M
+originalSemiAutoSimpleCC                               —     26.0M
+
+### AvroEncodeBenchmark
+method                                              2.13         3
+kindlingsEvent                                     17.4M     18.0M
+kindlingsPerson                                    19.5M     19.1M
+kindlingsSimpleADT                                364.3M    378.5M
+kindlingsSimpleCC                                 272.5M    277.4M
+originalAutoPerson                                  4.5M      5.8M
+originalAutoSimpleCC                               44.6M     50.5M
+originalSemiAutoPerson                                 —      5.8M
+originalSemiAutoSimpleCC                               —     48.7M
+
+### CatsEmptyBenchmark
+method                                              2.13         3
+kindlingsEmpty                                      1.6B      1.8B
+originalSemiAutoEmpty                               1.6B      1.1B
+
+### CatsEqBenchmark
+method                                              2.13         3
+kindlingsSimpleCCEqual                            100.2M    102.3M
+kindlingsSimpleCCNotEqual                         549.8M    561.4M
+originalAutoSimpleCCEqual                          45.5M     92.2M
+originalSemiAutoSimpleCCEqual                      46.1M     86.5M
+
+### CatsFoldableBenchmark
+method                                              2.13         3
+kindlingsSimpleCCBoxFoldLeft                        1.6B      1.6B
+
+### CatsFoldableKittensBenchmark
+method                                              2.13         3
+kittensFoldLeft                                        —    109.6M
+
+### CatsFunctorBenchmark
+method                                              2.13         3
+kindlingsSimpleCCBoxMap                           277.3M    275.9M
+originalSemiAutoSimpleCCBoxMap                      5.7M     65.2M
+
+### CatsHashBenchmark
+method                                              2.13         3
+kindlingsSimpleCC                                 824.9M    828.3M
+originalAutoSimpleCC                               27.4M    108.3M
+originalSemiAutoSimpleCC                           27.2M    110.0M
+
+### CatsMonoidBenchmark
+method                                              2.13         3
+kindlingsCombine                                  192.8M    193.9M
+kindlingsEmpty                                      3.6B      3.7B
+originalSemiAutoCombine                            49.0M    119.5M
+originalSemiAutoEmpty                               1.7B      1.0B
+
+### CatsOrderBenchmark
+method                                              2.13         3
+kindlingsSimpleCCCompare                          424.8M    429.7M
+originalAutoSimpleCCCompare                       387.8M    347.6M
+originalSemiAutoSimpleCCCompare                   389.7M    313.9M
+
+### CatsSemigroupBenchmark
+method                                              2.13         3
+kindlingsCombine                                  194.1M    193.6M
+originalSemiAutoCombine                            54.3M    146.3M
+
+### CatsShowBenchmark
+method                                              2.13         3
+kindlingsEvent                                      1.9M      1.5M
+kindlingsPerson                                     2.0M      1.6M
+kindlingsSimpleADT                                 86.0M     72.8M
+kindlingsSimpleCC                                  38.2M     27.2M
+originalAutoEvent                                   620K      1.2M
+originalAutoPerson                                  804K      1.4M
+originalAutoSimpleADT                              10.4M     52.8M
+originalAutoSimpleCC                                7.0M     19.9M
+originalSemiAutoEvent                               602K      535K
+originalSemiAutoSimpleADT                          16.2M     51.9M
+originalSemiAutoSimpleCC                            7.5M     19.6M
+
+### CatsShowPrettyBenchmark
+method                                              2.13         3
+kindlingsFastShowPrettyPerson                       1.2M      1.3M
+kindlingsFastShowPrettySimpleCC                    13.5M     18.0M
+kindlingsShowPerson                                 2.0M      1.7M
+kindlingsShowPrettyPerson                           1.9M      1.8M
+kindlingsShowPrettySimpleCC                        34.4M     34.3M
+kindlingsShowSimpleCC                              39.1M     27.0M
+
+### CatsShowPrettyKittensBenchmark
+method                                              2.13         3
+kittensShowPrettyPerson                                —      557K
+kittensShowPrettySimpleCC                              —      5.4M
+
+### CatsTraverseBenchmark
+method                                              2.13         3
+kindlingsSimpleCCBoxTraverse                      170.8M    164.2M
+
+### CatsTraverseKittensBenchmark
+method                                              2.13         3
+kittensTraverse                                        —     18.7M
+
+### CirceBoosterDecodeBenchmark
+method                                              2.13         3
+kindlingsBoosterEvent                               1.0M      996K
+kindlingsBoosterPerson                              1.3M      1.3M
+kindlingsBoosterSimpleADT                          11.2M     10.9M
+kindlingsBoosterSimpleCC                            9.3M      8.8M
+kindlingsNoBoosterEvent                             736K      836K
+kindlingsNoBoosterPerson                            918K      1.1M
+kindlingsNoBoosterSimpleADT                         8.7M      9.8M
+kindlingsNoBoosterSimpleCC                          6.1M      7.1M
+originalBoosterEvent                                906K      825K
+originalBoosterPerson                               1.1M      1.0M
+originalBoosterSimpleADT                            9.1M      9.2M
+originalBoosterSimpleCC                             8.1M      6.6M
+originalNoBoosterEvent                              724K      703K
+originalNoBoosterPerson                             879K      874K
+originalNoBoosterSimpleADT                          7.4M      8.5M
+originalNoBoosterSimpleCC                           5.9M      5.9M
+
+### CirceBoosterEncodeBenchmark
+method                                              2.13         3
+kindlingsBoosterEvent                               1.3M      1.4M
+kindlingsBoosterPerson                              1.6M      1.7M
+kindlingsBoosterSimpleADT                          14.3M     15.6M
+kindlingsBoosterSimpleCC                           13.9M     15.5M
+kindlingsNoBoosterEvent                             831K      939K
+kindlingsNoBoosterPerson                            985K      1.1M
+kindlingsNoBoosterSimpleADT                         7.8M      8.1M
+kindlingsNoBoosterSimpleCC                          6.8M      7.2M
+originalBoosterEvent                                1.1M      1.2M
+originalBoosterPerson                               1.4M      1.5M
+originalBoosterSimpleADT                            8.1M     11.7M
+originalBoosterSimpleCC                            10.5M     12.0M
+originalNoBoosterEvent                              764K      805K
+originalNoBoosterPerson                             882K      964K
+originalNoBoosterSimpleADT                          5.9M      6.9M
+originalNoBoosterSimpleCC                           5.4M      6.7M
+
+### CirceDecodeBenchmark
+method                                              2.13         3
+kindlingsAutoEvent                                  3.5M      3.3M
+kindlingsAutoPerson                                 5.3M      5.4M
+kindlingsAutoSimpleADT                             55.9M     54.6M
+kindlingsAutoSimpleCC                              93.2M     92.1M
+kindlingsSemiAutoEvent                              3.3M      3.5M
+kindlingsSemiAutoPerson                             5.4M      5.5M
+kindlingsSemiAutoSimpleADT                         56.3M     58.3M
+kindlingsSemiAutoSimpleCC                          88.3M     91.9M
+originalAutoEvent                                   2.7M      2.2M
+originalAutoPerson                                  3.6M      2.6M
+originalAutoSimpleADT                              25.7M     28.0M
+originalAutoSimpleCC                               42.6M     21.2M
+originalSemiAutoEvent                               2.7M      2.1M
+originalSemiAutoPerson                              3.5M      2.7M
+originalSemiAutoSimpleADT                          25.0M     27.9M
+originalSemiAutoSimpleCC                           42.0M     20.5M
+
+### CirceEncodeBenchmark
+method                                              2.13         3
+kindlingsAutoEvent                                  3.4M      3.4M
+kindlingsAutoPerson                                 4.5M      4.5M
+kindlingsAutoSimpleADT                             27.1M     25.7M
+kindlingsAutoSimpleCC                              30.9M     31.2M
+kindlingsSemiAutoEvent                              3.4M      3.3M
+kindlingsSemiAutoPerson                             4.5M      4.4M
+kindlingsSemiAutoSimpleADT                         27.5M     26.8M
+kindlingsSemiAutoSimpleCC                          30.3M     31.2M
+originalAutoEvent                                   2.4M      2.3M
+originalAutoPerson                                  3.1M      3.2M
+originalAutoSimpleADT                              13.9M     27.1M
+originalAutoSimpleCC                               19.0M     20.9M
+originalSemiAutoEvent                               2.3M      2.4M
+originalSemiAutoPerson                              3.0M      3.1M
+originalSemiAutoSimpleADT                          13.4M     26.6M
+originalSemiAutoSimpleCC                           18.8M     21.8M
+
+### FastShowPrettyBenchmark
+method                                              2.13         3
+kindlingsEvent                                      854K      972K
+kindlingsPerson                                     1.2M      1.3M
+kindlingsSimpleADT                                 15.6M     14.6M
+kindlingsSimpleCC                                  13.5M     17.9M
+
+### JsoniterReadBenchmark
+method                                              2.13         3
+kindlingsAutoEvent                                  3.3M      3.3M
+kindlingsAutoPerson                                 3.6M      3.7M
+kindlingsAutoSimpleADT                             16.8M     15.7M
+kindlingsAutoSimpleCC                              35.8M     36.4M
+kindlingsSemiAutoEvent                              3.3M      3.3M
+kindlingsSemiAutoPerson                             3.6M      3.6M
+kindlingsSemiAutoSimpleADT                         15.5M     15.8M
+kindlingsSemiAutoSimpleCC                          36.4M     36.4M
+originalSemiAutoPerson                              3.8M      3.8M
+originalSemiAutoSimpleCC                           35.5M     35.1M
+
+### JsoniterWriteBenchmark
+method                                              2.13         3
+kindlingsAutoEvent                                  4.5M      4.8M
+kindlingsAutoPerson                                 4.7M      5.4M
+kindlingsAutoSimpleADT                             62.7M     65.7M
+kindlingsAutoSimpleCC                              59.3M     63.9M
+kindlingsSemiAutoEvent                              4.5M      4.8M
+kindlingsSemiAutoPerson                             4.8M      5.5M
+kindlingsSemiAutoSimpleADT                         62.2M     65.9M
+kindlingsSemiAutoSimpleCC                          61.1M     63.6M
+originalSemiAutoEvent                               4.3M      4.9M
+originalSemiAutoPerson                              4.7M      5.4M
+originalSemiAutoSimpleADT                          69.2M     71.9M
+originalSemiAutoSimpleCC                           60.8M     63.8M
+
+### OpticsBenchmark
+method                                              2.13         3
+handWrittenDeepName                                98.8M     93.2M
+handWrittenEachSalary                              21.4M     21.9M
+kindlingsDeepName                                  99.0M     99.2M
+kindlingsEachSalary                                21.8M     21.2M
+quicklensDeepName                                  98.7M     99.1M
+quicklensEachSalary                                20.1M     20.8M
+
+### PureconfigReadBenchmark
+method                                              2.13         3
+kindlingsPerson                                     1.0M      1.0M
+kindlingsSimpleCC                                  17.2M     17.2M
+originalSemiAutoPerson                              216K      197K
+originalSemiAutoSimpleCC                            1.4M      1.4M
+
+### PureconfigWriteBenchmark
+method                                              2.13         3
+kindlingsPerson                                     1.2M      1.2M
+kindlingsSimpleCC                                  11.0M     11.1M
+originalSemiAutoPerson                              205K      248K
+originalSemiAutoSimpleCC                            1.2M      1.7M
+
+### ScalacheckArbitraryBenchmark
+method                                              2.13         3
+kindlingsPerson                                       4K        4K
+kindlingsSimpleADT                                  1.9M      1.9M
+kindlingsSimpleCC                                   779K      741K
+
+### ScalacheckShrinkBenchmark
+method                                              2.13         3
+kindlingsPerson                                     5.8M      5.2M
+kindlingsSimpleCC                                   5.8M      6.9M
+
+### SconfigReadBenchmark
+method                                              2.13         3
+kindlingsEvent                                      2.6M      2.8M
+kindlingsPerson                                     5.0M      4.7M
+kindlingsSimpleADT                                 12.0M     11.8M
+kindlingsSimpleCC                                  72.4M     60.9M
+
+### SconfigWriteBenchmark
+method                                              2.13         3
+kindlingsEvent                                      630K      648K
+kindlingsPerson                                     1.2M      1.3M
+kindlingsSimpleADT                                  5.2M      6.3M
+kindlingsSimpleCC                                  10.9M     10.9M
+
+### TapirOpenApiJsoniterBenchmark
+method                                              2.13         3
+circeDecode                                          12K        5K
+circeEncode                                          24K       24K
+kindlingsDecode                                      26K       21K
+kindlingsEncode                                      70K       56K
+
+### TapirSchemaBenchmark
+method                                              2.13         3
+kindlingsEvent                                      3.9B      3.8B
+kindlingsPerson                                     3.9B      3.8B
+kindlingsSimpleCC                                   3.8B      3.8B
+originalAutoEvent                                   3.8B      3.8B
+originalAutoPerson                                  3.8B      3.8B
+originalAutoSimpleCC                                3.8B      3.8B
+originalSemiAutoEvent                               3.8B      3.8B
+originalSemiAutoPerson                              3.8B      3.7B
+originalSemiAutoSimpleCC                            3.8B      3.8B
+
+### UbjsonReadBenchmark
+method                                              2.13         3
+kindlingsEvent                                      1.3M      1.2M
+kindlingsPerson                                     1.4M      1.4M
+kindlingsSimpleADT                                 13.8M     13.6M
+kindlingsSimpleCC                                  11.3M     10.4M
+
+### UbjsonWriteBenchmark
+method                                              2.13         3
+kindlingsEvent                                      1.3M      1.2M
+kindlingsPerson                                     1.4M      1.4M
+kindlingsSimpleADT                                 13.4M     13.2M
+kindlingsSimpleCC                                  11.2M     11.0M
+
+### XmlDecodeBenchmark
+method                                              2.13         3
+kindlingsAddress                                    3.2M      3.4M
+kindlingsSimpleCC                                   4.8M      5.0M
+
+### XmlEncodeBenchmark
+method                                              2.13         3
+kindlingsAddress                                   38.6M     38.8M
+kindlingsSimpleCC                                  46.2M     45.2M
+
+### YamlDecodeBenchmark
+method                                              2.13         3
+kindlingsEvent                                      721K      629K
+kindlingsPerson                                     774K      763K
+kindlingsSimpleADT                                 98.6M    104.1M
+kindlingsSimpleCC                                   9.4M      7.0M
+
+### YamlEncodeBenchmark
+method                                              2.13         3
+kindlingsEvent                                      136K      148K
+kindlingsPerson                                     147K      164K
+kindlingsSimpleADT                                  2.2M      2.3M
+kindlingsSimpleCC                                   1.4M      1.4M

--- a/docs/research/either-fold-owner-conflict.md
+++ b/docs/research/either-fold-owner-conflict.md
@@ -1,0 +1,66 @@
+# `buildEitherFailFast` + nested-case-class field → "Block contains definitions with different owners"
+
+## Status
+
+Open. Blocks adopting the zero-allocation fail-fast field construction
+(`derivation-commons` `EitherFieldsConstruct.buildEitherFailFast`) in **pureconfig**. circe and
+yaml adopt it fine; pureconfig is left on the legacy `List` + `sequenceResults` path.
+
+## What works vs. what fails
+
+`buildEitherFailFast` combines N per-field `Either[E, _]` results into the constructor via nested
+`IsEither.fold` (zero-closure `match` on Hearth ≥ 0.3.1-51), binding each field result to a local
+`val` first:
+
+```scala
+val r0 = <decode field 0>           // Either[E, Any]
+r0 match {
+  case Right(v0) =>
+    val r1 = <decode field 1>
+    r1 match { case Right(v1) => Right(new A(v0, v1, …)); case Left(e) => Left(e) }
+  case Left(e) => Left(e)
+}
+```
+
+- **circe / yaml** — field decoders return an `Either` directly
+  (`cursor.downField(name).as(decoder)`, `node.as[Field]`). The scrutinee `rN` is a clean value.
+  Works on Scala 2.13 + 3.
+- **pureconfig** — field decoders wrap the result in a `flatMap` lambda:
+  `cur.asObjectCursor.flatMap(obj => readRequiredFieldWithSuggestions(obj, "address", reader))`.
+  When that expression is bound to `val rN` and matched on inside the nested fold, Scala 3 aborts:
+
+  ```
+  assertion failed: Block contains definitions with different owners.
+  Found definitions 2 distinct owners: method $anonfun, val macro
+  Block: {
+    val either$macro$7: Either[ConfigReaderFailures, Any] = {
+      val cur: ConfigCursor = configcursor$macro$4
+      cur.asObjectCursor.flatMap((obj: ConfigObjectCursor) => …readRequiredField…)
+    }
+    (either$macro$7 …) match { … }
+  }
+  ```
+
+  The `flatMap` lambda's internal definitions keep their `$anonfun` owner while the surrounding
+  `val`/match binders are owned by `val macro`; the two land in one `Block` and the owner-consistency
+  assertion fires. Binding to a `val` (as above) did **not** help — the lambda is inside the val RHS.
+
+## Reproducer
+
+`pureconfig-derivation` test `KindlingsConfigConvertSpec` →
+`KindlingsConfigConvert.derived[PersonWithAddress]` (a case class with a **direct** nested
+case-class field `address: Address`). Re-apply `EitherFieldsConstruct.buildEitherFailFast` to
+`ReaderHandleAsCaseClassRule` (see the circe/yaml wiring for the shape) and the derivation fails to
+compile on Scala 3 with the assertion above. Collections/maps of nested case classes are fine —
+only a *direct* nested case-class field whose decoder introduces a lambda triggers it.
+
+## Hypotheses / next steps
+
+- Likely a tree-owner-fixup gap when a `MatchCase` scrutinee (or a `ValDefs.createVal` RHS) contains
+  a lambda with its own definitions — candidate Hearth fix in `MatchCase` / `ValDefs` owner handling
+  (consistent with "fix it in Hearth"). Minimal Hearth-level repro still TODO.
+- Alternative kindlings-side shapes to try: normalize the field-decode expr so the lambda is hoisted
+  to its own cached `def` (no inline lambda in the scrutinee); or special-case direct nested
+  case-class fields to a non-`MatchCase` construction.
+
+Until resolved, pureconfig keeps the `List`+`sequenceResults`+`Array[Any]` construction.

--- a/docs/research/either-fold-owner-conflict.md
+++ b/docs/research/either-fold-owner-conflict.md
@@ -2,15 +2,14 @@
 
 ## Status
 
-Open. Blocks adopting the zero-allocation fail-fast field construction
-(`derivation-commons` `EitherFieldsConstruct.buildEitherFailFast`) in **pureconfig**. circe and
-yaml adopt it fine; pureconfig is left on the legacy `List` + `sequenceResults` path.
+**Resolved** in Hearth `0.3.1-52` (`MatchCase.matchOn` now re-owns case bodies). All of
+`derivation-commons`' `EitherFieldsConstruct.buildEitherFailFast` adopters — circe, yaml, **and
+pureconfig** — now compile the zero-allocation fail-fast construction on Scala 2.13 + 3.
 
-## What works vs. what fails
+## Symptom
 
 `buildEitherFailFast` combines N per-field `Either[E, _]` results into the constructor via nested
-`IsEither.fold` (zero-closure `match` on Hearth ≥ 0.3.1-51), binding each field result to a local
-`val` first:
+`IsEither.fold` (zero-closure `match`), binding each field result to a local `val` first:
 
 ```scala
 val r0 = <decode field 0>           // Either[E, Any]
@@ -22,45 +21,32 @@ r0 match {
 }
 ```
 
-- **circe / yaml** — field decoders return an `Either` directly
-  (`cursor.downField(name).as(decoder)`, `node.as[Field]`). The scrutinee `rN` is a clean value.
-  Works on Scala 2.13 + 3.
-- **pureconfig** — field decoders wrap the result in a `flatMap` lambda:
-  `cur.asObjectCursor.flatMap(obj => readRequiredFieldWithSuggestions(obj, "address", reader))`.
-  When that expression is bound to `val rN` and matched on inside the nested fold, Scala 3 aborts:
+circe/yaml field decoders return an `Either` directly (`cursor.downField(name).as(decoder)`,
+`node.as[Field]`) — they worked from the start. **pureconfig** field decoders wrap the result in an
+inline `flatMap` lambda (`cur.asObjectCursor.flatMap(obj => readRequiredField(obj, key, reader))`).
+Deriving `KindlingsConfigConvert.derived[PersonWithAddress]` (a case class with a **direct** nested
+case-class field `address: Address`) then aborted on Scala 3:
 
-  ```
-  assertion failed: Block contains definitions with different owners.
-  Found definitions 2 distinct owners: method $anonfun, val macro
-  Block: {
-    val either$macro$7: Either[ConfigReaderFailures, Any] = {
-      val cur: ConfigCursor = configcursor$macro$4
-      cur.asObjectCursor.flatMap((obj: ConfigObjectCursor) => …readRequiredField…)
-    }
-    (either$macro$7 …) match { … }
-  }
-  ```
+```
+assertion failed: Block contains definitions with different owners.
+Found definitions 2 distinct owners: method $anonfun, val macro
+```
 
-  The `flatMap` lambda's internal definitions keep their `$anonfun` owner while the surrounding
-  `val`/match binders are owned by `val macro`; the two land in one `Block` and the owner-consistency
-  assertion fires. Binding to a `val` (as above) did **not** help — the lambda is inside the val RHS.
+## Root cause
 
-## Reproducer
+`MatchCase.matchOn` (Scala 3, `ExprsScala3.scala`) changed the **scrutinee** owner to
+`Symbol.spliceOwner` but left the **case bodies** (`stripInlined(result.asTerm)`) untouched. A body
+that nests definitions built in another context — here a `ValDefs.createVal` whose value contains the
+field decoder's inline `flatMap` lambda — kept stale owners, so the spliced `CaseDef` body mixed
+`$anonfun`- and `val macro`-owned definitions in one `Block`.
 
-`pureconfig-derivation` test `KindlingsConfigConvertSpec` →
-`KindlingsConfigConvert.derived[PersonWithAddress]` (a case class with a **direct** nested
-case-class field `address: Address`). Re-apply `EitherFieldsConstruct.buildEitherFailFast` to
-`ReaderHandleAsCaseClassRule` (see the circe/yaml wiring for the shape) and the derivation fails to
-compile on Scala 3 with the assertion above. Collections/maps of nested case classes are fine —
-only a *direct* nested case-class field whose decoder introduces a lambda triggers it.
+## Fix
 
-## Hypotheses / next steps
+Re-own each case body to the splice owner, matching the scrutinee:
 
-- Likely a tree-owner-fixup gap when a `MatchCase` scrutinee (or a `ValDefs.createVal` RHS) contains
-  a lambda with its own definitions — candidate Hearth fix in `MatchCase` / `ValDefs` owner handling
-  (consistent with "fix it in Hearth"). Minimal Hearth-level repro still TODO.
-- Alternative kindlings-side shapes to try: normalize the field-decode expr so the lambda is hoisted
-  to its own cached `def` (no inline lambda in the scrutinee); or special-case direct nested
-  case-class fields to a non-`MatchCase` construction.
+```scala
+stripInlined(result.asTerm).changeOwner(Symbol.spliceOwner)
+```
 
-Until resolved, pureconfig keeps the `List`+`sequenceResults`+`Array[Any]` construction.
+Hearth commit on branch `foreach-zero-closure-default`; full macro suite green (1152 2.13 + 1280 3 +
+sandwich). kindlings bumped to `0.3.1-52`; pureconfig 148 (3) + 133 (2.13), circe 419, yaml 248 green.

--- a/docs/research/macro-expansion-profile-0.3.1-52.md
+++ b/docs/research/macro-expansion-profile-0.3.1-52.md
@@ -1,0 +1,54 @@
+# Macro-expansion profile — jsoniter derivation, Hearth 0.3.1-52
+
+Aggregated from the 344 per-derivation `.speedscope.json` flame graphs emitted by
+`jsoniterDerivation3/Test/compile` (`-Xmacro-settings:hearth.mioBenchmarkScopes=true`). Self-time =
+time a scope is on top of the MIO stack (excludes nested derivations). Total wall ≈ 11.1s across 344
+derivations (~32 ms each).
+
+## Top scopes by self-time (% of total wall)
+
+| scope | self ms | % |
+|---|---:|---:|
+| decoder rule: handle as case class | 698 | 6.3 |
+| **encoder rule: handle as map** | **670** | **6.0** |
+| **decoder rule: handle as map** | **538** | **4.8** |
+| encoder rule: handle as case class | 451 | 4.0 |
+| encoder rule: handle as collection | 434 | 3.9 |
+| decoder rule: handle as collection | 422 | 3.8 |
+| encoder rule: handle as Option | 302 | 2.7 |
+| encoder rule: use implicit when available | 261 | 2.3 |
+| encoder/decoder: handle as enum | 165 / 135 | 1.5 / 1.2 |
+| encoder/decoder: handle as value type | 150 / 133 | 1.3 / 1.2 |
+| encoder/decoder: handle as built-in | 105 / 88 | 0.9 / 0.8 |
+
+Almost all the cost is **rule applicability evaluation** (the `IsX` checks run on every field of every
+type until one matches), not the actual code generation (`Deriving …` scopes are <1% each).
+
+## Key opportunity: the map rule double-parses `IsCollection`
+
+`IsMap.parse` is implemented as `IsCollection.parse` + an `isInstanceOf[IsMapOf]` check. The map rule
+runs **before** the collection rule (required — `Map <: Iterable`). So for any field that is **not** a
+map, the chain pays:
+
+1. map rule → `IsMap.unapply` → **full `IsCollection.parse`** (iterates every collection provider,
+   doing `=:=`/`baseType` type matching) → not a map → yields;
+2. collection rule → **`IsCollection.parse` again**.
+
+`IsCollection.parse` is the expensive part (provider iteration + compiler-reflection type matching),
+and it runs twice for every non-map field — which is most fields. This is consistent with the map
+rule's outsized self-time (≈11% combined) despite few map-typed fields in the suite.
+
+### Candidate fixes
+
+- **Merge "handle as map" + "handle as collection" into one rule** that calls `IsCollection.parse`
+  once and dispatches on `IsMapOf` vs plain `IsCollectionOf`. Halves the `IsCollection.parse` calls
+  for every collection/non-collection field. Multi-module (jsoniter, circe, yaml, pureconfig, avro,
+  …) but mechanical, and the `IsMap`-before-`IsCollection` ordering is preserved (it becomes a single
+  match arm order). Reusable shape could live in `derivation-commons`.
+- **Reusable Hearth angle:** `IsMap`/`IsCollection` could expose a combined parse so a caller learns
+  "collection, and here's whether it's a map" in one pass. Memoizing parse results by type is *not*
+  viable (compiler types lack stable `hashCode`/`equals`, per prior research).
+
+Memoization of type comparisons remains the irreducible floor; the double-parse is the one clearly
+removable redundancy. Runtime codegen is already at/above parity with best-in-class libraries (see the
+0.3.1-52 ratio scan), so compile-time is where the remaining macro headroom is.

--- a/docs/research/macro-expansion-profile-0.3.1-52.md
+++ b/docs/research/macro-expansion-profile-0.3.1-52.md
@@ -52,3 +52,20 @@ rule's outsized self-time (≈11% combined) despite few map-typed fields in the 
 Memoization of type comparisons remains the irreducible floor; the double-parse is the one clearly
 removable redundancy. Runtime codegen is already at/above parity with best-in-class libraries (see the
 0.3.1-52 ratio scan), so compile-time is where the remaining macro headroom is.
+
+## Implemented (jsoniter, Hearth 0.3.1-53)
+
+- Hearth: added `IsCollectionOf.asMap: Option[IsMapOf[CollA, Item]]` (default `None`, `Some(this)` in
+  `IsMapOf`) so a held `IsCollectionOf` reveals map-ness without re-parsing or an erasure-unsound
+  `isInstanceOf`. `IsMap.parse` uses it.
+- jsoniter: merged the map rule into the collection rule — `case IsCollection(c) => c.value.asMap match
+  { case Some(m) => deriveMapEntries(m); case None => …collection… }`. The standalone map rule is out of
+  the encoder/decoder chains (its object kept for `deriveMapEntries` / `deriveKeyEncoding`). Every
+  non-map field now parses `IsCollection` once instead of twice. 340 (3) + 324 (2.13) green; generated
+  code (and runtime) unchanged.
+
+**Measurement caveat:** the macro-compile wall-time delta is **within shared-machine noise** — runs
+on the (concurrently loaded) dev box bounced 11.1s ↔ 7.7s ↔ 11.0s regardless of the change. The win is
+*structural* (provably one fewer `IsCollection.parse` per non-map field + one fewer rule traversal),
+not a measured wall-time number; a clean magnitude needs a low-load/controlled run. Rollout to the
+other modules (circe, yaml, pureconfig, avro, …) is the same mechanical change.

--- a/docs/user-guide/avro-derivation.md
+++ b/docs/user-guide/avro-derivation.md
@@ -363,24 +363,24 @@ This enables `LogDerivation` implicits for `AvroSchemaFor`, `AvroEncoder`, and `
 All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
 
 !!! note
-    Kindlings is **1.5-6.5x faster** than avro4s across all benchmarks — both simple and complex nested types.
+    Kindlings is **1.5-6.7x faster** than avro4s across all benchmarks — both simple and complex nested types.
 
 #### Encode
 
 | Type | Scala | Kindlings | Original semi | Original auto | vs best original |
 |------|-------|-----------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 270M | — | 41.4M | **6.5x faster** |
-| SimpleCC | 3 | 263M | 40.3M | 45.2M | **5.8x faster** |
-| Person | 2.13 | 19.6M | — | 4.5M | **4.3x faster** |
-| Person | 3 | 19.2M | 5.5M | 5.5M | **3.5x faster** |
+| SimpleCC | 2.13 | 272M | — | 44.6M | **6.1x faster** |
+| SimpleCC | 3 | 277M | 48.7M | 50.5M | **5.5x faster** |
+| Person | 2.13 | 19.5M | — | 4.5M | **4.3x faster** |
+| Person | 3 | 19.1M | 5.8M | 5.8M | **3.3x faster** |
 
 #### Decode
 
 | Type | Scala | Kindlings | Original semi | Original auto | vs best original |
 |------|-------|-----------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 56.7M | — | 16.0M | **3.5x faster** |
-| SimpleCC | 3 | 61.0M | 27.8M | 42.0M | **1.5x faster** |
-| Person | 2.13 | 6.3M | — | 3.6M | **1.7x faster** |
-| Person | 3 | 6.8M | 3.0M | 4.1M | **1.7x faster** |
+| SimpleCC | 2.13 | 119M | — | 17.7M | **6.7x faster** |
+| SimpleCC | 3 | 127M | 26.0M | 83.9M | **1.5x faster** |
+| Person | 2.13 | 9.8M | — | 3.7M | **2.6x faster** |
+| Person | 3 | 9.3M | 3.1M | 4.4M | **2.1x faster** |
 
 Note: Kindlings semi-automatic and automatic derivation produce identical performance -- this is the "sanely-automatic" design.

--- a/docs/user-guide/cats-derivation.md
+++ b/docs/user-guide/cats-derivation.md
@@ -320,65 +320,65 @@ All values in ops/s (higher is better). Measured on macOS, JVM temurin 17, 2 for
 
 | Type | Scala | Kindlings | kittens semi | kittens auto | vs best kittens |
 |------|-------|-----------|-------------|-------------|-----------------|
-| SimpleCC | 2.13 | 48.1M | 18.0M | 17.6M | **2.7x faster** |
-| SimpleCC | 3 | 47.8M | 14.3M | 12.3M | **3.3x faster** |
-| SimpleADT | 2.13 | 166M | 30.0M | 17.2M | **5.5x faster** |
-| SimpleADT | 3 | 97.6M | 34.1M | 35.0M | **2.8x faster** |
-| Person | 2.13 | 2.3M | — | 1.4M | **1.7x faster** |
-| Person | 3 | 1.8M | — | 1.5M | **1.2x faster** |
-| Event | 2.13 | 2.1M | 1.2M | 1.1M | **1.8x faster** |
-| Event | 3 | 1.9M | 567.5K | 1.3M | **1.5x faster** |
+| SimpleCC | 2.13 | 38.2M | 7.5M | 7.0M | **5.1x faster** |
+| SimpleCC | 3 | 27.2M | 19.6M | 19.9M | **1.4x faster** |
+| SimpleADT | 2.13 | 86.0M | 16.2M | 10.4M | **5.3x faster** |
+| SimpleADT | 3 | 72.8M | 51.9M | 52.8M | **1.4x faster** |
+| Person | 2.13 | 2.0M | — | 804K | **2.5x faster** |
+| Person | 3 | 1.6M | — | 1.4M | **1.1x faster** |
+| Event | 2.13 | 1.9M | 602K | 620K | **3.1x faster** |
+| Event | 3 | 1.5M | 535K | 1.2M | **1.3x faster** |
 
 #### Eq
 
 | Type | Scala | Kindlings | kittens best | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| SimpleCC (eq) | 2.13 | 97.4M | 46.0M | **2.1x faster** |
-| SimpleCC (eq) | 3 | 83.2M | 85.3M | **~tied** |
+| SimpleCC (eq) | 2.13 | 100.2M | 46.1M | **2.2x faster** |
+| SimpleCC (eq) | 3 | 102.3M | 92.2M | **1.1x faster** |
 
 #### Hash
 
 | Type | Scala | Kindlings | kittens best | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| SimpleCC | 2.13 | 264M | 37.4M | **7.1x faster** |
-| SimpleCC | 3 | 234M | 53.4M | **4.4x faster** |
+| SimpleCC | 2.13 | 824.9M | 27.4M | **30.1x faster** |
+| SimpleCC | 3 | 828.3M | 110.0M | **7.5x faster** |
 
 #### Order
 
 | Type | Scala | Kindlings | kittens best | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| SimpleCC | 2.13 | 451M | 72.0M | **6.3x faster** |
-| SimpleCC | 3 | 415M | 329M | **1.3x faster** |
+| SimpleCC | 2.13 | 424.8M | 389.7M | **1.1x faster** |
+| SimpleCC | 3 | 429.7M | 347.6M | **1.2x faster** |
 
 #### Semigroup
 
 | Type | Scala | Kindlings | kittens semi | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| IntPair | 2.13 | 508M | 71.6M | **7.1x faster** |
-| IntPair | 3 | 154M | 102M | **1.5x faster** |
+| IntPair | 2.13 | 194.1M | 54.3M | **3.6x faster** |
+| IntPair | 3 | 193.6M | 146.3M | **1.3x faster** |
 
 #### Monoid
 
 | Type | Scala | Kindlings | kittens semi | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| IntPair (combine) | 2.13 | 561M | 72.9M | **7.7x faster** |
-| IntPair (combine) | 3 | 155M | 101M | **1.5x faster** |
-| IntPair (empty) | 2.13 | 1896M | 1659M | **1.14x faster** |
-| IntPair (empty) | 3 | 2077M | 603M | **3.4x faster** |
+| IntPair (combine) | 2.13 | 192.8M | 49.0M | **3.9x faster** |
+| IntPair (combine) | 3 | 193.9M | 119.5M | **1.6x faster** |
+| IntPair (empty) | 2.13 | 3.6B | 1.7B | **2.1x faster** |
+| IntPair (empty) | 3 | 3.7B | 1.0B | **3.7x faster** |
 
 #### Functor
 
 | Type | Scala | Kindlings | kittens semi | vs kittens |
 |------|-------|-----------|-------------|-----------|
-| SimpleCCBox (map) | 2.13 | 205M | 4.4M | **47x faster** |
-| SimpleCCBox (map) | 3 | 238M | 84.9M | **2.8x faster** |
+| SimpleCCBox (map) | 2.13 | 277.3M | 5.7M | **49x faster** |
+| SimpleCCBox (map) | 3 | 275.9M | 65.2M | **4.2x faster** |
 
 #### Foldable / Traverse (Scala 3 only — kittens Scala 2 doesn't support these)
 
 | Type class | Kindlings | kittens semi | vs kittens |
 |-----------|-----------|-------------|-----------|
-| Foldable (foldLeft) | 1006M | 120M | **8.4x faster** |
-| Traverse (traverse) | 123M | 24.2M | **5.1x faster** |
+| Foldable (foldLeft) | 1.6B | 109.6M | **14.6x faster** |
+| Traverse (traverse) | 164.2M | 18.7M | **8.8x faster** |
 
 #### Show vs ShowPretty vs FastShowPretty
 
@@ -386,11 +386,11 @@ Pretty printing introduces indentation and multi-line output. The table below co
 
 | Approach | SimpleCC | Person | Notes |
 |----------|----------|--------|-------|
-| Kindlings Show | 49.0M | 2.0M | Plain single-line output |
-| Kindlings ShowPretty | 50.0M | 2.1M | Multi-line indented, ~0% overhead vs Show |
-| kittens ShowPretty | 6.2M | 644.7K | List[String] line accumulation |
-| Kindlings FastShowPretty | 27.3M | 1.4M | StringBuilder + escaped strings |
+| Kindlings Show | 27.0M | 1.7M | Plain single-line output |
+| Kindlings ShowPretty | 34.3M | 1.8M | Multi-line indented, ~0% overhead vs Show |
+| kittens ShowPretty | 5.4M | 557.0K | List[String] line accumulation |
+| Kindlings FastShowPretty | 18.0M | 1.3M | StringBuilder + escaped strings |
 
-Kindlings ShowPretty is **8.1x faster** than kittens ShowPretty for SimpleCC and **3.3x** for Person. The overhead vs plain Show is negligible because indentation is handled at runtime by a simple `indentSubsequentLines` helper on the result string.
+Kindlings ShowPretty is **6.4x faster** than kittens ShowPretty for SimpleCC and **3.2x** for Person. The overhead vs plain Show is negligible because indentation is handled at runtime by a simple `indentSubsequentLines` helper on the result string.
 
-FastShowPretty uses `StringBuilder` instead of string concatenation and produces a richer format (quoted strings with escape handling, type suffixes on numeric literals). The StringBuilder allocation + `.toString()` copy adds fixed overhead that dominates for small types but amortizes for larger ones (Person: only 1.5x behind ShowPretty).
+FastShowPretty uses `StringBuilder` instead of string concatenation and produces a richer format (quoted strings with escape handling, type suffixes on numeric literals). The StringBuilder allocation + `.toString()` copy adds fixed overhead that dominates for small types but amortizes for larger ones (Person: only 1.4x behind ShowPretty).

--- a/docs/user-guide/circe-derivation.md
+++ b/docs/user-guide/circe-derivation.md
@@ -228,27 +228,27 @@ All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
 |------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 30.8M | 30.9M | 20.9M | 20.9M | **1.5x faster** |
-| SimpleCC | 3 | 33.8M | 38.5M | 17.6M | 17.6M | **2.2x faster** |
-| SimpleADT | 2.13 | 32.1M | 28.7M | 14.8M | 18.4M | **1.7x faster** |
-| SimpleADT | 3 | 31.3M | 31.2M | 25.5M | 25.6M | **1.2x faster** |
-| Person | 2.13 | 3.8M | 3.7M | 2.6M | 2.9M | **1.3x faster** |
-| Person | 3 | 3.8M | 3.4M | 2.4M | 2.1M | **1.6x faster** |
-| Event | 2.13 | 3.1M | 3.1M | 2.3M | 2.4M | **1.3x faster** |
-| Event | 3 | 3.1M | 3.1M | 2.0M | 2.0M | **1.5x faster** |
+| SimpleCC | 2.13 | 30.3M | 30.9M | 18.8M | 19.0M | **1.63x faster** |
+| SimpleCC | 3 | 31.2M | 31.2M | 21.8M | 20.9M | **1.43x faster** |
+| SimpleADT | 2.13 | 27.5M | 27.1M | 13.4M | 13.9M | **1.98x faster** |
+| SimpleADT | 3 | 26.8M | 25.7M | 26.6M | 27.1M | **0.99x faster** |
+| Person | 2.13 | 4.5M | 4.5M | 3.0M | 3.1M | **1.45x faster** |
+| Person | 3 | 4.4M | 4.5M | 3.1M | 3.2M | **1.41x faster** |
+| Event | 2.13 | 3.4M | 3.4M | 2.3M | 2.4M | **1.42x faster** |
+| Event | 3 | 3.3M | 3.4M | 2.4M | 2.3M | **1.42x faster** |
 
 #### Decode
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | Original auto | vs best original |
 |------|-------|---------------|---------------|--------------|--------------|-----------------|
-| SimpleCC | 2.13 | 46.1M | 46.3M | 38.5M | 38.8M | **1.2x faster** |
-| SimpleCC | 3 | 40.6M | 41.3M | 18.3M | 17.9M | **2.3x faster** |
-| SimpleADT | 2.13 | 38.8M | 39.1M | 30.2M | 30.2M | **1.3x faster** |
-| SimpleADT | 3 | 39.5M | 41.6M | 25.7M | 25.1M | **1.6x faster** |
-| Person | 2.13 | 3.1M | 3.2M | 2.3M | 2.5M | **1.3x faster** |
-| Person | 3 | 3.1M | 3.1M | 2.4M | 2.5M | **1.3x faster** |
-| Event | 2.13 | 2.5M | 2.5M | 2.2M | 2.1M | **1.2x faster** |
-| Event | 3 | 2.5M | 2.6M | 2.0M | 1.9M | **1.3x faster** |
+| SimpleCC | 2.13 | 88.3M | 93.2M | 42.0M | 42.6M | **2.19x faster** |
+| SimpleCC | 3 | 91.9M | 92.1M | 20.5M | 21.2M | **4.34x faster** |
+| SimpleADT | 2.13 | 56.3M | 55.9M | 25.0M | 25.7M | **2.19x faster** |
+| SimpleADT | 3 | 58.3M | 54.6M | 27.9M | 28.0M | **2.08x faster** |
+| Person | 2.13 | 5.4M | 5.3M | 3.5M | 3.6M | **1.50x faster** |
+| Person | 3 | 5.5M | 5.4M | 2.7M | 2.6M | **2.04x faster** |
+| Event | 2.13 | 3.3M | 3.5M | 2.7M | 2.7M | **1.30x faster** |
+| Event | 3 | 3.5M | 3.3M | 2.1M | 2.2M | **1.59x faster** |
 
 ### End-to-end with jsoniter-scala-circe booster
 
@@ -260,26 +260,26 @@ The booster is an optional add-on — Kindlings works with standard Circe parsin
 
 | Type | Scala | Kindlings + booster | Original + booster | Kindlings (no booster) | Original (no booster) |
 |------|-------|--------------------|--------------------|----------------------|---------------------|
-| SimpleCC | 2.13 | **8.3M** | 7.3M | 7.2M | 6.7M |
-| SimpleCC | 3 | **12.1M** | 7.6M | 8.0M | 6.6M |
-| SimpleADT | 2.13 | **13.2M** | 7.1M | 7.6M | 6.4M |
-| SimpleADT | 3 | **9.7M** | 8.8M | 7.3M | 7.4M |
-| Person | 2.13 | **1.5M** | 1.4M | 922.5K | 845.8K |
-| Person | 3 | **1.6M** | 1.4M | 1.0M | 917.5K |
-| Event | 2.13 | **1.3M** | 1.1M | 795.0K | 714.9K |
-| Event | 3 | **1.3M** | 1.1M | 872.2K | 768.4K |
+| SimpleCC | 2.13 | **13.9M** | 10.5M | 6.8M | 5.4M |
+| SimpleCC | 3 | **15.5M** | 12.0M | 7.2M | 6.7M |
+| SimpleADT | 2.13 | **14.3M** | 8.1M | 7.8M | 5.9M |
+| SimpleADT | 3 | **15.6M** | 11.7M | 8.1M | 6.9M |
+| Person | 2.13 | **1.6M** | 1.4M | 985K | 882K |
+| Person | 3 | **1.7M** | 1.5M | 1.1M | 964K |
+| Event | 2.13 | **1.3M** | 1.1M | 831K | 764K |
+| Event | 3 | **1.4M** | 1.2M | 939K | 805K |
 
 #### Decode (bytes/String to domain type)
 
 | Type | Scala | Kindlings + booster | Original + booster | Kindlings (no booster) | Original (no booster) |
 |------|-------|--------------------|--------------------|----------------------|---------------------|
-| SimpleCC | 2.13 | **8.0M** | 6.8M | 7.5M | 6.8M |
-| SimpleCC | 3 | **9.6M** | 6.2M | 7.3M | 5.1M |
-| SimpleADT | 2.13 | **9.0M** | 8.8M | 7.2M | 7.2M |
-| SimpleADT | 3 | **10.7M** | 8.9M | 9.3M | 7.3M |
-| Person | 2.13 | **957.0K** | 799.3K | 695.8K | 521.2K |
-| Person | 3 | **1.1M** | 1.0M | 747.5K | 704.6K |
-| Event | 2.13 | **845.5K** | 717.6K | 598.3K | 576.1K |
-| Event | 3 | **992.4K** | 787.3K | 683.3K | 627.8K |
+| SimpleCC | 2.13 | **9.3M** | 8.1M | 6.1M | 5.9M |
+| SimpleCC | 3 | **8.8M** | 6.6M | 7.1M | 5.9M |
+| SimpleADT | 2.13 | **11.2M** | 9.1M | 8.7M | 7.4M |
+| SimpleADT | 3 | **10.9M** | 9.2M | 9.8M | 8.5M |
+| Person | 2.13 | **1.3M** | 1.1M | 918K | 879K |
+| Person | 3 | **1.3M** | 1.0M | 1.1M | 874K |
+| Event | 2.13 | **1.0M** | 906K | 736K | 724K |
+| Event | 3 | **996K** | 825K | 836K | 703K |
 
 Note: Kindlings semi-automatic and automatic derivation produce identical performance — this is the "sanely-automatic" design.

--- a/docs/user-guide/feature-parity.md
+++ b/docs/user-guide/feature-parity.md
@@ -178,18 +178,18 @@ Kindlings uses `Int` priority (upstream avro4s uses `Float`). Higher priority va
 
 | Type class | Scala | Kindlings | kittens best | vs kittens |
 |---|---|---|---|---|
-| Show (SimpleCC) | 2.13 | 48.1M | 18.0M | **2.7x faster** |
-| Show (SimpleCC) | 3 | 47.8M | 14.3M | **3.3x faster** |
-| Eq (SimpleCC) | 2.13 | 97.4M | 46.0M | **2.1x faster** |
-| Hash (SimpleCC) | 2.13 | 264M | 37.4M | **7.1x faster** |
-| Hash (SimpleCC) | 3 | 234M | 53.4M | **4.4x faster** |
-| Semigroup (IntPair) | 2.13 | 508M | 71.6M | **7.1x faster** |
-| Monoid (IntPair) | 2.13 | 561M | 72.9M | **7.7x faster** |
-| Functor (map) | 2.13 | 205M | 4.4M | **47x faster** |
-| Functor (map) | 3 | 238M | 84.9M | **2.8x faster** |
-| Foldable (foldLeft) | 3 | 1006M | 120M | **8.4x faster** |
-| Traverse (traverse) | 3 | 123M | 24.2M | **5.1x faster** |
-| ShowPretty (SimpleCC) | 3 | 50.0M | 6.2M | **8.1x faster** |
+| Show (SimpleCC) | 2.13 | 38.2M | 7.5M | **5.1x faster** |
+| Show (SimpleCC) | 3 | 27.2M | 19.9M | **1.4x faster** |
+| Eq (SimpleCC) | 2.13 | 100.2M | 46.1M | **2.2x faster** |
+| Hash (SimpleCC) | 2.13 | 824.9M | 27.4M | **30.1x faster** |
+| Hash (SimpleCC) | 3 | 828.3M | 110.0M | **7.5x faster** |
+| Semigroup (IntPair) | 2.13 | 194.1M | 54.3M | **3.6x faster** |
+| Monoid (IntPair) | 2.13 | 192.8M | 49.0M | **3.9x faster** |
+| Functor (map) | 2.13 | 277.3M | 5.7M | **49x faster** |
+| Functor (map) | 3 | 275.9M | 65.2M | **4.2x faster** |
+| Foldable (foldLeft) | 3 | 1.6B | 109.6M | **14.6x faster** |
+| Traverse (traverse) | 3 | 164.2M | 18.7M | **8.8x faster** |
+| ShowPretty (SimpleCC) | 3 | 34.3M | 5.4M | **6.4x faster** |
 
 ### Not ported
 

--- a/docs/user-guide/jsoniter-derivation.md
+++ b/docs/user-guide/jsoniter-derivation.md
@@ -236,24 +236,24 @@ scalacOptions += "-Xmacro-settings:jsoniterDerivation.logDerivation=true"
 All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
 
 !!! note
-    Kindlings is at parity with jsoniter-scala's own macros: writes and reads are ~tied (within ~1.1x in both directions). The only consistent gap is SimpleCC read on Scala 2.13 (0.92x).
+    Kindlings matches jsoniter-scala's own macros: reads land at 0.96–1.04x and writes at 0.91–1.02x of the hand-tuned reference. The only consistent gap is SimpleADT write (0.91x on 2.13, 0.92x on 3).
 
 #### Write
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | vs original |
 |------|-------|---------------|---------------|--------------|------------|
-| SimpleCC | 2.13 | 59.5M | 60.2M | 62.4M | 0.97x |
-| SimpleCC | 3 | 62.0M | 62.4M | 58.4M | **1.07x faster** |
-| Person | 2.13 | 4.5M | 4.5M | 4.4M | **~tied** |
-| Person | 3 | 5.3M | 5.3M | 5.2M | **~tied** |
-| Event | 2.13 | 4.0M | 3.7M | 4.1M | **~tied** |
-| Event | 3 | 4.7M | 4.7M | 4.7M | **~tied** |
+| SimpleCC | 2.13 | 61.1M | 59.3M | 60.8M | **~tied** |
+| SimpleCC | 3 | 63.6M | 63.9M | 63.8M | **~tied** |
+| Person | 2.13 | 4.8M | 4.7M | 4.7M | **~tied** |
+| Person | 3 | 5.5M | 5.4M | 5.4M | **~tied** |
+| Event | 2.13 | 4.5M | 4.5M | 4.3M | **~tied** |
+| Event | 3 | 4.8M | 4.8M | 4.9M | **~tied** |
 
 #### Read
 
 | Type | Scala | Kindlings semi | Kindlings auto | Original semi | vs original |
 |------|-------|---------------|---------------|--------------|------------|
-| SimpleCC | 2.13 | 29.7M | 31.2M | 33.7M | 0.92x |
-| SimpleCC | 3 | 34.6M | 34.5M | 33.9M | **~tied** |
-| Person | 2.13 | 2.6M | 3.5M | 3.1M | **1.11x faster** |
-| Person | 3 | 3.6M | 3.6M | 3.6M | **~tied** |
+| SimpleCC | 2.13 | 36.4M | 35.8M | 35.5M | **~tied** |
+| SimpleCC | 3 | 36.4M | 36.4M | 35.1M | **~tied** |
+| Person | 2.13 | 3.6M | 3.6M | 3.8M | 0.96x |
+| Person | 3 | 3.6M | 3.7M | 3.8M | 0.98x |

--- a/docs/user-guide/pureconfig-derivation.md
+++ b/docs/user-guide/pureconfig-derivation.md
@@ -297,21 +297,21 @@ All values in ops/s (higher is better). Measured on macOS, JVM temurin 17.
 
 | Type | Scala | Kindlings | Original semi | vs original |
 |------|-------|-----------|--------------|------------|
-| SimpleCC | 2.13 | 10.5M | 1.4M | **7.6x faster** |
-| SimpleCC | 3 | 11.4M | 1.1M | **10x faster** |
-| Person | 2.13 | 1.1M | 218.1K | **5.1x faster** |
-| Person | 3 | 1.2M | 207.3K | **5.5x faster** |
+| SimpleCC | 2.13 | 11.0M | 1.2M | **9.1x faster** |
+| SimpleCC | 3 | 11.1M | 1.7M | **6.6x faster** |
+| Person | 2.13 | 1.2M | 205K | **5.8x faster** |
+| Person | 3 | 1.2M | 248K | **4.7x faster** |
 
 #### Read
 
 | Type | Scala | Kindlings | Original semi | vs original |
 |------|-------|-----------|--------------|------------|
-| SimpleCC | 2.13 | 15.6M | 1.4M | **11x faster** |
-| SimpleCC | 3 | 17.3M | 959.7K | **18x faster** |
-| Person | 2.13 | 783.5K | 214.2K | **3.7x faster** |
-| Person | 3 | 760.1K | 173.6K | **4.4x faster** |
+| SimpleCC | 2.13 | 17.2M | 1.4M | **12.5x faster** |
+| SimpleCC | 3 | 17.2M | 1.4M | **12.5x faster** |
+| Person | 2.13 | 1.0M | 216K | **4.8x faster** |
+| Person | 3 | 1.0M | 197K | **5.3x faster** |
 
 !!! note
-    Kindlings is 3.7--18x faster across the board, for both reads and writes, on both Scala versions and type complexities.
+    Kindlings is 4.7--12.5x faster across the board, for both reads and writes, on both Scala versions and type complexities.
 
 Note: Kindlings semi-automatic and automatic derivation produce identical performance -- this is the "sanely-automatic" design.

--- a/docs/user-guide/tapir-openapi-jsoniter.md
+++ b/docs/user-guide/tapir-openapi-jsoniter.md
@@ -80,7 +80,7 @@ import hearth.kindlings.tapiropenapijsoniter.OpenApiJsoniter
 import com.github.plokhotnyuk.jsoniter_scala.core._
 import sttp.apispec.openapi.OpenAPI
 
-import OpenApiJsoniter.circe._ // OpenAPI 3.1 codecs (the name mirrors sttp-apispec's `circe` entry point)
+import OpenApiJsoniter.openapi_3_1._ // OpenAPI 3.1 codecs (no Circe involved — named after the OpenAPI version)
 
 def render(doc: OpenAPI): String = writeToString(doc)
 def parse(json: String): OpenAPI = readFromString[OpenAPI](json)
@@ -91,9 +91,9 @@ def parse(json: String): OpenAPI = readFromString[OpenAPI](json)
 The model is the same; only the JSON translation differs (`nullable`, `exclusiveMinimum/Maximum` as booleans, `example`,
 `enum`-instead-of-`const`). Pick the entry point that matches the version you advertise:
 
-- `OpenApiJsoniter.circe` / `TapirOpenApi.toJson` — OpenAPI **3.1** (JSON Schema draft 2020-12), the default.
-- `OpenApiJsoniter.circe_openapi_3_0_3` / `TapirOpenApi.toJson30` — OpenAPI **3.0.3**.
-- `OpenApiJsoniter.circeObjectAnySchema` — 3.1, encoding `AnySchema` as `{}` / `{"not":{}}` objects rather than booleans.
+- `OpenApiJsoniter.openapi_3_1` / `TapirOpenApi.toJson` — OpenAPI **3.1** (JSON Schema draft 2020-12), the default.
+- `OpenApiJsoniter.openapi_3_0` / `TapirOpenApi.toJson30` — OpenAPI **3.0.3**.
+- `OpenApiJsoniter.openapi_3_1_objectAny` — 3.1, encoding `AnySchema` as `{}` / `{"not":{}}` objects rather than booleans.
 - `OpenApiJsoniter.custom(openApi30Flag, anyEncoding)` — build your own combination.
 
 ## Notes

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -902,7 +902,9 @@ trait CodecMacrosImpl
           EncoderHandleAsBuiltInRule,
           EncoderHandleAsValueTypeRule,
           EncoderHandleAsOptionRule,
-          EncoderHandleAsMapRule,
+          // EncoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone EncoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // deriveMapEntries / deriveKeyEncoding).
           EncoderHandleAsCollectionRule,
           EncoderHandleAsNamedTupleRule,
           EncoderHandleAsOneValueClassRule,
@@ -1089,7 +1091,9 @@ trait CodecMacrosImpl
           DecoderHandleAsBuiltInRule,
           DecoderHandleAsValueTypeRule,
           DecoderHandleAsOptionRule,
-          DecoderHandleAsMapRule,
+          // DecoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone DecoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // decodeMapEntries / deriveKeyDecoding).
           DecoderHandleAsCollectionRule,
           DecoderHandleAsNamedTupleRule,
           DecoderHandleAsOneValueClassRule,

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
@@ -11,20 +11,27 @@ import com.github.plokhotnyuk.jsoniter_scala.core.JsonReader
 trait DecoderHandleAsCollectionRuleImpl {
   this: CodecMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection when possible") {
+  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection or map when possible") {
 
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
-
-            if (dctx.evaluatedConfig.isDefined) decodeCollectionInline[A, Item](isCollection.value)
-            else decodeCollectionViaHelper[A, Item](isCollection.value)
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                DecoderHandleAsMapRule.decodeMapEntries[A, Item](isMapOf)
+              case None =>
+                implicit val JsonReaderT: Type[JsonReader] = CTypes.JsonReader
+                if (dctx.evaluatedConfig.isDefined) decodeCollectionInline[A, Item](isCollection.value)
+                else decodeCollectionViaHelper[A, Item](isCollection.value)
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
 

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
@@ -26,7 +26,8 @@ trait DecoderHandleAsMapRuleImpl {
         }
       }
 
-    private def decodeMapEntries[A: DecoderCtx, Pair: Type](
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
+    private[rules] def decodeMapEntries[A: DecoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[A]]] = {
       import isMap.{Key, Value, CtorResult}

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
@@ -12,19 +12,27 @@ import com.github.plokhotnyuk.jsoniter_scala.core.JsonWriter
 trait EncoderHandleAsCollectionRuleImpl {
   this: CodecMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection when possible") {
+  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection or map when possible") {
     implicit val UnitT: Type[Unit] = CTypes.Unit
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            if (ectx.evaluatedConfig.isDefined) encodeCollectionInline[A, Item](isCollection.value)
-            else encodeCollectionViaHelper[A, Item](isCollection.value)
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                EncoderHandleAsMapRule.deriveMapEntries[A, Item](isMapOf)
+              case None =>
+                if (ectx.evaluatedConfig.isDefined) encodeCollectionInline[A, Item](isCollection.value)
+                else encodeCollectionViaHelper[A, Item](isCollection.value)
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
 

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
@@ -135,16 +135,20 @@ trait EncoderHandleAsMapRuleImpl {
       deriveEncoderRecursively[Value](using ectx.nest(dummyValue)).flatMap { _ =>
         ectx.getHelper[Value].map { helperOpt =>
           val helper = helperOpt.get
-          val iterableExpr = isMap.asIterable(ectx.value)
+          // `isMap.foreach` lowers to a zero-closure `while` loop over the map's iterator (Hearth's default
+          // `IsCollectionOf.foreach`), so this needs no hand-rolled loop — the optimisation lives in Hearth and is
+          // shared by every module that iterates a map.
+          val writeEntries = isMap.foreach(ectx.value) { pairExpr =>
+            Expr.quote {
+              val entry = Expr.splice(pairExpr).asInstanceOf[(String, Value)]
+              Expr.splice(ectx.writer).writeKey(entry._1)
+              Expr.splice(helper(Expr.quote(entry._2), ectx.writer, ectx.config))
+            }
+          }
           Rule.matched(Expr.quote {
             val out = Expr.splice(ectx.writer)
             out.writeObjectStart()
-            val iter = Expr.splice(iterableExpr).asInstanceOf[Iterable[(String, Value)]].iterator
-            while (iter.hasNext) {
-              val entry = iter.next()
-              out.writeKey(entry._1)
-              Expr.splice(helper(Expr.quote(entry._2), ectx.writer, ectx.config))
-            }
+            Expr.splice(writeEntries)
             out.writeObjectEnd()
           })
         }

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
@@ -30,7 +30,8 @@ trait EncoderHandleAsMapRuleImpl {
         }
       }
 
-    private def deriveMapEntries[A: EncoderCtx, Pair: Type](
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
+    private[rules] def deriveMapEntries[A: EncoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Unit]]] = {
       import isMap.{Key, Value}

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -18,6 +18,7 @@ import pureconfig.error.ConfigReaderFailures
 trait ReaderMacrosImpl
     extends PureconfigDerivationTimeout
     with hearth.kindlings.derivation.compiletime.MethodFolds
+    with hearth.kindlings.derivation.compiletime.EitherFieldsConstruct
     with rules.ReaderUseCachedDefWhenAvailableRuleImpl
     with rules.ReaderUseImplicitWhenAvailableRuleImpl
     with rules.ReaderHandleAsValueTypeRuleImpl

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -259,7 +259,8 @@ trait ReaderMacrosImpl
           ReaderUseImplicitWhenAvailableRule,
           ReaderHandleAsValueTypeRule,
           ReaderHandleAsOptionRule,
-          ReaderHandleAsMapRule,
+          // ReaderHandleAsMapRule is merged into ReaderHandleAsCollectionRule: a map is an `IsCollection` whose
+          // proof is an `IsMapOf`, so we parse `IsCollection` once and dispatch via `.asMap`.
           ReaderHandleAsCollectionRule,
           ReaderHandleAsNamedTupleRule,
           ReaderHandleAsSingletonRule,

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/WriterMacrosImpl.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/WriterMacrosImpl.scala
@@ -251,7 +251,8 @@ trait WriterMacrosImpl
           WriterUseImplicitWhenAvailableRule,
           WriterHandleAsValueTypeRule,
           WriterHandleAsOptionRule,
-          WriterHandleAsMapRule,
+          // WriterHandleAsMapRule is merged into WriterHandleAsCollectionRule: a map is an `IsCollection` whose
+          // proof is an `IsMapOf`, so we parse `IsCollection` once and dispatch via `.asMap`.
           WriterHandleAsCollectionRule,
           WriterHandleAsNamedTupleRule,
           WriterHandleAsSingletonRule,

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsCaseClassRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsCaseClassRule.scala
@@ -276,28 +276,22 @@ trait ReaderHandleAsCaseClassRuleImpl {
                             .asInstanceOf[Either[ConfigReaderFailures, Any]]
                         }
                   }
-                  val makeAccessor: Expr[Array[Any]] => (String, Expr_??) = { arrExpr =>
+                  // Reads the already-bound `Right` value directly (zero-allocation fail-fast construction); no
+                  // intermediate `Array[Any]`.
+                  val makeFieldArg: Expr[Any] => (String, Expr_??) = { valExpr =>
                     val typedExpr = Expr.quote {
-                      PureConfigDerivationUtils.unsafeCast(
-                        Expr.splice(arrExpr)(Expr.splice(Expr(reindex))),
-                        Expr.splice(readerExpr)
-                      )
+                      PureConfigDerivationUtils.unsafeCast(Expr.splice(valExpr), Expr.splice(readerExpr))
                     }
                     (fName, typedExpr.as_??)
                   }
-                  (decodeExpr, makeAccessor, keyExpr)
+                  (decodeExpr, makeFieldArg, keyExpr)
                 }
               }
             }
             .flatMap { fieldData =>
               val decodeExprs = fieldData.toList.map(_._1)
-              val makeAccessors = fieldData.toList.map(_._2)
+              val makeFieldArgs = fieldData.toList.map(_._2)
               val keyExprs = fieldData.toList.map(_._3)
-
-              val listExpr: Expr[List[Either[ConfigReaderFailures, Any]]] =
-                decodeExprs.foldRight(Expr.quote(List.empty[Either[ConfigReaderFailures, Any]])) { (elem, acc) =>
-                  Expr.quote(Expr.splice(elem) :: Expr.splice(acc))
-                }
 
               // Build the runtime expected-keys set from the per-field key expressions.
               // Used by the strict-mode (`allowUnknownKeys = false`) check at the end.
@@ -310,51 +304,43 @@ trait ReaderHandleAsCaseClassRuleImpl {
                     Expr.quote(Expr.splice(acc) + Expr.splice(k))
                   }
 
-              LambdaBuilder
-                .of1[Array[Any]]("decodedValues")
-                .traverse { decodedValuesExpr =>
-                  val nonTransientFieldMap: Map[String, Expr_??] =
-                    makeAccessors.map(_(decodedValuesExpr)).toMap
-                  val fieldMap: Map[String, Expr_??] = nonTransientFieldMap ++ transientDefaults
-                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
-                    onTypes = _ => Map.empty,
-                    onValues = _ => fieldMap
-                  ) match {
-                    case Right(constructExpr) => MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-                    case Left(error)          =>
-                      val err = ReaderDerivationError.CannotConstructType(
-                        Type[A].prettyPrint,
-                        isSingleton = false,
-                        Some(error)
-                      )
-                      Log.error(err.message) >> MIO.fail(err)
+              // Zero-allocation fail-fast construction: nested zero-closure `Either` folds short-circuit on the first
+              // `Left`, with no intermediate `List`, `Array[Any]`, `sequence`, or closure.
+              def constructFF(boundValues: List[Expr[Any]]): Expr[A] = {
+                val nonTransientFieldMap: Map[String, Expr_??] =
+                  makeFieldArgs.zip(boundValues).map { case (mk, v) => mk(v) }.toMap
+                val fieldMap: Map[String, Expr_??] = nonTransientFieldMap ++ transientDefaults
+                foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
+                  onTypes = _ => Map.empty,
+                  onValues = _ => fieldMap
+                ) match {
+                  case Right(constructExpr) => constructExpr.value.asInstanceOf[Expr[A]]
+                  case Left(error)          =>
+                    Environment.reportErrorAndAbort(
+                      ReaderDerivationError
+                        .CannotConstructType(Type[A].prettyPrint, isSingleton = false, Some(error))
+                        .message
+                    )
+                }
+              }
+              val ffConstructed: Expr[Either[ConfigReaderFailures, A]] =
+                buildEitherFailFast[ConfigReaderFailures, A](decodeExprs)(constructFF)
+
+              MIO.pure(
+                // When allowUnknownKeys is statically true, skip the checkUnknownKeys call entirely.
+                if (staticAllowUnknownKeys.contains(true)) ffConstructed
+                else
+                  Expr.quote {
+                    val coreResult: Either[ConfigReaderFailures, A] = Expr.splice(ffConstructed)
+                    PureConfigDerivationUtils.checkUnknownKeys[A](
+                      Expr.splice(rctx.cursor),
+                      coreResult,
+                      Expr.splice(expectedKeysExpr),
+                      Expr.splice(allowUnknownKeysExpr),
+                      Expr.splice(rctx.config).discriminator
+                    )
                   }
-                }
-                .map { builder =>
-                  val constructLambda = builder.build[A]
-                  // When allowUnknownKeys is statically true, skip the checkUnknownKeys
-                  // call entirely — it's a no-op that just returns coreResult.
-                  if (staticAllowUnknownKeys.contains(true))
-                    Expr.quote {
-                      PureConfigDerivationUtils
-                        .sequenceResults(Expr.splice(listExpr))
-                        .map(Expr.splice(constructLambda))
-                    }
-                  else
-                    Expr.quote {
-                      val coreResult: Either[ConfigReaderFailures, A] =
-                        PureConfigDerivationUtils
-                          .sequenceResults(Expr.splice(listExpr))
-                          .map(Expr.splice(constructLambda))
-                      PureConfigDerivationUtils.checkUnknownKeys[A](
-                        Expr.splice(rctx.cursor),
-                        coreResult,
-                        Expr.splice(expectedKeysExpr),
-                        Expr.splice(allowUnknownKeysExpr),
-                        Expr.splice(rctx.config).discriminator
-                      )
-                    }
-                }
+              )
             }
       }
     }

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsCollectionRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsCollectionRule.scala
@@ -13,127 +13,135 @@ import pureconfig.error.ConfigReaderFailures
 trait ReaderHandleAsCollectionRuleImpl {
   this: ReaderMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object ReaderHandleAsCollectionRule extends ReaderDerivationRule("handle as collection when possible") {
+  object ReaderHandleAsCollectionRule extends ReaderDerivationRule("handle as collection or map when possible") {
 
     @scala.annotation.nowarn("msg=is never used")
     def apply[A: ReaderCtx]: MIO[Rule.Applicability[Expr[Either[ConfigReaderFailures, A]]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            import isCollection.value.CtorResult
-            implicit val ConfigCursorT: Type[ConfigCursor] = RTypes.ConfigCursor
-            implicit val EitherItem: Type[Either[ConfigReaderFailures, Item]] = RTypes.ReaderResult[Item]
-            implicit val EitherA: Type[Either[ConfigReaderFailures, A]] = RTypes.ReaderResult[A]
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                ReaderHandleAsMapRule.decodeMapEntries[A, Item](isMapOf)
+              case None =>
+                import isCollection.value.CtorResult
+                implicit val ConfigCursorT: Type[ConfigCursor] = RTypes.ConfigCursor
+                implicit val EitherItem: Type[Either[ConfigReaderFailures, Item]] = RTypes.ReaderResult[Item]
+                implicit val EitherA: Type[Either[ConfigReaderFailures, A]] = RTypes.ReaderResult[A]
 
-            LambdaBuilder
-              .of1[ConfigCursor]("itemCursor")
-              .traverse { itemCursorExpr =>
-                deriveReaderRecursively[Item](using rctx.nest[Item](itemCursorExpr))
-              }
-              .map { builder =>
-                val decodeFn = builder.build[Either[ConfigReaderFailures, Item]]
-                val factoryExpr = isCollection.value.factory
-                val buildStep = isCollection.value.build
-
-                val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
-                  val collBuilder = Expr.splice(factoryExpr).newBuilder
-                  val reader = PureConfigDerivationUtils.readerFromFn(Expr.splice(decodeFn))
-                  val cursor = Expr.splice(rctx.cursor)
-                  cursor.asList match {
-                    case Right(items) =>
-                      items.foreach { itemCursor =>
-                        reader.from(itemCursor) match {
-                          case Right(item) => collBuilder += item
-                          case Left(e)     =>
-                            throw new PureConfigDerivationUtils.CollectionBuildException(e)
-                        }
-                      }
-                    case Left(e) =>
-                      throw new PureConfigDerivationUtils.CollectionBuildException(e)
+                LambdaBuilder
+                  .of1[ConfigCursor]("itemCursor")
+                  .traverse { itemCursorExpr =>
+                    deriveReaderRecursively[Item](using rctx.nest[Item](itemCursorExpr))
                   }
-                  collBuilder
-                }
-                val buildResultExpr = buildStep.ctor(readLoop)
+                  .map { builder =>
+                    val decodeFn = builder.build[Either[ConfigReaderFailures, Item]]
+                    val factoryExpr = isCollection.value.factory
+                    val buildStep = isCollection.value.build
 
-                buildStep match {
-                  case _: CtorLikeOf.PlainValue[?, ?] =>
-                    Rule.matched(Expr.quote {
-                      try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
-                      catch {
-                        case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
+                    val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
+                      val collBuilder = Expr.splice(factoryExpr).newBuilder
+                      val reader = PureConfigDerivationUtils.readerFromFn(Expr.splice(decodeFn))
+                      val cursor = Expr.splice(rctx.cursor)
+                      cursor.asList match {
+                        case Right(items) =>
+                          items.foreach { itemCursor =>
+                            reader.from(itemCursor) match {
+                              case Right(item) => collBuilder += item
+                              case Left(e)     =>
+                                throw new PureConfigDerivationUtils.CollectionBuildException(e)
+                            }
+                          }
+                        case Left(e) =>
+                          throw new PureConfigDerivationUtils.CollectionBuildException(e)
                       }
-                    })
+                      collBuilder
+                    }
+                    val buildResultExpr = buildStep.ctor(readLoop)
 
-                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    =>
-                            Left(PureConfigDerivationUtils.liftStringError(Expr.splice(rctx.cursor), err))
-                        }
-                      catch {
-                        case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
-                      }
-                    })
+                    buildStep match {
+                      case _: CtorLikeOf.PlainValue[?, ?] =>
+                        Rule.matched(Expr.quote {
+                          try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
+                          catch {
+                            case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(
-                              PureConfigDerivationUtils
-                                .liftStringError(Expr.splice(rctx.cursor), errs.mkString("\n"))
-                            )
-                        }
-                      catch {
-                        case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    =>
+                                Left(PureConfigDerivationUtils.liftStringError(Expr.splice(rctx.cursor), err))
+                            }
+                          catch {
+                            case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    =>
-                            Left(
-                              PureConfigDerivationUtils
-                                .liftStringError(Expr.splice(rctx.cursor), err.getMessage)
-                            )
-                        }
-                      catch {
-                        case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(
+                                  PureConfigDerivationUtils
+                                    .liftStringError(Expr.splice(rctx.cursor), errs.mkString("\n"))
+                                )
+                            }
+                          catch {
+                            case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(
-                              PureConfigDerivationUtils
-                                .liftStringError(Expr.splice(rctx.cursor), errs.map(_.getMessage).mkString("\n"))
-                            )
-                        }
-                      catch {
-                        case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
-                      }
-                    })
-                }
-              }
+                      case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    =>
+                                Left(
+                                  PureConfigDerivationUtils
+                                    .liftStringError(Expr.splice(rctx.cursor), err.getMessage)
+                                )
+                            }
+                          catch {
+                            case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
+                          }
+                        })
+
+                      case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(
+                                  PureConfigDerivationUtils
+                                    .liftStringError(Expr.splice(rctx.cursor), errs.map(_.getMessage).mkString("\n"))
+                                )
+                            }
+                          catch {
+                            case e: PureConfigDerivationUtils.CollectionBuildException => Left(e.error)
+                          }
+                        })
+                    }
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsMapRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderHandleAsMapRule.scala
@@ -28,8 +28,9 @@ trait ReaderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def decodeMapEntries[A: ReaderCtx, Pair: Type](
+    private[rules] def decodeMapEntries[A: ReaderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Either[ConfigReaderFailures, A]]]] = {
       import isMap.{Key, Value, CtorResult}

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/WriterHandleAsCollectionRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/WriterHandleAsCollectionRule.scala
@@ -12,32 +12,40 @@ import hearth.kindlings.pureconfigderivation.internal.runtime.PureConfigDerivati
 trait WriterHandleAsCollectionRuleImpl {
   this: WriterMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object WriterHandleAsCollectionRule extends WriterDerivationRule("handle as collection when possible") {
+  object WriterHandleAsCollectionRule extends WriterDerivationRule("handle as collection or map when possible") {
     implicit val ConfigValueT: Type[ConfigValue] = WTypes.ConfigValue
 
     def apply[A: WriterCtx]: MIO[Rule.Applicability[Expr[ConfigValue]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            LambdaBuilder
-              .of1[Item]("item")
-              .traverse { itemExpr =>
-                deriveWriterRecursively[Item](using wctx.nest(itemExpr))
-              }
-              .map { builder =>
-                val lambda = builder.build[ConfigValue]
-                val iterableExpr = isCollection.value.asIterable(wctx.value)
-                Rule.matched(Expr.quote {
-                  PureConfigDerivationUtils.writeIterable[Item](
-                    Expr.splice(iterableExpr),
-                    Expr.splice(lambda)
-                  )
-                })
-              }
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                WriterHandleAsMapRule.deriveMapEntries[A, Item](isMapOf)
+              case None =>
+                LambdaBuilder
+                  .of1[Item]("item")
+                  .traverse { itemExpr =>
+                    deriveWriterRecursively[Item](using wctx.nest(itemExpr))
+                  }
+                  .map { builder =>
+                    val lambda = builder.build[ConfigValue]
+                    val iterableExpr = isCollection.value.asIterable(wctx.value)
+                    Rule.matched(Expr.quote {
+                      PureConfigDerivationUtils.writeIterable[Item](
+                        Expr.splice(iterableExpr),
+                        Expr.splice(lambda)
+                      )
+                    })
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/WriterHandleAsMapRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/WriterHandleAsMapRule.scala
@@ -30,7 +30,8 @@ trait WriterHandleAsMapRuleImpl {
         }
       }
 
-    private def deriveMapEntries[A: WriterCtx, Pair: Type](
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
+    private[rules] def deriveMapEntries[A: WriterCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[ConfigValue]]] = {
       import isMap.{Key, Value}

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -242,7 +242,8 @@ trait ReaderMacrosImpl
           ReaderUseImplicitWhenAvailableRule,
           ReaderHandleAsValueTypeRule,
           ReaderHandleAsOptionRule,
-          ReaderHandleAsMapRule,
+          // ReaderHandleAsMapRule is merged into ReaderHandleAsCollectionRule: a map is an `IsCollection` whose
+          // proof is an `IsMapOf`, so we parse `IsCollection` once and dispatch via `.asMap`.
           ReaderHandleAsCollectionRule,
           ReaderHandleAsNamedTupleRule,
           ReaderHandleAsSingletonRule,

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/WriterMacrosImpl.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/WriterMacrosImpl.scala
@@ -236,7 +236,8 @@ trait WriterMacrosImpl
           WriterUseImplicitWhenAvailableRule,
           WriterHandleAsValueTypeRule,
           WriterHandleAsOptionRule,
-          WriterHandleAsMapRule,
+          // WriterHandleAsMapRule is merged into WriterHandleAsCollectionRule: a map is an `IsCollection` whose
+          // proof is an `IsMapOf`, so we parse `IsCollection` once and dispatch via `.asMap`.
           WriterHandleAsCollectionRule,
           WriterHandleAsNamedTupleRule,
           WriterHandleAsSingletonRule,

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsCollectionRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsCollectionRule.scala
@@ -13,119 +13,127 @@ import org.ekrich.config.ConfigValue
 trait ReaderHandleAsCollectionRuleImpl {
   this: ReaderMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object ReaderHandleAsCollectionRule extends ReaderDerivationRule("handle as collection when possible") {
+  object ReaderHandleAsCollectionRule extends ReaderDerivationRule("handle as collection or map when possible") {
 
     @scala.annotation.nowarn("msg=is never used")
     def apply[A: ReaderCtx]: MIO[Rule.Applicability[Expr[Either[ConfigDecodingError, A]]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            import isCollection.value.CtorResult
-            implicit val ConfigValueT: Type[ConfigValue] = RTypes.ConfigValue
-            implicit val EitherItem: Type[Either[ConfigDecodingError, Item]] = RTypes.ReaderResult[Item]
-            implicit val EitherA: Type[Either[ConfigDecodingError, A]] = RTypes.ReaderResult[A]
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                ReaderHandleAsMapRule.decodeMapEntries[A, Item](isMapOf)
+              case None =>
+                import isCollection.value.CtorResult
+                implicit val ConfigValueT: Type[ConfigValue] = RTypes.ConfigValue
+                implicit val EitherItem: Type[Either[ConfigDecodingError, Item]] = RTypes.ReaderResult[Item]
+                implicit val EitherA: Type[Either[ConfigDecodingError, A]] = RTypes.ReaderResult[A]
 
-            LambdaBuilder
-              .of1[ConfigValue]("itemValue")
-              .traverse { itemValueExpr =>
-                deriveReaderRecursively[Item](using rctx.nest[Item](itemValueExpr))
-              }
-              .map { builder =>
-                val decodeFn = builder.build[Either[ConfigDecodingError, Item]]
-                val factoryExpr = isCollection.value.factory
-                val buildStep = isCollection.value.build
-
-                val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
-                  val collBuilder = Expr.splice(factoryExpr).newBuilder
-                  val reader = SConfigDerivationUtils.readerFromFn(Expr.splice(decodeFn))
-                  val list = SConfigDerivationUtils.asList(Expr.splice(rctx.value)) match {
-                    case Right(l) => l
-                    case Left(e)  => throw new SConfigDerivationUtils.CollectionBuildException(e)
+                LambdaBuilder
+                  .of1[ConfigValue]("itemValue")
+                  .traverse { itemValueExpr =>
+                    deriveReaderRecursively[Item](using rctx.nest[Item](itemValueExpr))
                   }
-                  val iter = list.iterator()
-                  while (iter.hasNext)
-                    reader.from(iter.next()) match {
-                      case Right(item) => collBuilder += item
-                      case Left(e)     => throw new SConfigDerivationUtils.CollectionBuildException(e)
+                  .map { builder =>
+                    val decodeFn = builder.build[Either[ConfigDecodingError, Item]]
+                    val factoryExpr = isCollection.value.factory
+                    val buildStep = isCollection.value.build
+
+                    val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
+                      val collBuilder = Expr.splice(factoryExpr).newBuilder
+                      val reader = SConfigDerivationUtils.readerFromFn(Expr.splice(decodeFn))
+                      val list = SConfigDerivationUtils.asList(Expr.splice(rctx.value)) match {
+                        case Right(l) => l
+                        case Left(e)  => throw new SConfigDerivationUtils.CollectionBuildException(e)
+                      }
+                      val iter = list.iterator()
+                      while (iter.hasNext)
+                        reader.from(iter.next()) match {
+                          case Right(item) => collBuilder += item
+                          case Left(e)     => throw new SConfigDerivationUtils.CollectionBuildException(e)
+                        }
+                      collBuilder
                     }
-                  collBuilder
-                }
-                val buildResultExpr = buildStep.ctor(readLoop)
+                    val buildResultExpr = buildStep.ctor(readLoop)
 
-                buildStep match {
-                  case _: CtorLikeOf.PlainValue[?, ?] =>
-                    Rule.matched(Expr.quote {
-                      try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
-                      catch {
-                        case e: SConfigDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
+                    buildStep match {
+                      case _: CtorLikeOf.PlainValue[?, ?] =>
+                        Rule.matched(Expr.quote {
+                          try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
+                          catch {
+                            case e: SConfigDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    => Left(SConfigDerivationUtils.liftStringError(err))
-                        }
-                      catch {
-                        case e: SConfigDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    => Left(SConfigDerivationUtils.liftStringError(err))
+                            }
+                          catch {
+                            case e: SConfigDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(SConfigDerivationUtils.liftStringError(errs.mkString("\n")))
-                        }
-                      catch {
-                        case e: SConfigDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(SConfigDerivationUtils.liftStringError(errs.mkString("\n")))
+                            }
+                          catch {
+                            case e: SConfigDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    =>
-                            Left(SConfigDerivationUtils.liftStringError(err.getMessage))
-                        }
-                      catch {
-                        case e: SConfigDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    =>
+                                Left(SConfigDerivationUtils.liftStringError(err.getMessage))
+                            }
+                          catch {
+                            case e: SConfigDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(SConfigDerivationUtils.liftStringError(errs.map(_.getMessage).mkString("\n")))
-                        }
-                      catch {
-                        case e: SConfigDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
-                }
-              }
+                      case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(SConfigDerivationUtils.liftStringError(errs.map(_.getMessage).mkString("\n")))
+                            }
+                          catch {
+                            case e: SConfigDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
+                    }
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsMapRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderHandleAsMapRule.scala
@@ -28,8 +28,9 @@ trait ReaderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def decodeMapEntries[A: ReaderCtx, Pair: Type](
+    private[rules] def decodeMapEntries[A: ReaderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Either[ConfigDecodingError, A]]]] = {
       import isMap.{Key, Value, CtorResult}

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/WriterHandleAsCollectionRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/WriterHandleAsCollectionRule.scala
@@ -12,32 +12,40 @@ import org.ekrich.config.ConfigValue
 trait WriterHandleAsCollectionRuleImpl {
   this: WriterMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object WriterHandleAsCollectionRule extends WriterDerivationRule("handle as collection when possible") {
+  object WriterHandleAsCollectionRule extends WriterDerivationRule("handle as collection or map when possible") {
     implicit val ConfigValueT: Type[ConfigValue] = WTypes.ConfigValue
 
     def apply[A: WriterCtx]: MIO[Rule.Applicability[Expr[ConfigValue]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            LambdaBuilder
-              .of1[Item]("item")
-              .traverse { itemExpr =>
-                deriveWriterRecursively[Item](using wctx.nest(itemExpr))
-              }
-              .map { builder =>
-                val lambda = builder.build[ConfigValue]
-                val iterableExpr = isCollection.value.asIterable(wctx.value)
-                Rule.matched(Expr.quote {
-                  SConfigDerivationUtils.writeIterable[Item](
-                    Expr.splice(iterableExpr),
-                    Expr.splice(lambda)
-                  )
-                })
-              }
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                WriterHandleAsMapRule.deriveMapEntries[A, Item](isMapOf)
+              case None =>
+                LambdaBuilder
+                  .of1[Item]("item")
+                  .traverse { itemExpr =>
+                    deriveWriterRecursively[Item](using wctx.nest(itemExpr))
+                  }
+                  .map { builder =>
+                    val lambda = builder.build[ConfigValue]
+                    val iterableExpr = isCollection.value.asIterable(wctx.value)
+                    Rule.matched(Expr.quote {
+                      SConfigDerivationUtils.writeIterable[Item](
+                        Expr.splice(iterableExpr),
+                        Expr.splice(lambda)
+                      )
+                    })
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/WriterHandleAsMapRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/WriterHandleAsMapRule.scala
@@ -30,7 +30,8 @@ trait WriterHandleAsMapRuleImpl {
         }
       }
 
-    private def deriveMapEntries[A: WriterCtx, Pair: Type](
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
+    private[rules] def deriveMapEntries[A: WriterCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[ConfigValue]]] = {
       import isMap.{Key, Value}

--- a/tapir-openapi-jsoniter/src/main/scala-tapir/hearth/kindlings/tapiropenapijsoniter/TapirOpenApi.scala
+++ b/tapir-openapi-jsoniter/src/main/scala-tapir/hearth/kindlings/tapiropenapijsoniter/TapirOpenApi.scala
@@ -36,11 +36,11 @@ object TapirOpenApi {
 
   /** Serialize an OpenAPI model to JSON via this module's jsoniter codec (OpenAPI 3.1, circe-free). */
   def toJson(doc: OpenAPI): String =
-    writeToString(doc)(OpenApiJsoniter.circe.openAPICodec)
+    writeToString(doc)(OpenApiJsoniter.openapi_3_1.openAPICodec)
 
   /** Serialize an OpenAPI model to JSON via this module's jsoniter codec, using the OpenAPI 3.0.3 translation. */
   def toJson30(doc: OpenAPI): String =
-    writeToString(doc)(OpenApiJsoniter.circe_openapi_3_0_3.openAPICodec)
+    writeToString(doc)(OpenApiJsoniter.openapi_3_0.openAPICodec)
 
   /** One call: tapir endpoint -> OpenAPI 3.1 JSON, with no circe on the classpath. */
   def endpointToJson(endpoint: AnyEndpoint, info: Info): String =

--- a/tapir-openapi-jsoniter/src/main/scala/hearth/kindlings/tapiropenapijsoniter/OpenApiJsoniter.scala
+++ b/tapir-openapi-jsoniter/src/main/scala/hearth/kindlings/tapiropenapijsoniter/OpenApiJsoniter.scala
@@ -8,11 +8,11 @@ import sttp.apispec.openapi.OpenAPI
 
 /** Circe-free jsoniter-scala codecs for the sttp-apispec OpenAPI + JSON-Schema model.
   *
-  * The byte-level encoding reproduces `sttp-apispec`'s circe codecs exactly. Two variants are provided, mirroring
-  * sttp-apispec's `circe` / `circe_openapi_3_0_3` entry points:
+  * The byte-level encoding reproduces `sttp-apispec`'s circe codecs exactly, but the entry points are named after the
+  * OpenAPI version they target (no Circe is involved on our side). Two variants are provided:
   *
-  *   - [[circe]] — OpenAPI 3.1 (JSON Schema draft 2020-12 semantics)
-  *   - [[circe_openapi_3_0_3]] — OpenAPI 3.0.3 (the `nullable`, `exclusiveMinimum/Maximum`-as-boolean, `example`,
+  *   - [[openapi_3_1]] — OpenAPI 3.1 (JSON Schema draft 2020-12 semantics)
+  *   - [[openapi_3_0]] — OpenAPI 3.0.3 (the `nullable`, `exclusiveMinimum/Maximum`-as-boolean, `example`,
   *     `enum`-instead-of-`const` translations)
   *
   * Each variant exposes the underlying [[internal.Encoder]] / [[internal.Decoder]] type classes as implicits (so model
@@ -21,19 +21,19 @@ import sttp.apispec.openapi.OpenAPI
 object OpenApiJsoniter {
 
   /** OpenAPI 3.1 codecs (default). */
-  object circe extends internal.OpenApiCodecs {
+  object openapi_3_1 extends internal.OpenApiCodecs {
     override def openApi30: Boolean = false
     override def anyObjectEncoding: AnySchema.Encoding = AnySchema.Encoding.Boolean
   }
 
   /** OpenAPI 3.0.3 codecs. */
-  object circe_openapi_3_0_3 extends internal.OpenApiCodecs {
+  object openapi_3_0 extends internal.OpenApiCodecs {
     override def openApi30: Boolean = true
     override def anyObjectEncoding: AnySchema.Encoding = AnySchema.Encoding.Boolean
   }
 
   /** OpenAPI 3.1 codecs that encode [[AnySchema]] as objects (`{}` / `{"not":{}}`) rather than booleans. */
-  object circeObjectAnySchema extends internal.OpenApiCodecs {
+  object openapi_3_1_objectAny extends internal.OpenApiCodecs {
     override def openApi30: Boolean = false
     override def anyObjectEncoding: AnySchema.Encoding = AnySchema.Encoding.Object
   }
@@ -53,8 +53,8 @@ object OpenApiJsoniter {
 
 package internal {
 
-  /** Bundles the full encoder + decoder set and exposes JSON byte codecs. Mixed into the public `circe` /
-    * `circe_openapi_3_0_3` objects.
+  /** Bundles the full encoder + decoder set and exposes JSON byte codecs. Mixed into the public `openapi_3_1` /
+    * `openapi_3_0` objects.
     */
   trait OpenApiCodecs extends OpenApiEncoders with OpenApiDecoders {
 

--- a/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/Oas30EdgesSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/Oas30EdgesSpec.scala
@@ -12,7 +12,7 @@ import scala.collection.immutable.ListMap
   */
 final class Oas30EdgesSpec extends MacroSuite {
 
-  private val codec30 = OpenApiJsoniter.circe_openapi_3_0_3.schemaCodec
+  private val codec30 = OpenApiJsoniter.openapi_3_0.schemaCodec
 
   private def enc30(s: Schema): String = writeToString(s)(codec30)
   private def dec30(s: String): Schema = readFromString[Schema](s)(codec30)
@@ -68,11 +68,11 @@ final class Oas30EdgesSpec extends MacroSuite {
     }
   }
 
-  group("circeObjectAnySchema in 3.0 mode") {
+  group("openapi_3_1_objectAny in 3.0 mode") {
     test("AnySchema.Anything encodes as {} (object) and Nothing as {\"not\":{}}") {
-      writeToString(AnySchema.Anything: SchemaLike)(OpenApiJsoniter.circeObjectAnySchema.schemaLikeCodec) ==> "{}"
+      writeToString(AnySchema.Anything: SchemaLike)(OpenApiJsoniter.openapi_3_1_objectAny.schemaLikeCodec) ==> "{}"
       writeToString(AnySchema.Nothing: SchemaLike)(
-        OpenApiJsoniter.circeObjectAnySchema.schemaLikeCodec
+        OpenApiJsoniter.openapi_3_1_objectAny.schemaLikeCodec
       ) ==> """{"not":{}}"""
     }
     test("object-any + 3.0 flag combined still emits object form") {
@@ -83,7 +83,7 @@ final class Oas30EdgesSpec extends MacroSuite {
   }
 
   group("ReferenceOr round-trips preserve summary/description") {
-    import OpenApiJsoniter.circe.*
+    import OpenApiJsoniter.openapi_3_1.*
     test("Left(Reference) with summary + description round-trips") {
       val ref: ReferenceOr[Response] = Left(Reference("#/x", summary = Some("s"), description = Some("d")))
       val components = Components(responses = ListMap("r" -> ref))
@@ -97,7 +97,7 @@ final class Oas30EdgesSpec extends MacroSuite {
   }
 
   group("extensions on containers that call dropNullsExpand") {
-    import OpenApiJsoniter.circe.*
+    import OpenApiJsoniter.openapi_3_1.*
     // Every such container hoists x-* extensions; verify the hoist for a representative spread of them.
     test("Info / Contact / License / Server / Tag / Components / Response / Operation / PathItem extensions hoist") {
       val doc = OpenAPI(
@@ -139,7 +139,7 @@ final class Oas30EdgesSpec extends MacroSuite {
   }
 
   group("non-JSON extension value falls back to a JSON string") {
-    import OpenApiJsoniter.circe.*
+    import OpenApiJsoniter.openapi_3_1.*
     test("an extension value that is not valid JSON is emitted as a JSON string") {
       val schema = Schema(
         `type` = Some(List(SchemaType.String)),

--- a/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/Oas30Spec.scala
+++ b/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/Oas30Spec.scala
@@ -7,8 +7,8 @@ import sttp.apispec.*
 /** Cross-platform (no resource IO) tests for the OAS 3.0.3 Schema translations and their decode inverses. */
 final class Oas30Spec extends MacroSuite {
 
-  import OpenApiJsoniter.circe_openapi_3_0_3.schemaCodec as codec30
-  import OpenApiJsoniter.circe.schemaCodec as codec31
+  import OpenApiJsoniter.openapi_3_0.schemaCodec as codec30
+  import OpenApiJsoniter.openapi_3_1.schemaCodec as codec31
 
   private def enc30(s: Schema): String = writeToString(s)(codec30)
   private def dec30(s: String): Schema = readFromString[Schema](s)(codec30)

--- a/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/OpenApiCodecSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/OpenApiCodecSpec.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable.ListMap
 
 final class OpenApiCodecSpec extends MacroSuite {
 
-  import OpenApiJsoniter.circe.*
+  import OpenApiJsoniter.openapi_3_1.*
 
   private val sampleDoc: OpenAPI = SampleDocs.sampleDoc
 

--- a/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/SchemaCodecSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/SchemaCodecSpec.scala
@@ -8,7 +8,7 @@ import scala.collection.immutable.ListMap
 
 final class SchemaCodecSpec extends MacroSuite {
 
-  import OpenApiJsoniter.circe.*
+  import OpenApiJsoniter.openapi_3_1.*
 
   private def enc(s: Schema): String = writeToString(s)(schemaCodec)
   private def dec(json: String): Schema = readFromString[Schema](json)(schemaCodec)

--- a/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/SchemaKeywordSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/SchemaKeywordSpec.scala
@@ -15,7 +15,7 @@ import scala.collection.immutable.ListMap
   */
 final class SchemaKeywordSpec extends MacroSuite {
 
-  import OpenApiJsoniter.circe.*
+  import OpenApiJsoniter.openapi_3_1.*
 
   private def enc(s: Schema): String = writeToString(s)(schemaCodec)
   private def roundTrip(s: Schema): Unit = {

--- a/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/ValueRoundTripSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scala/hearth/kindlings/tapiropenapijsoniter/ValueRoundTripSpec.scala
@@ -20,7 +20,7 @@ import scala.collection.immutable.ListMap
   */
 final class ValueRoundTripSpec extends MacroSuite {
 
-  import OpenApiJsoniter.circe.*
+  import OpenApiJsoniter.openapi_3_1.*
 
   private def encDoc(doc: OpenAPI): String = writeToString(doc)(openAPICodec)
   private def roundTripOpenAPI(doc: OpenAPI): Unit =

--- a/tapir-openapi-jsoniter/src/test/scalajvm/hearth/kindlings/tapiropenapijsoniter/CirceCrossCheckJvmSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scalajvm/hearth/kindlings/tapiropenapijsoniter/CirceCrossCheckJvmSpec.scala
@@ -29,7 +29,7 @@ import scala.io.Source
   */
 final class CirceCrossCheckJvmSpec extends MacroSuite {
 
-  // --- circe variants, mirroring OpenApiJsoniter.{circe, circe_openapi_3_0_3, circeObjectAnySchema} ---
+  // --- circe variants, mirroring OpenApiJsoniter.{openapi_3_1, openapi_3_0, openapi_3_1_objectAny} ---
   private object circe31 extends sttp.apispec.openapi.circe.SttpOpenAPICirceEncoders
   private object circe303 extends sttp.apispec.openapi.circe.SttpOpenAPI3_0_3CirceEncoders {
     override def anyObjectEncoding: AnySchema.Encoding = AnySchema.Encoding.Boolean
@@ -58,7 +58,7 @@ final class CirceCrossCheckJvmSpec extends MacroSuite {
     ast(writeToString(model)(ourCodec)) ==> ast(circeEnc(model).noSpaces)
 
   group("OpenAPI 3.1 fixtures cross-checked against openapi-circe") {
-    val ours = OpenApiJsoniter.circe
+    val ours = OpenApiJsoniter.openapi_3_1
     // Note: fixtures that carry `Any`-typed example/extension values (e.g. /spec/3.1/schema.json's "object with example")
     // are NOT comparable through circe's encoder once decoded by us — our decoder stores them as our `Json` AST, which
     // circe's encoder serialises via its `.toString` fallback. Those models are cross-checked from in-memory native
@@ -76,8 +76,8 @@ final class CirceCrossCheckJvmSpec extends MacroSuite {
     )
   }
 
-  group("OpenAPI 3.0.3 fixtures cross-checked against circe_openapi_3_0_3") {
-    val ours = OpenApiJsoniter.circe_openapi_3_0_3
+  group("OpenAPI 3.0.3 fixtures cross-checked against openapi_3_0") {
+    val ours = OpenApiJsoniter.openapi_3_0
     def check(path: String): Unit = crossCheckModel[OpenAPI](path)(ours.openAPICodec)(circe303.encoderOpenAPI)
     test("callbacks")(check("/callbacks/callbacks.json"))
     test("3.0 schema (in-memory native values)")(
@@ -87,20 +87,20 @@ final class CirceCrossCheckJvmSpec extends MacroSuite {
   }
 
   group("AnySchema object-encoding cross-checked against circe (object encoding)") {
-    val ours = OpenApiJsoniter.circeObjectAnySchema
+    val ours = OpenApiJsoniter.openapi_3_1_objectAny
     def check(path: String): Unit = crossCheckModel[OpenAPI](path)(ours.openAPICodec)(circeObjAny.encoderOpenAPI)
     test("any and nothing (object)")(check("/spec/3.1/any_and_nothing2.json"))
   }
 
   group("Schema fixtures cross-checked against jsonschema-circe") {
-    val ours = OpenApiJsoniter.circe
+    val ours = OpenApiJsoniter.openapi_3_1
     def check(path: String): Unit = crossCheckModel[Schema](path)(ours.schemaCodec)(sttp.apispec.circe.encoderSchema)
     test("self-describing schema")(check("/self-describing-schema.json"))
     test("extending-recursive schema")(check("/extending-recursive.json"))
   }
 
   group("SecurityScheme fixtures cross-checked against circe") {
-    val ours = OpenApiJsoniter.circe
+    val ours = OpenApiJsoniter.openapi_3_1
     def check(path: String): Unit =
       crossCheckModel[SecurityScheme](path)(ours.securitySchemeCodec)(circe31.encoderSecurityScheme)
     test("security scheme with scopes")(check("/securityScheme/security-scheme-with-scopes.json"))
@@ -109,7 +109,7 @@ final class CirceCrossCheckJvmSpec extends MacroSuite {
 
   // --- Hand-built documents exercising encoder branches not covered by the fixtures ---
   group("hand-built documents exercising rarely-used encoder branches (3.1)") {
-    val ours = OpenApiJsoniter.circe
+    val ours = OpenApiJsoniter.openapi_3_1
     val schemaLikeCodec: JsonValueCodec[SchemaLike] = ours.schemaLikeCodec
     def checkSchema(s: SchemaLike): Unit =
       crossCheckValue[SchemaLike](s)(schemaLikeCodec)(sttp.apispec.circe.encoderSchemaLike)

--- a/tapir-openapi-jsoniter/src/test/scalajvm/hearth/kindlings/tapiropenapijsoniter/EncoderGoldenJvmSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scalajvm/hearth/kindlings/tapiropenapijsoniter/EncoderGoldenJvmSpec.scala
@@ -41,17 +41,17 @@ final class EncoderGoldenJvmSpec extends MacroSuite {
   private val fullSchemaOpenApi = HandBuiltDocs.fullSchemaOpenApi
 
   test("full 3.1 schema") {
-    import OpenApiJsoniter.circe.*
+    import OpenApiJsoniter.openapi_3_1.*
     assertEncodes(HandBuiltDocs.fullSchemaOpenApi31, "/spec/3.1/schema.json")
   }
 
   test("full 3.0 schema") {
-    import OpenApiJsoniter.circe_openapi_3_0_3.*
+    import OpenApiJsoniter.openapi_3_0.*
     assertEncodes(HandBuiltDocs.fullSchemaOpenApi30, "/spec/3.0/schema.json")
   }
 
   test("replace const by single enum value in 3.0 schema") {
-    import OpenApiJsoniter.circe_openapi_3_0_3.*
+    import OpenApiJsoniter.openapi_3_0.*
     val components = Components(
       schemas = ListMap(
         schemaComponent("const and enum")(

--- a/tapir-openapi-jsoniter/src/test/scalajvm/hearth/kindlings/tapiropenapijsoniter/GoldenRoundTripJvmSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scalajvm/hearth/kindlings/tapiropenapijsoniter/GoldenRoundTripJvmSpec.scala
@@ -44,7 +44,7 @@ final class GoldenRoundTripJvmSpec extends MacroSuite {
   }
 
   group("OpenAPI 3.1 encoder fixpoints") {
-    import OpenApiJsoniter.circe.*
+    import OpenApiJsoniter.openapi_3_1.*
     test("basic petstore")(roundTrip[OpenAPI]("/petstore/basic-petstore.json"))
     test("header petstore")(roundTrip[OpenAPI]("/petstore/header-petstore.json"))
     test("full 3.1 schema")(roundTrip[OpenAPI]("/spec/3.1/schema.json"))
@@ -52,23 +52,23 @@ final class GoldenRoundTripJvmSpec extends MacroSuite {
   }
 
   group("OpenAPI 3.0.3 encoder fixpoints") {
-    import OpenApiJsoniter.circe_openapi_3_0_3.*
+    import OpenApiJsoniter.openapi_3_0.*
     test("callbacks")(roundTrip[OpenAPI]("/callbacks/callbacks.json"))
   }
 
   group("AnySchema object encoding") {
-    import OpenApiJsoniter.circeObjectAnySchema.*
+    import OpenApiJsoniter.openapi_3_1_objectAny.*
     test("any and nothing (object)")(roundTrip[OpenAPI]("/spec/3.1/any_and_nothing2.json"))
   }
 
   group("security schemes") {
-    import OpenApiJsoniter.circe.*
+    import OpenApiJsoniter.openapi_3_1.*
     test("with scopes")(roundTrip[SecurityScheme]("/securityScheme/security-scheme-with-scopes.json"))
     test("with empty scopes")(roundTrip[SecurityScheme]("/securityScheme/security-scheme-with-empty-scopes.json"))
   }
 
   group("decode-only fixtures") {
-    import OpenApiJsoniter.circe.*
+    import OpenApiJsoniter.openapi_3_1.*
 
     test("self-describing schema decodes") {
       val json = loadAst("/self-describing-schema.json")
@@ -85,7 +85,7 @@ final class GoldenRoundTripJvmSpec extends MacroSuite {
 
   // Ported from sttp-apispec openapi-circe DecoderTest.
   group("decode semantics (ported from sttp-apispec)") {
-    import OpenApiJsoniter.circe.*
+    import OpenApiJsoniter.openapi_3_1.*
 
     def decodeOpenAPI(path: String): OpenAPI =
       readFromString[OpenAPI](writeToString(loadAst(path))(jsonValueCodec))(openAPICodec)
@@ -131,7 +131,7 @@ final class GoldenRoundTripJvmSpec extends MacroSuite {
     test("callbacks decode") {
       val openapi =
         readFromString[OpenAPI](writeToString(loadAst("/callbacks/callbacks.json"))(jsonValueCodec))(
-          OpenApiJsoniter.circe_openapi_3_0_3.openAPICodec
+          OpenApiJsoniter.openapi_3_0.openAPICodec
         )
       val callback = openapi.paths
         .pathItems("/pets")

--- a/tapir-openapi-jsoniter/src/test/scalajvm/hearth/kindlings/tapiropenapijsoniter/TapirInteropJvmSpec.scala
+++ b/tapir-openapi-jsoniter/src/test/scalajvm/hearth/kindlings/tapiropenapijsoniter/TapirInteropJvmSpec.scala
@@ -27,7 +27,7 @@ final class TapirInteropJvmSpec extends MacroSuite {
 
   /** Assert the bridge's serialisation equals circe's, byte-for-byte, and round-trips to the same model. */
   private def crossCheckAndRoundTrip(doc: OpenAPI): Unit = {
-    import OpenApiJsoniter.circe.openAPICodec
+    import OpenApiJsoniter.openapi_3_1.openAPICodec
     val ours = TapirOpenApi.toJson(doc)
     ast(ours) ==> ast(circe.encoderOpenAPI(doc).noSpaces)
     readFromString[OpenAPI](ours)(openAPICodec) ==> doc

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -324,7 +324,9 @@ trait CodecMacrosImpl
           EncoderHandleAsBuiltInRule,
           EncoderHandleAsValueTypeRule,
           EncoderHandleAsOptionRule,
-          EncoderHandleAsMapRule,
+          // EncoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone EncoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // deriveMapEntries).
           EncoderHandleAsCollectionRule,
           EncoderHandleAsSingletonRule,
           EncoderHandleAsCaseClassRule,
@@ -461,7 +463,9 @@ trait CodecMacrosImpl
           DecoderHandleAsBuiltInRule,
           DecoderHandleAsValueTypeRule,
           DecoderHandleAsOptionRule,
-          DecoderHandleAsMapRule,
+          // DecoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone DecoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // decodeMapEntries).
           DecoderHandleAsCollectionRule,
           DecoderHandleAsSingletonRule,
           DecoderHandleAsCaseClassRule,

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
@@ -11,91 +11,99 @@ import hearth.kindlings.ubjsonderivation.UBJsonReader
 trait DecoderHandleAsCollectionRuleImpl {
   this: CodecMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection when possible") {
+  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection or map when possible") {
 
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[A]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            import isCollection.value.CtorResult
-            implicit val UBJsonReaderT: Type[UBJsonReader] = CTypes.UBJsonReader
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                DecoderHandleAsMapRule.decodeMapEntries[A, Item](isMapOf)
+              case None =>
+                import isCollection.value.CtorResult
+                implicit val UBJsonReaderT: Type[UBJsonReader] = CTypes.UBJsonReader
 
-            LambdaBuilder
-              .of1[UBJsonReader]("itemReader")
-              .traverse { itemReaderExpr =>
-                deriveDecoderRecursively[Item](using dctx.nest[Item](itemReaderExpr))
-              }
-              .map { builder =>
-                val decodeFn = builder.build[Item]
-                val factoryExpr = isCollection.value.factory
-                val buildStep = isCollection.value.build
-
-                val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
-                  val decodeFnVal = Expr.splice(decodeFn)
-                  val reader = Expr.splice(dctx.reader)
-                  val maxInserts = Expr.splice(dctx.config).setMaxInsertNumber
-                  val collBuilder = Expr.splice(factoryExpr).newBuilder
-                  reader.readArrayStart()
-                  var count = 0
-                  while (!reader.isArrayEnd()) {
-                    count += 1
-                    if (count > maxInserts)
-                      reader.decodeError("too many collection items (max: " + maxInserts + ")")
-                    collBuilder += decodeFnVal(reader)
+                LambdaBuilder
+                  .of1[UBJsonReader]("itemReader")
+                  .traverse { itemReaderExpr =>
+                    deriveDecoderRecursively[Item](using dctx.nest[Item](itemReaderExpr))
                   }
-                  collBuilder
-                }
-                val buildResultExpr = buildStep.ctor(readLoop)
+                  .map { builder =>
+                    val decodeFn = builder.build[Item]
+                    val factoryExpr = isCollection.value.factory
+                    val buildStep = isCollection.value.build
 
-                buildStep match {
-                  case _: CtorLikeOf.PlainValue[?, ?] =>
-                    Rule.matched(buildResultExpr.asInstanceOf[Expr[A]])
-
-                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(eitherExpr) match {
-                        case Right(value) => value
-                        case Left(err)    => Expr.splice(dctx.reader).decodeError(err)
+                    val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
+                      val decodeFnVal = Expr.splice(decodeFn)
+                      val reader = Expr.splice(dctx.reader)
+                      val maxInserts = Expr.splice(dctx.config).setMaxInsertNumber
+                      val collBuilder = Expr.splice(factoryExpr).newBuilder
+                      reader.readArrayStart()
+                      var count = 0
+                      while (!reader.isArrayEnd()) {
+                        count += 1
+                        if (count > maxInserts)
+                          reader.decodeError("too many collection items (max: " + maxInserts + ")")
+                        collBuilder += decodeFnVal(reader)
                       }
-                    })
+                      collBuilder
+                    }
+                    val buildResultExpr = buildStep.ctor(readLoop)
 
-                  case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(eitherExpr) match {
-                        case Right(value) => value
-                        case Left(errs)   =>
-                          Expr.splice(dctx.reader).decodeError(errs.mkString(", "))
-                      }
-                    })
+                    buildStep match {
+                      case _: CtorLikeOf.PlainValue[?, ?] =>
+                        Rule.matched(buildResultExpr.asInstanceOf[Expr[A]])
 
-                  case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(eitherExpr) match {
-                        case Right(value) => value
-                        case Left(err)    => throw err
-                      }
-                    })
+                      case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
+                        Rule.matched(Expr.quote {
+                          Expr.splice(eitherExpr) match {
+                            case Right(value) => value
+                            case Left(err)    => Expr.splice(dctx.reader).decodeError(err)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                    Rule.matched(Expr.quote {
-                      Expr.splice(eitherExpr) match {
-                        case Right(value) => value
-                        case Left(errs)   =>
-                          val iter = errs.iterator
-                          if (iter.hasNext) throw iter.next()
-                          else Expr.splice(dctx.reader).decodeError("collection construction failed")
-                      }
-                    })
-                }
-              }
+                      case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
+                        Rule.matched(Expr.quote {
+                          Expr.splice(eitherExpr) match {
+                            case Right(value) => value
+                            case Left(errs)   =>
+                              Expr.splice(dctx.reader).decodeError(errs.mkString(", "))
+                          }
+                        })
+
+                      case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
+                        Rule.matched(Expr.quote {
+                          Expr.splice(eitherExpr) match {
+                            case Right(value) => value
+                            case Left(err)    => throw err
+                          }
+                        })
+
+                      case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+                        Rule.matched(Expr.quote {
+                          Expr.splice(eitherExpr) match {
+                            case Right(value) => value
+                            case Left(errs)   =>
+                              val iter = errs.iterator
+                              if (iter.hasNext) throw iter.next()
+                              else Expr.splice(dctx.reader).decodeError("collection construction failed")
+                          }
+                        })
+                    }
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
@@ -24,8 +24,9 @@ trait DecoderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def decodeMapEntries[A: DecoderCtx, Pair: Type](
+    private[rules] def decodeMapEntries[A: DecoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[A]]] = {
       import isMap.{Key, Value, CtorResult}

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
@@ -11,33 +11,41 @@ import hearth.kindlings.ubjsonderivation.internal.runtime.UBJsonDerivationUtils
 trait EncoderHandleAsCollectionRuleImpl {
   this: CodecMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection when possible") {
+  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection or map when possible") {
     implicit val UnitT: Type[Unit] = CTypes.Unit
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Unit]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            LambdaBuilder
-              .of1[Item]("item")
-              .traverse { itemExpr =>
-                deriveEncoderRecursively[Item](using ectx.nest(itemExpr))
-              }
-              .map { builder =>
-                val lambda = builder.build[Unit]
-                val iterableExpr = isCollection.value.asIterable(ectx.value)
-                Rule.matched(Expr.quote {
-                  UBJsonDerivationUtils.writeArray[Item](
-                    Expr.splice(ectx.writer),
-                    Expr.splice(iterableExpr),
-                    Expr.splice(lambda)
-                  )
-                })
-              }
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                EncoderHandleAsMapRule.deriveMapEntries[A, Item](isMapOf)
+              case None =>
+                LambdaBuilder
+                  .of1[Item]("item")
+                  .traverse { itemExpr =>
+                    deriveEncoderRecursively[Item](using ectx.nest(itemExpr))
+                  }
+                  .map { builder =>
+                    val lambda = builder.build[Unit]
+                    val iterableExpr = isCollection.value.asIterable(ectx.value)
+                    Rule.matched(Expr.quote {
+                      UBJsonDerivationUtils.writeArray[Item](
+                        Expr.splice(ectx.writer),
+                        Expr.splice(iterableExpr),
+                        Expr.splice(lambda)
+                      )
+                    })
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
@@ -29,8 +29,9 @@ trait EncoderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def deriveMapEntries[A: EncoderCtx, Pair: Type](
+    private[rules] def deriveMapEntries[A: EncoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Unit]]] = {
       import isMap.{Key, Value}

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -394,7 +394,9 @@ trait DecoderMacrosImpl
           DecoderHandleAsValueTypeRule,
           DecoderHandleAsBuiltInRule,
           DecoderHandleAsOptionRule,
-          DecoderHandleAsMapRule,
+          // DecoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone DecoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // decodeMapEntries).
           DecoderHandleAsCollectionRule,
           DecoderHandleAsSingletonRule,
           DecoderHandleAsCaseClassRule,

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -306,7 +306,9 @@ trait EncoderMacrosImpl
           EncoderHandleAsBuiltInRule,
           EncoderHandleAsValueTypeRule,
           EncoderHandleAsOptionRule,
-          EncoderHandleAsMapRule,
+          // EncoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone EncoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // deriveMapEntries).
           EncoderHandleAsCollectionRule,
           EncoderHandleAsSingletonRule,
           EncoderHandleAsCaseClassRule,

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
@@ -11,110 +11,118 @@ import hearth.kindlings.xmlderivation.XmlDecodingError
 trait DecoderHandleAsCollectionRuleImpl {
   this: DecoderMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection when possible") {
+  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection or map when possible") {
 
     @scala.annotation.nowarn("msg=is never used")
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[Either[XmlDecodingError, A]]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         implicit val EitherT: Type[Either[XmlDecodingError, A]] = DTypes.DecoderResult[A]
         implicit val XmlDecodingErrorT: Type[XmlDecodingError] = DTypes.XmlDecodingError
         implicit val ElemT: Type[scala.xml.Elem] = DTypes.Elem
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            import isCollection.value.CtorResult
-            implicit val EitherItemT: Type[Either[XmlDecodingError, Item]] = DTypes.DecoderResult[Item]
-            LambdaBuilder
-              .of1[scala.xml.Elem]("collItemElem")
-              .traverse { itemElemExpr =>
-                deriveDecoderRecursively[Item](using dctx.nest[Item](itemElemExpr))
-              }
-              .map { builder =>
-                val lambda = builder.build[Either[XmlDecodingError, Item]]
-                val factoryExpr = isCollection.value.factory
-                val buildStep = isCollection.value.build
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                DecoderHandleAsMapRule.decodeMapEntries[A, Item](isMapOf)
+              case None =>
+                import isCollection.value.CtorResult
+                implicit val EitherItemT: Type[Either[XmlDecodingError, Item]] = DTypes.DecoderResult[Item]
+                LambdaBuilder
+                  .of1[scala.xml.Elem]("collItemElem")
+                  .traverse { itemElemExpr =>
+                    deriveDecoderRecursively[Item](using dctx.nest[Item](itemElemExpr))
+                  }
+                  .map { builder =>
+                    val lambda = builder.build[Either[XmlDecodingError, Item]]
+                    val factoryExpr = isCollection.value.factory
+                    val buildStep = isCollection.value.build
 
-                val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
-                  hearth.kindlings.xmlderivation.internal.runtime.XmlDerivationUtils
-                    .decodeCollectionBuilder(
-                      Expr.splice(dctx.elem),
-                      Expr.splice(lambda),
-                      Expr.splice(factoryExpr)
-                    )
-                }
-                val buildResultExpr = buildStep.ctor(readLoop)
+                    val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
+                      hearth.kindlings.xmlderivation.internal.runtime.XmlDerivationUtils
+                        .decodeCollectionBuilder(
+                          Expr.splice(dctx.elem),
+                          Expr.splice(lambda),
+                          Expr.splice(factoryExpr)
+                        )
+                    }
+                    val buildResultExpr = buildStep.ctor(readLoop)
 
-                buildStep match {
-                  case _: CtorLikeOf.PlainValue[?, ?] =>
-                    Rule.matched(Expr.quote {
-                      try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
-                      catch {
-                        case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
-                          Left(XmlDecodingError.Multiple(e.errors))
-                      }
-                    })
+                    buildStep match {
+                      case _: CtorLikeOf.PlainValue[?, ?] =>
+                        Rule.matched(Expr.quote {
+                          try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
+                          catch {
+                            case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
+                              Left(XmlDecodingError.Multiple(e.errors))
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    => Left(XmlDecodingError.General(err))
-                        }
-                      catch {
-                        case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
-                          Left(XmlDecodingError.Multiple(e.errors))
-                      }
-                    })
+                      case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    => Left(XmlDecodingError.General(err))
+                            }
+                          catch {
+                            case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
+                              Left(XmlDecodingError.Multiple(e.errors))
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   => Left(XmlDecodingError.General(errs.mkString("\n")))
-                        }
-                      catch {
-                        case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
-                          Left(XmlDecodingError.Multiple(e.errors))
-                      }
-                    })
+                      case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   => Left(XmlDecodingError.General(errs.mkString("\n")))
+                            }
+                          catch {
+                            case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
+                              Left(XmlDecodingError.Multiple(e.errors))
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    => Left(XmlDecodingError.General(err.getMessage))
-                        }
-                      catch {
-                        case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
-                          Left(XmlDecodingError.Multiple(e.errors))
-                      }
-                    })
+                      case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    => Left(XmlDecodingError.General(err.getMessage))
+                            }
+                          catch {
+                            case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
+                              Left(XmlDecodingError.Multiple(e.errors))
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(XmlDecodingError.General(errs.map(_.getMessage).mkString("\n")))
-                        }
-                      catch {
-                        case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
-                          Left(XmlDecodingError.Multiple(e.errors))
-                      }
-                    })
-                }
-              }
+                      case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(XmlDecodingError.General(errs.map(_.getMessage).mkString("\n")))
+                            }
+                          catch {
+                            case e: hearth.kindlings.xmlderivation.internal.runtime.XmlCollectionBuildException =>
+                              Left(XmlDecodingError.Multiple(e.errors))
+                          }
+                        })
+                    }
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
@@ -26,8 +26,9 @@ trait DecoderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def decodeMapEntries[A: DecoderCtx, Pair: Type](
+    private[rules] def decodeMapEntries[A: DecoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Either[XmlDecodingError, A]]]] = {
       import isMap.{Key, Value, CtorResult}

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
@@ -11,36 +11,44 @@ import hearth.kindlings.xmlderivation.internal.runtime.XmlDerivationUtils
 trait EncoderHandleAsCollectionRuleImpl {
   this: EncoderMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection when possible") {
+  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection or map when possible") {
     implicit val ElemT: Type[scala.xml.Elem] = Types.Elem
     implicit val StringT: Type[String] = Types.String
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[scala.xml.Elem]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            LambdaBuilder
-              .of2[Item, String]("collItem", "itemElementName")
-              .traverse { case (itemExpr, itemNameExpr) =>
-                deriveEncoderRecursively[Item](using ectx.nest(itemExpr).copy(elementName = itemNameExpr))
-              }
-              .map { builder =>
-                val lambda = builder.build[scala.xml.Elem]
-                val iterableExpr = isCollection.value.asIterable(ectx.value)
-                Rule.matched(Expr.quote {
-                  val items = Expr.splice(iterableExpr)
-                  val children = XmlDerivationUtils.encodeIterable[Item](
-                    items,
-                    "item",
-                    (i: Item, n: String) => Expr.splice(lambda).apply(i, n)
-                  )
-                  XmlDerivationUtils.makeElem(Expr.splice(ectx.elementName), Nil, children)
-                })
-              }
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                EncoderHandleAsMapRule.deriveMapEntries[A, Item](isMapOf)
+              case None =>
+                LambdaBuilder
+                  .of2[Item, String]("collItem", "itemElementName")
+                  .traverse { case (itemExpr, itemNameExpr) =>
+                    deriveEncoderRecursively[Item](using ectx.nest(itemExpr).copy(elementName = itemNameExpr))
+                  }
+                  .map { builder =>
+                    val lambda = builder.build[scala.xml.Elem]
+                    val iterableExpr = isCollection.value.asIterable(ectx.value)
+                    Rule.matched(Expr.quote {
+                      val items = Expr.splice(iterableExpr)
+                      val children = XmlDerivationUtils.encodeIterable[Item](
+                        items,
+                        "item",
+                        (i: Item, n: String) => Expr.splice(lambda).apply(i, n)
+                      )
+                      XmlDerivationUtils.makeElem(Expr.splice(ectx.elementName), Nil, children)
+                    })
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
@@ -27,7 +27,8 @@ trait EncoderHandleAsMapRuleImpl {
         }
       }
 
-    private def deriveMapEntries[A: EncoderCtx, Pair: Type](
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
+    private[rules] def deriveMapEntries[A: EncoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[scala.xml.Elem]]] = {
       import isMap.{Key, Value}

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -311,7 +311,9 @@ trait DecoderMacrosImpl
           DecoderUseImplicitWhenAvailableRule,
           DecoderHandleAsValueTypeRule,
           DecoderHandleAsOptionRule,
-          DecoderHandleAsMapRule,
+          // DecoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone DecoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // decodeMapEntries).
           DecoderHandleAsCollectionRule,
           DecoderHandleAsNamedTupleRule,
           DecoderHandleAsSingletonRule,

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -13,6 +13,7 @@ import org.virtuslab.yaml.{ConstructError, Node, YamlDecoder, YamlError}
 trait DecoderMacrosImpl
     extends YamlDerivationTimeout
     with hearth.kindlings.derivation.compiletime.MethodFolds
+    with hearth.kindlings.derivation.compiletime.EitherFieldsConstruct
     with rules.DecoderUseCachedDefWhenAvailableRuleImpl
     with rules.DecoderUseImplicitWhenAvailableRuleImpl
     with rules.DecoderHandleAsLiteralTypeRuleImpl

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -279,7 +279,9 @@ trait EncoderMacrosImpl
           EncoderUseImplicitWhenAvailableRule,
           EncoderHandleAsValueTypeRule,
           EncoderHandleAsOptionRule,
-          EncoderHandleAsMapRule,
+          // EncoderHandleAsCollectionRule now handles maps too (single IsCollection parse + IsMapOf dispatch),
+          // so the standalone EncoderHandleAsMapRule is no longer in the chain (its object is kept for
+          // deriveMapEntries).
           EncoderHandleAsCollectionRule,
           EncoderHandleAsNamedTupleRule,
           EncoderHandleAsSingletonRule,

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsCaseClassRule.scala
@@ -201,56 +201,42 @@ trait DecoderHandleAsCaseClassRuleImpl {
                           .asInstanceOf[Either[ConstructError, Any]]
                       }
                   }
-                  val makeAccessor: Expr[Array[Any]] => (String, Expr_??) = { arrExpr =>
+                  // Reads the already-bound `Right` value directly (zero-allocation fail-fast construction); no
+                  // intermediate `Array[Any]`.
+                  val makeFieldArg: Expr[Any] => (String, Expr_??) = { valExpr =>
                     val typedExpr = Expr.quote {
-                      YamlDerivationUtils.unsafeCast(
-                        Expr.splice(arrExpr)(Expr.splice(Expr(reindex))),
-                        Expr.splice(decoderExpr)
-                      )
+                      YamlDerivationUtils.unsafeCast(Expr.splice(valExpr), Expr.splice(decoderExpr))
                     }
                     (fName, typedExpr.as_??)
                   }
-                  (decodeExpr, makeAccessor)
+                  (decodeExpr, makeFieldArg)
                 }
               }
             }
             .flatMap { fieldData =>
               val decodeExprs = fieldData.toList.map(_._1)
-              val makeAccessors = fieldData.toList.map(_._2)
+              val makeFieldArgs = fieldData.toList.map(_._2)
 
-              val listExpr: Expr[List[Either[ConstructError, Any]]] =
-                decodeExprs.foldRight(Expr.quote(List.empty[Either[ConstructError, Any]])) { (elem, acc) =>
-                  Expr.quote(Expr.splice(elem) :: Expr.splice(acc))
+              // Zero-allocation fail-fast construction: nested zero-closure `Either` folds short-circuit on the first
+              // `Left`, with no intermediate `List`, `Array[Any]`, `sequence`, or closure.
+              def constructFF(boundValues: List[Expr[Any]]): Expr[A] = {
+                val nonTransientFieldMap: Map[String, Expr_??] =
+                  makeFieldArgs.zip(boundValues).map { case (mk, v) => mk(v) }.toMap
+                val fieldMap: Map[String, Expr_??] = nonTransientFieldMap ++ transientDefaults
+                foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
+                  onTypes = _ => Map.empty,
+                  onValues = _ => fieldMap
+                ) match {
+                  case Right(constructExpr) => constructExpr.value.asInstanceOf[Expr[A]]
+                  case Left(error)          =>
+                    Environment.reportErrorAndAbort(
+                      DecoderDerivationError
+                        .CannotConstructType(Type[A].prettyPrint, isSingleton = false, Some(error))
+                        .message
+                    )
                 }
-
-              LambdaBuilder
-                .of1[Array[Any]]("decodedValues")
-                .traverse { decodedValuesExpr =>
-                  val nonTransientFieldMap: Map[String, Expr_??] =
-                    makeAccessors.map(_(decodedValuesExpr)).toMap
-                  val fieldMap: Map[String, Expr_??] = nonTransientFieldMap ++ transientDefaults
-                  foldInstanceFree(caseClass.primaryConstructor, "Constructor")(
-                    onTypes = _ => Map.empty,
-                    onValues = _ => fieldMap
-                  ) match {
-                    case Right(constructExpr) => MIO.pure(constructExpr.value.asInstanceOf[Expr[A]])
-                    case Left(error)          =>
-                      val err = DecoderDerivationError.CannotConstructType(
-                        Type[A].prettyPrint,
-                        isSingleton = false,
-                        Some(error)
-                      )
-                      Log.error(err.message) >> MIO.fail(err)
-                  }
-                }
-                .map { builder =>
-                  val constructLambda = builder.build[A]
-                  Expr.quote {
-                    YamlDerivationUtils
-                      .sequenceDecodeResults(Expr.splice(listExpr))
-                      .map(Expr.splice(constructLambda))
-                  }
-                }
+              }
+              MIO.pure(buildEitherFailFast[ConstructError, A](decodeExprs)(constructFF))
             }
       }
     }

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsCollectionRule.scala
@@ -13,125 +13,134 @@ import org.virtuslab.yaml.Node.SequenceNode
 trait DecoderHandleAsCollectionRuleImpl {
   this: DecoderMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection when possible") {
+  object DecoderHandleAsCollectionRule extends DecoderDerivationRule("handle as collection or map when possible") {
 
     @scala.annotation.nowarn("msg=is never used")
     def apply[A: DecoderCtx]: MIO[Rule.Applicability[Expr[Either[ConstructError, A]]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            import isCollection.value.CtorResult
-            implicit val NodeT: Type[Node] = DTypes.Node
-            implicit val EitherCEItem: Type[Either[ConstructError, Item]] = DTypes.DecoderResult[Item]
-            implicit val EitherCEA: Type[Either[ConstructError, A]] = DTypes.DecoderResult[A]
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                DecoderHandleAsMapRule.decodeMapEntries[A, Item](isMapOf)
+              case None =>
+                import isCollection.value.CtorResult
+                implicit val NodeT: Type[Node] = DTypes.Node
+                implicit val EitherCEItem: Type[Either[ConstructError, Item]] = DTypes.DecoderResult[Item]
+                implicit val EitherCEA: Type[Either[ConstructError, A]] = DTypes.DecoderResult[A]
 
-            LambdaBuilder
-              .of1[Node]("itemNode")
-              .traverse { itemNodeExpr =>
-                deriveDecoderRecursively[Item](using dctx.nest[Item](itemNodeExpr))
-              }
-              .map { builder =>
-                val decodeFn = builder.build[Either[ConstructError, Item]]
-                val factoryExpr = isCollection.value.factory
-                val buildStep = isCollection.value.build
-
-                val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
-                  val collBuilder = Expr.splice(factoryExpr).newBuilder
-                  val decoder = YamlDerivationUtils.decoderFromFn(Expr.splice(decodeFn))
-                  Expr.splice(dctx.node) match {
-                    case SequenceNode(nodes, _) =>
-                      val iter = nodes.iterator
-                      while (iter.hasNext)
-                        decoder.construct(iter.next())(LoadSettings.empty) match {
-                          case Right(item) => collBuilder += item
-                          case Left(err)   =>
-                            throw new YamlDerivationUtils.CollectionBuildException(err)
-                        }
-                    case other =>
-                      throw new YamlDerivationUtils.CollectionBuildException(
-                        ConstructError.from(s"Expected sequence node but got ${other.getClass.getSimpleName}", other)
-                      )
+                LambdaBuilder
+                  .of1[Node]("itemNode")
+                  .traverse { itemNodeExpr =>
+                    deriveDecoderRecursively[Item](using dctx.nest[Item](itemNodeExpr))
                   }
-                  collBuilder
-                }
-                val buildResultExpr = buildStep.ctor(readLoop)
+                  .map { builder =>
+                    val decodeFn = builder.build[Either[ConstructError, Item]]
+                    val factoryExpr = isCollection.value.factory
+                    val buildStep = isCollection.value.build
 
-                buildStep match {
-                  case _: CtorLikeOf.PlainValue[?, ?] =>
-                    Rule.matched(Expr.quote {
-                      try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
-                      catch {
-                        case e: YamlDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
+                    val readLoop: Expr[scala.collection.mutable.Builder[Item, CtorResult]] = Expr.quote {
+                      val collBuilder = Expr.splice(factoryExpr).newBuilder
+                      val decoder = YamlDerivationUtils.decoderFromFn(Expr.splice(decodeFn))
+                      Expr.splice(dctx.node) match {
+                        case SequenceNode(nodes, _) =>
+                          val iter = nodes.iterator
+                          while (iter.hasNext)
+                            decoder.construct(iter.next())(LoadSettings.empty) match {
+                              case Right(item) => collBuilder += item
+                              case Left(err)   =>
+                                throw new YamlDerivationUtils.CollectionBuildException(err)
+                            }
+                        case other =>
+                          throw new YamlDerivationUtils.CollectionBuildException(
+                            ConstructError
+                              .from(s"Expected sequence node but got ${other.getClass.getSimpleName}", other)
+                          )
                       }
-                    })
+                      collBuilder
+                    }
+                    val buildResultExpr = buildStep.ctor(readLoop)
 
-                  case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    => Left(ConstructError.from(err, Expr.splice(dctx.node)))
-                        }
-                      catch {
-                        case e: YamlDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
+                    buildStep match {
+                      case _: CtorLikeOf.PlainValue[?, ?] =>
+                        Rule.matched(Expr.quote {
+                          try Right(Expr.splice(buildResultExpr.asInstanceOf[Expr[A]]))
+                          catch {
+                            case e: YamlDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(ConstructError.from(errs.mkString("\n"), Expr.splice(dctx.node)))
-                        }
-                      catch {
-                        case e: YamlDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[String, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    => Left(ConstructError.from(err, Expr.splice(dctx.node)))
+                            }
+                          catch {
+                            case e: YamlDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(err)    =>
-                            Left(ConstructError.from(err.getMessage, Expr.splice(dctx.node)))
-                        }
-                      catch {
-                        case e: YamlDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
+                      case _: CtorLikeOf.EitherIterableStringOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[String], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(ConstructError.from(errs.mkString("\n"), Expr.splice(dctx.node)))
+                            }
+                          catch {
+                            case e: YamlDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
 
-                  case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
-                    val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
-                    Rule.matched(Expr.quote {
-                      try
-                        Expr.splice(eitherExpr) match {
-                          case Right(value) => Right(value)
-                          case Left(errs)   =>
-                            Left(
-                              ConstructError.from(errs.map(_.getMessage).mkString("\n"), Expr.splice(dctx.node))
-                            )
-                        }
-                      catch {
-                        case e: YamlDerivationUtils.CollectionBuildException =>
-                          Left(e.error)
-                      }
-                    })
-                }
-              }
+                      case _: CtorLikeOf.EitherThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Throwable, A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(err)    =>
+                                Left(ConstructError.from(err.getMessage, Expr.splice(dctx.node)))
+                            }
+                          catch {
+                            case e: YamlDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
+
+                      case _: CtorLikeOf.EitherIterableThrowableOrValue[?, ?] =>
+                        val eitherExpr = buildResultExpr.asInstanceOf[Expr[Either[Iterable[Throwable], A]]]
+                        Rule.matched(Expr.quote {
+                          try
+                            Expr.splice(eitherExpr) match {
+                              case Right(value) => Right(value)
+                              case Left(errs)   =>
+                                Left(
+                                  ConstructError.from(errs.map(_.getMessage).mkString("\n"), Expr.splice(dctx.node))
+                                )
+                            }
+                          catch {
+                            case e: YamlDerivationUtils.CollectionBuildException =>
+                              Left(e.error)
+                          }
+                        })
+                    }
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderHandleAsMapRule.scala
@@ -28,8 +28,9 @@ trait DecoderHandleAsMapRuleImpl {
         }
       }
 
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
     @scala.annotation.nowarn("msg=is never used")
-    private def decodeMapEntries[A: DecoderCtx, Pair: Type](
+    private[rules] def decodeMapEntries[A: DecoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Either[ConstructError, A]]]] = {
       import isMap.{Key, Value, CtorResult}

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/EncoderHandleAsCollectionRule.scala
@@ -12,32 +12,40 @@ import org.virtuslab.yaml.Node
 trait EncoderHandleAsCollectionRuleImpl {
   this: EncoderMacrosImpl & MacroCommons & StdExtensions & AnnotationSupport =>
 
-  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection when possible") {
+  object EncoderHandleAsCollectionRule extends EncoderDerivationRule("handle as collection or map when possible") {
     implicit val NodeT: Type[Node] = Types.Node
 
     def apply[A: EncoderCtx]: MIO[Rule.Applicability[Expr[Node]]] =
-      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection") >> {
+      Log.info(s"Attempting to handle ${Type[A].prettyPrint} as a collection or map") >> {
         Type[A] match {
           case IsCollection(isCollection) =>
+            // A map is an `IsCollectionOf` whose proof is an `IsMapOf`. Parse `IsCollection` ONCE and dispatch on
+            // that, instead of the old map-rule (`IsMap.parse` = `IsCollection.parse` + cast) followed by a separate
+            // collection rule that parsed `IsCollection` again — every non-map field paid for the parse twice.
             import isCollection.Underlying as Item
-            LambdaBuilder
-              .of1[Item]("item")
-              .traverse { itemExpr =>
-                deriveEncoderRecursively[Item](using ectx.nest(itemExpr))
-              }
-              .map { builder =>
-                val lambda = builder.build[Node]
-                val iterableExpr = isCollection.value.asIterable(ectx.value)
-                Rule.matched(Expr.quote {
-                  YamlDerivationUtils.encodeIterable[Item](
-                    Expr.splice(iterableExpr),
-                    Expr.splice(lambda)
-                  )
-                })
-              }
+            isCollection.value.asMap match {
+              case Some(isMapOf) =>
+                EncoderHandleAsMapRule.deriveMapEntries[A, Item](isMapOf)
+              case None =>
+                LambdaBuilder
+                  .of1[Item]("item")
+                  .traverse { itemExpr =>
+                    deriveEncoderRecursively[Item](using ectx.nest(itemExpr))
+                  }
+                  .map { builder =>
+                    val lambda = builder.build[Node]
+                    val iterableExpr = isCollection.value.asIterable(ectx.value)
+                    Rule.matched(Expr.quote {
+                      YamlDerivationUtils.encodeIterable[Item](
+                        Expr.splice(iterableExpr),
+                        Expr.splice(lambda)
+                      )
+                    })
+                  }
+            }
 
           case _ =>
-            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection"))
+            MIO.pure(Rule.yielded(s"The type ${Type[A].prettyPrint} is not a collection or map"))
         }
       }
   }

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/EncoderHandleAsMapRule.scala
@@ -30,7 +30,8 @@ trait EncoderHandleAsMapRuleImpl {
         }
       }
 
-    private def deriveMapEntries[A: EncoderCtx, Pair: Type](
+    // Exposed so the combined collection-or-map rule can call it after a single IsCollection parse.
+    private[rules] def deriveMapEntries[A: EncoderCtx, Pair: Type](
         isMap: IsMapOf[A, Pair]
     ): MIO[Rule.Applicability[Expr[Node]]] = {
       import isMap.{Key, Value}


### PR DESCRIPTION
Builds on the just-merged Hearth std/codegen fixes (now `0.3.1-53-g8ec996c`).

## Runtime codegen (all via reusable Hearth primitives, generated code unchanged elsewhere)
- **Zero-closure collection/map iteration** — jsoniter map encode now uses `isMap.foreach` (Hearth `foreach` lowers to a zero-closure `while`).
- **Zero-allocation fail-fast `Either` decode** for circe / yaml / pureconfig — new `derivation-commons` `EitherFieldsConstruct` builds the constructor via nested zero-closure `IsEither.fold` (bind each field to a `val`, short-circuit on first `Left`), replacing `List`+`sequence`+`Array[Any]`+closure. Bytecode: 0 `anewarray` / 0 `sequenceDecodeResults` on the fail-fast path.
- **Avro decode**: halve per-field hash lookups (`record.get(field.pos())`) and `semiEval` the config so field-name mapping is a compile-time constant (0 `transformFieldNames` in decode methods). A full position-based fast path is unsafe under schema-evolution-via-Scala-defaults (documented).

## Macro-compile
- **Parse `IsCollection` once per field** — merged the map rule into the collection rule (`c.value.asMap match { Some(m) => map; None => collection }`) across all 8 derivation modules; the standalone map rule leaves every `Rules()` chain. One `IsCollection.parse` per non-map field instead of two.

## API / docs / tooling
- **tapir-openapi-jsoniter**: rename `.circe` entry points to OpenAPI-version names (`openapi_3_1` / `openapi_3_0` / `openapi_3_1_objectAny`).
- **New skill** `docs/contributing/kindlings-jfr-profiling` (JFR sampling + JEP 520 method timing).
- **Benchmarks refreshed** to Hearth 0.3.1-53 on Scala 2.13.18 + 3.8.3 — `benchmark-results.md`, user-guide sections, raw JMH JSON in `benchmark-runs/2026-06-17-master`. vs originals: circe decode 2–4.3x, pureconfig 4.7–12.5x, avro 2–6.7x, cats up to 30x; jsoniter matches jsoniter-scala (only SimpleADT write 0.91–0.92x behind). Shared-machine caveat noted.
- Research notes for the macro-expansion profile and the `Either`-fold owner conflict.

All module test suites green on JVM 2.13 + 3 locally.