### PR TITLE
Fix snippet-check version extraction + bump scala-yaml 0.3.2 & sconfig 2.0.0

### DIFF
--- a/docs/Justfile
+++ b/docs/Justfile
@@ -12,7 +12,17 @@ test-snippets:
   # Extract the published version. sbt 2.0's `print` output is prefixed with an ANSI erase
   # sequence (\e[0J) in CI's non-TTY environment, so strip ANSI first and match a version token
   # anywhere on the line (not anchored at start-of-line, which the old `grep -oE '^[0-9]…'` was).
-  kindlings_version="$(sbt --client 'print fastShowPretty/version' 2>/dev/null | sed -E 's/\x1b\[[0-9;?]*[A-Za-z]//g' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*' | head -1)"
-  if [ -z "${kindlings_version}" ]; then echo "ERROR: could not determine kindlings version" >&2; exit 1; fi
+  # Keep the sbt call and the grep pipeline as SEPARATE statements, each ended with `|| true`:
+  # under `set -euo pipefail`, folding them into one `$(... | grep | head)` made the recipe abort
+  # silently before the guard below — `grep` exits 1 on no match, and `head -1` closing the pipe
+  # gives upstream commands SIGPIPE (141); pipefail propagated either, set -e killed the script,
+  # and `2>/dev/null` hid the cause. Capture raw output so the guard can surface it on failure.
+  raw="$(sbt --client 'print fastShowPretty/version' 2>&1 || true)"
+  kindlings_version="$(printf '%s\n' "${raw}" | sed -E 's/\x1b\[[0-9;?]*[A-Za-z]//g' | grep -oE '[0-9]+\.[0-9]+\.[0-9]+[A-Za-z0-9.+-]*' | head -1 || true)"
+  if [ -z "${kindlings_version}" ]; then
+    echo "ERROR: could not determine kindlings version. sbt output was:" >&2
+    printf '%s\n' "${raw}" >&2
+    exit 1
+  fi
   echo "Using kindlings-version=${kindlings_version}"
   scala-cli run scripts/test-snippets.scala -- --extra "kindlings-version=${kindlings_version}" "$PWD/docs/user-guide"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,7 +19,7 @@ object versions {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.3.1-55-g61e5238-SNAPSHOT"
+  val hearth = "0.4.0"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -39,8 +39,8 @@ object versions {
   val scalacheck = "1.19.0"
   val scalaJavaTime = "2.7.0"
   val scalaSaxParser = "0.1.1"
-  val scalaYaml = "0.3.1"
+  val scalaYaml = "0.3.2"
   val scalaXml = "2.4.0"
   val catsTagless = "0.16.5"
-  val sconfig = "1.12.4"
+  val sconfig = "2.0.0"
 }


### PR DESCRIPTION
## Why

The `Check Scala CLI snippets from documentation` job has been red on `master` and on every open Scala Steward PR (#145, #151, #153) — but **not because of the dependency bumps**. It fails in the `test-snippets` recipe's *version-extraction* step, before the snippet tests ever run.

Because Scala Steward only rebases on conflict, the open PRs never pick up a master fix on their own, so this PR bundles the fix together with the pending dependency updates.

## What's in here

### 1. `docs/Justfile` — fix the silent failure
The recipe runs under `set -euo pipefail`. The version was extracted with a single folded pipeline:

```bash
kindlings_version="$(sbt --client 'print fastShowPretty/version' 2>/dev/null | sed … | grep -oE '…' | head -1)"
if [ -z "${kindlings_version}" ]; then echo "ERROR…"; exit 1; fi
```

That aborts the whole recipe **at the assignment, before the guard**, whenever the pipeline returns non-zero:
- `grep -oE` exits `1` on no match, **and/or**
- `head -1` closes the pipe → upstream `grep`/`sed`/`sbt` get **SIGPIPE (141)**.

`pipefail` propagates either, `set -e` kills the script, and `2>/dev/null` hides the cause — so the job dies ~0.1s after the `publish-local-for-tests` step with **no** `Using kindlings-version=`, **no** `ERROR: could not determine`, and **no** scala-cli output (the snippets never run). Confirmed in runs [28119234787](https://github.com/kubuszok/kindlings/actions/runs/28119234787) (#153) and [27973258905](https://github.com/kubuszok/kindlings/actions/runs/27973258905) (#145).

Fix: split the sbt call and the grep pipeline into separate statements, each `|| true`, so the explicit `if [ -z ]` guard handles an empty result — and capture raw sbt output so the guard prints it when extraction genuinely fails.

### 2. `project/Versions.scala` — pending Steward bumps
- `scala-yaml` 0.3.1 → **0.3.2** (folds in #153)
- `sconfig` 1.12.4 → **2.0.0** (folds in #145)
- `hearth` `0.3.1-…-SNAPSHOT` → **0.4.0** — stable, now on Maven Central (supersedes the SNAPSHOT bump in #151)

Closes #145
Closes #151
Closes #153