### PR TITLE
Macro debug output (optics/mock/di/di-cats) + ZIO-Magic wiring graph + DI.plan endpoint + di-cats resource[F]

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -321,7 +321,7 @@ lazy val diCats = projectMatrix
   // JVM + JS only: cats-effect for Scala Native 0.5 is published from 3.7.0+, but we pin 3.6.3 (which has no
   // `cats-effect_native0.5_3` artifact). Add `VirtualAxis.native` here once the cats-effect pin moves to >= 3.7.0.
   .someVariations(versions.scalas, List(VirtualAxis.jvm, VirtualAxis.js))((useCrossQuotes ++ dev.only1VersionInIDE) *)
-  .dependsOn(di)
+  .dependsOn(di, macroCommons)
   .settings(
     moduleName := "kindlings-di-cats",
     name := "kindlings-di-cats",

--- a/build.sbt
+++ b/build.sbt
@@ -248,6 +248,7 @@ lazy val root = project
   .settings(publishSettings)
   .settings(noPublishSettings)
   .aggregate(derivationCommons.projectRefs *)
+  .aggregate(macroCommons.projectRefs *)
   .aggregate(fastShowPretty.projectRefs *)
   .aggregate(circeDerivation.projectRefs *)
   .aggregate(jsoniterDerivation.projectRefs *)
@@ -302,6 +303,7 @@ lazy val di = projectMatrix
   .someVariations(versions.scalas, versions.platforms)(
     (useCrossQuotes ++ dev.only1VersionInIDE ++ nativeEvictionWarn) *
   )
+  .dependsOn(macroCommons)
   .settings(
     moduleName := "kindlings-di",
     name := "kindlings-di",
@@ -342,6 +344,7 @@ lazy val optics = projectMatrix
   // cats-integration is a TEST dependency only: its `IsCollection`/`IsMap` providers are loaded from the classpath by
   // `loadStandardExtensions`, demonstrating that `.each` lights up over cats `NonEmpty*` purely because the provider
   // jar is present — no optics-specific cats code (see `CatsEachSpec`).
+  .dependsOn(macroCommons)
   .dependsOn(catsIntegration % Test)
   .settings(
     moduleName := "kindlings-optics",
@@ -357,6 +360,7 @@ lazy val mock = projectMatrix
   .someVariations(versions.scalas, versions.platforms)(
     (useCrossQuotes ++ dev.only1VersionInIDE ++ nativeEvictionWarn) *
   )
+  .dependsOn(macroCommons)
   .settings(
     moduleName := "kindlings-mock",
     name := "kindlings-mock",
@@ -643,6 +647,24 @@ lazy val derivationCommons = projectMatrix
     moduleName := "kindlings-derivation-commons",
     name := "kindlings-derivation-commons",
     description := "Shared compile-time utilities for Kindlings derivation modules"
+  )
+  .settings(settings *)
+  .settings(dependencies *)
+  .settings(publishSettings *)
+
+// Shared compile-time utilities for the NON-derivation, direct-style macro modules (optics, mock, di).
+// Kept separate from `derivation-commons` because those modules are not derivations and must not pull in
+// the derivation-specific machinery (DerivationPolicy/DerivationTimeout/...). Currently hosts the opt-in
+// generation-logging tracer (GenerationLogging).
+lazy val macroCommons = projectMatrix
+  .in(file("macro-commons"))
+  .someVariations(versions.scalas, versions.platforms)(
+    (useCrossQuotes ++ dev.only1VersionInIDE ++ nativeEvictionWarn) *
+  )
+  .settings(
+    moduleName := "kindlings-macro-commons",
+    name := "kindlings-macro-commons",
+    description := "Shared compile-time utilities for Kindlings direct-style (non-derivation) macro modules"
   )
   .settings(settings *)
   .settings(dependencies *)

--- a/build.sbt
+++ b/build.sbt
@@ -181,6 +181,7 @@ val noPublishSettings =
 lazy val aliases = new Aliases(
   published = Seq(
     derivationCommons,
+    macroCommons,
     fastShowPretty,
     circeDerivation,
     jsoniterDerivation,

--- a/di-cats/src/main/scala-2/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacros.scala
+++ b/di-cats/src/main/scala-2/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacros.scala
@@ -9,6 +9,22 @@ final private[dicats] class ResourceWiringMacros(val c: blackbox.Context)
     extends MacroCommonsScala2
     with ResourceWiringMacrosImpl {
 
+  protected def companionResourceCall(
+      companion: Expr_??,
+      methodName: String,
+      fType: ??,
+      expected: ??
+  ): Option[Expr_??] = {
+    import c.universe.*
+    val companionTree: Tree = companion.value.tree
+    val fTpe: c.Type = fType.asUntyped
+    val expectedTpe: c.Type = expected.asUntyped
+    // `(companion.resource[F]): Resource[F, T]` — the ascription drives the compiler to insert any `implicit Sync[F]`
+    // clause via its own implicit search; typecheck validates the whole thing (and yields `None` if unsuitable).
+    val ascribed = q"($companionTree.${TermName(methodName)}[$fTpe]): $expectedTpe"
+    scala.util.Try(c.typecheck(ascribed)).toOption.map(typed => UntypedExpr.as_??(typed))
+  }
+
   def wireResourceImpl[F[_], T](dependencies: c.Tree*)(implicit
       ft: c.WeakTypeTag[F[Any]],
       tt: c.WeakTypeTag[T]

--- a/di-cats/src/main/scala-3/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacros.scala
+++ b/di-cats/src/main/scala-3/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacros.scala
@@ -12,6 +12,44 @@ final private[dicats] class ResourceWiringMacros(q: Quotes)
   /** Create Type.Ctor1[G] — the cross-quotes plugin rewrites Type.Ctor1.of[G] here because MacroCommons is in scope. */
   def mkCtor1[G[_]](using scala.quoted.Type[G]): Type.Ctor1[G] = Type.Ctor1.of[G]
 
+  protected def companionResourceCall(
+      companion: Expr_??,
+      methodName: String,
+      fType: ??,
+      expected: ??
+  ): Option[Expr_??] = {
+    import quotes.reflect.*
+    val companionTerm = companion.value.asTerm
+    val fRepr = fType.asUntyped
+    // Apply our `F`, then apply each remaining IMPLICIT/`using` clause by running the compiler's implicit search on its
+    // (now `F`-substituted) parameter types. A remaining EXPLICIT clause means the method needs arguments we cannot
+    // supply here, so we bail (`None`) and let ordinary construction take over.
+    def applyClauses(term: Term): Option[Term] = term.tpe.widen match {
+      case mt: MethodType if mt.isImplicit =>
+        val maybeArgs = mt.paramTypes.foldRight(Option(List.empty[Term])) { (pt, acc) =>
+          acc.flatMap { rest =>
+            Implicits.search(pt) match {
+              case iss: ImplicitSearchSuccess => Some(iss.tree :: rest)
+              case _                          => None
+            }
+          }
+        }
+        maybeArgs.flatMap(args => applyClauses(Apply(term, args)))
+      case _: MethodType => None
+      case _             => Some(term)
+    }
+    companionTerm.tpe.typeSymbol.methodMember(methodName).headOption.flatMap { sym =>
+      scala.util
+        .Try(companionTerm.select(sym).appliedToType(fRepr))
+        .toOption
+        .flatMap(applyClauses)
+        .flatMap { fullyApplied =>
+          import expected.Underlying as R
+          scala.util.Try(fullyApplied.asExprOf[R]).toOption.map(_.as_??)
+        }
+    }
+  }
+
   /** Split the (already inlined) varargs literal into the individual dependency expressions, each typed as `Any`. On
     * Scala 3 `Expr[A] = scala.quoted.Expr[A]` and `Type[A] = scala.quoted.Type[A]`, so the conversions are identities.
     */

--- a/di-cats/src/main/scala/hearth/kindlings/dicats/DICats.scala
+++ b/di-cats/src/main/scala/hearth/kindlings/dicats/DICats.scala
@@ -28,4 +28,12 @@ package hearth.kindlings.dicats
   * No `Sync`/`Async`/`Applicative` constraint on `F` is required: in cats-effect 3 `Resource.pure`, `Resource.eval` and
   * `Resource#flatMap` are all constraint-free.
   */
-object DICats extends DICatsCompanionCompat
+object DICats extends DICatsCompanionCompat {
+
+  /** Special marker type — if its implicit is in scope, `wireResource` logs the generated code and the resolution logic
+    * that produced it. Import `hearth.kindlings.dicats.debug.*` to enable, or set
+    * `-Xmacro-settings:diCats.logGeneration=true`. Kept outside auto-summoned scope.
+    */
+  sealed trait LogGeneration
+  object LogGeneration extends LogGeneration
+}

--- a/di-cats/src/main/scala/hearth/kindlings/dicats/debug/package.scala
+++ b/di-cats/src/main/scala/hearth/kindlings/dicats/debug/package.scala
@@ -1,0 +1,13 @@
+package hearth.kindlings.dicats
+
+package object debug {
+
+  /** Import into the scope of a `wireResource` call to preview how the `Resource[F, _]` graph is assembled — the
+    * resolution logic and the generated code. Placed outside the `DICats` companion so the implicit is never summoned
+    * automatically.
+    *
+    * To see only the wiring *graph* (ZIO-Magic style) rather than the full generation log, use the
+    * `diCats.logWiring=tree|mermaid` scalac option instead.
+    */
+  implicit val logGenerationForDICats: DICats.LogGeneration = DICats.LogGeneration
+}

--- a/di-cats/src/main/scala/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacrosImpl.scala
+++ b/di-cats/src/main/scala/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacrosImpl.scala
@@ -2,6 +2,7 @@ package hearth.kindlings.dicats
 package internal.compiletime
 
 import hearth.MacroCommons
+import hearth.kindlings.macros.compiletime.{NodeKind, Storage, WiringGraph}
 import cats.effect.kernel.Resource
 
 /** Shared, macro-platform-agnostic implementation of the `wireResource` macro.
@@ -28,7 +29,9 @@ import cats.effect.kernel.Resource
   *
   * Implemented:
   *   - plain instances (spliced directly), `Resource[F, X]` and `F[X]` effect dependencies (folded as `flatMap`s);
-  *   - root construction via the primary constructor OR a single companion `apply`;
+  *   - root/intermediate construction via the primary constructor, a single companion `apply`, OR a companion
+  *     `def resource[F[_]: <constraints>]: Resource[F, T]` factory (Kindlings extension over macwire — we apply OUR `F`
+  *     and let the compiler resolve the context-bound implicits; see `companionResourceCall`);
   *   - parameter resolution to the single provider whose `resultType <:< paramType` (subtype-aware), with
   *     macwire-parity errors (missing dependency path / ambiguous);
   *   - factory-method (`FunctionN`) dependencies: a passed lambda / eta-expanded method whose params are themselves
@@ -53,7 +56,16 @@ import cats.effect.kernel.Resource
   * macwire's `taggingParameters` (softwaremill `@@`-tagged dependency disambiguation) is not yet ported — it needs a
   * tagging-type provider. Left cleanly unimplemented (no failing test).
   */
-private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
+private[dicats] trait ResourceWiringMacrosImpl
+    extends hearth.kindlings.macros.compiletime.GenerationLogging
+    with hearth.kindlings.macros.compiletime.WiringGraphLogging { this: MacroCommons =>
+
+  protected val generationLoggingNamespace: String = "diCats"
+  protected val wiringLoggingNamespace: String = "diCats"
+  protected def generationMarkerImported: Boolean = {
+    implicit val tpe: Type[DICats.LogGeneration] = Type.of[DICats.LogGeneration]
+    Expr.summonImplicit[DICats.LogGeneration].isDefined
+  }
 
   // ---------------------------------------------------------------------------------------------------------------
   // Provider model (port of macwire's CatsProviders.scala)
@@ -230,6 +242,9 @@ private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
     // Keys currently under construction (the DFS stack), used to detect dependency cycles before they recurse forever.
     val inProgress: scala.collection.mutable.Set[String] = scala.collection.mutable.Set.empty
     val used: scala.collection.mutable.Set[Int] = scala.collection.mutable.Set.empty
+    // Nodes collected for the ZIO-Magic-style wiring graph (keyed by type FQCN), populated during resolution.
+    val graphNodes: scala.collection.mutable.LinkedHashMap[String, WiringGraph.RawNode] =
+      scala.collection.mutable.LinkedHashMap.empty
 
     /** Providers whose `resultType` conforms to `t` (subtype-aware, excluding bottom types), with their input index. */
     def matchingProviders(t: ??): List[(Provider, Int)] = {
@@ -241,6 +256,44 @@ private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
       }
     }
   }
+
+  // ---------------------------------------------------------------------------------------------------------------
+  // Wiring-graph collection (ZIO-Magic style) — di-cats has no val/lazy/def storage (every node is shared via the
+  // monadic Resource chain), so nodes are always emitted with Storage.Inline (no storage annotation in the graph).
+  // ---------------------------------------------------------------------------------------------------------------
+
+  private def keyOf(t: ??): String = { import t.Underlying as T; Type.fqcn[T] }
+  private def displayOf(t: ??): String = {
+    import t.Underlying as T
+    Type.prettyPrint[T].replaceAll("\\[[0-9;]*m", "")
+  }
+
+  /** Record a graph node once (first write wins). */
+  private def recordGraphNode(resolver: Resolver, key: String, t: ??, kind: NodeKind, depKeys: List[String]): Unit =
+    if (!resolver.graphNodes.contains(key)) {
+      val _ = resolver.graphNodes += (key -> WiringGraph.RawNode(key, displayOf(t), kind, Storage.Inline, depKeys))
+    }
+
+  /** The graph key a dependency of type `t` resolves to — a single matching provider's result type, or (when nothing
+    * matches but `t` is wireable) `t` itself (a constructed intermediate). Mirrors [[resolveTypeViaResolver]]'s
+    * dispatch, read-only (does not consume `used`), so graph edges point at the same node keys the plan uses.
+    */
+  private def resolvedKeyOf(resolver: Resolver, t: ??): Option[String] =
+    resolver.matchingProviders(t) match {
+      case (provider, _) :: Nil => Some(keyOf(provider.resultType))
+      case Nil                  => if (isWireable(t)) Some(keyOf(t)) else None
+      case _                    => None
+    }
+
+  /** The graph keys of a method's/factory's parameters (implicit params are recorded as `Summoned` leaf nodes). */
+  private def depKeysOf(resolver: Resolver, params: List[(String, Parameter)]): List[String] =
+    params.flatMap { case (_, parameter) =>
+      if (parameter.isImplicit) {
+        val k = keyOf(parameter.tpe)
+        recordGraphNode(resolver, k, parameter.tpe, NodeKind.Summoned, Nil)
+        Some(k)
+      } else resolvedKeyOf(resolver, parameter.tpe)
+    }
 
   // ---------------------------------------------------------------------------------------------------------------
   // Build
@@ -288,7 +341,19 @@ private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
         // Unused-provider check (macwire's verifyOrder).
         val unused = providers.zipWithIndex.collect { case (p, i) if !resolver.used.contains(i) => p.describe }
         if (unused.nonEmpty) Left(s"Not used providers for the following types [${unused.mkString(", ")}]")
-        else Right(emitChain[F, T](resolver.nodes.toList, resolver.instanceBindings.toMap, rootBuilder))
+        else {
+          val expr = emitChain[F, T](resolver.nodes.toList, resolver.instanceBindings.toMap, rootBuilder)
+          val rootKey = resolvedKeyOf(resolver, Type[T].as_??).getOrElse(keyOf(Type[T].as_??))
+          emitWiringGraphIfEnabled("DICats.wireResource", rootKey, resolver.graphNodes, wiringLogModeFromSettings)
+          if (shouldWeLogGeneration) {
+            val trace = new Trace
+            trace.step(s"wireResource[${Type.prettyPrint[T]}] from ${providers.size} provided dependency(ies)")
+            trace.step("wiring graph:")
+            trace.step(wiringTreeFor(rootKey, resolver.graphNodes))
+            emitGenerationLog("DICats.wireResource", trace, expr.prettyPrint)
+          }
+          Right(expr)
+        }
     }
   }
 
@@ -335,14 +400,17 @@ private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
       case Instance(value) =>
         // Instances are spliced directly (no binding needed); record once for stability.
         if (!resolver.instanceBindings.contains(key)) resolver.instanceBindings += (key -> value)
+        recordGraphNode(resolver, key, x, NodeKind.Provided("instance"), Nil)
         (_: Map[String, Expr_??]) => resolver.instanceBindings.getOrElse(key, value)
 
       case ResourceP(value, _) =>
         ensureNode(resolver, key, x)(_ => value)
+        recordGraphNode(resolver, key, x, NodeKind.Provided("resource"), Nil)
         (bound: Map[String, Expr_??]) => bound(key)
 
       case EffectP(value, _) =>
         ensureNode(resolver, key, x)(_ => evalToResource[F, X](value))
+        recordGraphNode(resolver, key, x, NodeKind.Provided("effect"), Nil)
         (bound: Map[String, Expr_??]) => bound(key)
 
       case _: FactoryP =>
@@ -443,14 +511,16 @@ private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
     val key = Type.fqcn[X]
     val methodLabel = s"[method ${f.applyM.name}]"
 
+    val factoryParams = f.applyM.totalParameters.flatten.toList
     // Resolve the factory's params (records their nodes/missing paths now).
     val paramResolvers: List[(String, Map[String, Expr_??] => Expr_??)] =
-      f.applyM.totalParameters.flatten.toList.map { case (pname, parameter) =>
+      factoryParams.map { case (pname, parameter) =>
         if (parameter.isImplicit) pname -> summonResolver(parameter)
         else
           pname -> resolveTypeViaResolver[F](resolver, parameter.tpe, path :+ s"$methodLabel.$pname", missing)
             .getOrElse((_: Map[String, Expr_??]) => nullPlaceholder(parameter.tpe))
       }
+    recordGraphNode(resolver, key, x, NodeKind.Provided("factory"), depKeysOf(resolver, factoryParams))
 
     ensureNode(resolver, key, x) { bound =>
       val args: Map[String, Expr_??] = paramResolvers.map { case (n, r) => n -> r(bound) }.toMap
@@ -460,6 +530,34 @@ private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
     }
     (bound: Map[String, Expr_??]) => bound(key)
   }
+
+  /** Kindlings extension over macwire's autocats: use a companion `object T { def resource[F[_]: <constraints>]:
+    * Resource[F, T] }` factory when present. We apply OUR `F` as the method's type argument and summon its
+    * context-bound implicits (which Hearth does not auto-supply), then hand back the folded `Resource[F, T]`. Only
+    * methods whose sole value parameters are implicit (i.e. context bounds) are used — a `resource` method with
+    * explicit value parameters is left to ordinary construction. Returns the `Resource[F, T]` expression, or `None` if
+    * no suitable method exists.
+    */
+  private def tryCompanionResource[F[_]](
+      t: ??
+  )(implicit FCtor: Type.Ctor1[F], fAnyType: Type[F[Any]], anyType: Type[Any]): Option[Expr_??] = {
+    import t.Underlying as X
+    implicit val resourceFX: Type[Resource[F, X]] = Type.of[Resource[F, X]]
+    Type.companionObject[X].flatMap { companion =>
+      companionResourceCall(companion, "resource", FCtor.asUntyped.as_??, Type[Resource[F, X]].as_??)
+    }
+  }
+
+  /** Build `T.resource[F]` from `companion` (the companion object of `T`) and let the compiler apply the type argument
+    * `F` and resolve any context-bound implicits (`Sync[F]`, ...), ascribing the result to `expected` (`Resource[F,
+    * T]`). Returns `None` when there is no such method or it does not yield a `Resource[F, <:T]`.
+    *
+    * Platform specific: Hearth's `Method` API cannot supply an implicit/`using` clause that follows a type-parameter
+    * clause (it exposes it as an empty parameter list — see `UntypedMethodsScala3.methodExpectations`), so we build the
+    * call by raw reflection and rely on the compiler's own implicit search, which is exactly what the user's
+    * `def resource[F[_]: Sync]` expects anyway.
+    */
+  protected def companionResourceCall(companion: Expr_??, methodName: String, fType: ??, expected: ??): Option[Expr_??]
 
   /** Construct a value of type `t` via its primary constructor (or a single companion `apply`), resolving each
     * parameter via `resolveType`. Returns a builder producing the (constructed) value, or `None` if missing deps were
@@ -479,6 +577,15 @@ private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
     import t.Underlying as P
     val key = Type.fqcn[P]
     if (resolver.planned.contains(key)) return Some((bound: Map[String, Expr_??]) => bound(key))
+    // Kindlings extension over macwire's autocats: prefer a companion `T.resource[F]: Resource[F, T]` factory if one
+    // exists — apply our `F`, summon its context-bound implicits, and fold the whole construction as a Resource node.
+    tryCompanionResource[F](t) match {
+      case Some(resExpr) =>
+        ensureNode(resolver, key, t)(_ => resExpr)
+        recordGraphNode(resolver, key, t, NodeKind.Provided("resource"), Nil)
+        return Some((bound: Map[String, Expr_??]) => bound(key))
+      case None => ()
+    }
     // Cycle guard: a type re-entered while still under construction (its node not yet `planned`) is a dependency
     // cycle. Without this the DFS recurses forever — a compile-time StackOverflow. Mirrors di's `verifyNotCyclic`.
     if (resolver.inProgress.contains(key)) {
@@ -490,12 +597,14 @@ private[dicats] trait ResourceWiringMacrosImpl { this: MacroCommons =>
     val result: Option[Map[String, Expr_??] => Expr_??] = callableFor(t) match {
       case None                       => recordMissing(missing, t, path); None
       case Some((method, ownerLabel)) =>
+        val ctorParams = method.totalParameters.flatten.toList
         val paramResolvers: List[(String, Option[Map[String, Expr_??] => Expr_??])] =
-          method.totalParameters.flatten.toList.map { case (pname, parameter) =>
+          ctorParams.map { case (pname, parameter) =>
             if (parameter.isImplicit) pname -> Some(summonResolver(parameter))
             else pname -> resolveType(parameter.tpe, path :+ s"$ownerLabel.$pname")
           }
         val anyMissing = paramResolvers.exists { case (_, r) => r.isEmpty }
+        recordGraphNode(resolver, key, t, NodeKind.Constructed, depKeysOf(resolver, ctorParams))
         // Reserve the memo key BEFORE building, so shared sub-structures resolve to a single binding.
         ensureNode(resolver, key, t) { bound =>
           val args = paramResolvers.collect { case (n, Some(r)) => n -> r(bound) }.toMap

--- a/di-cats/src/test/scala/hearth/kindlings/dicats/GenerationLoggingSpec.scala
+++ b/di-cats/src/test/scala/hearth/kindlings/dicats/GenerationLoggingSpec.scala
@@ -1,0 +1,34 @@
+package hearth.kindlings.dicats
+
+import hearth.MacroSuite
+import cats.effect.{Resource, SyncIO}
+
+/** Smoke test for di-cats' opt-in generation logging: importing `hearth.kindlings.dicats.debug.*` puts the
+  * `LogGeneration` marker in scope, so `wireResource` emits (as a compiler-info message) the resolution logic, the
+  * embedded ZIO-Magic-style wiring graph, and the generated code. Exercising it here proves the logging +
+  * graph-building paths compile and run, and that the generated `Resource` is still correct.
+  */
+final class GenerationLoggingSpec extends MacroSuite {
+
+  import hearth.kindlings.dicats.debug.* // enables the generation log (incl. the wiring graph) for macros in this scope
+
+  group("wireResource with generation logging enabled") {
+
+    test("still generates a correct Resource for a mixed graph (instance + Resource dependency)") {
+      val config = new GenerationLoggingSpec.Config
+      val dbResource: Resource[SyncIO, GenerationLoggingSpec.Db] =
+        Resource.pure(new GenerationLoggingSpec.Db(config))
+      val res: Resource[SyncIO, GenerationLoggingSpec.App] =
+        DICats.wireResource[SyncIO, GenerationLoggingSpec.App](config, dbResource)
+      val app = res.use(a => SyncIO.pure(a)).unsafeRunSync()
+      (app.db.config eq config) ==> true
+      (app.config eq config) ==> true
+    }
+  }
+}
+
+object GenerationLoggingSpec {
+  final class Config
+  final class Db(val config: Config)
+  final class App(val db: Db, val config: Config)
+}

--- a/di-cats/src/test/scala/hearth/kindlings/dicats/ResourceMethodSpec.scala
+++ b/di-cats/src/test/scala/hearth/kindlings/dicats/ResourceMethodSpec.scala
@@ -1,0 +1,46 @@
+package hearth.kindlings.dicats
+
+import hearth.MacroSuite
+import cats.effect.{Resource, Sync, SyncIO}
+
+/** Tests for the Kindlings extension: auto-discovering a companion `object T { def resource[F[_]: <constraints>]:
+  * Resource[F, T] }` factory and using it to build `T` (applying our `F`, summoning its context-bound implicits).
+  */
+final class ResourceMethodSpec extends MacroSuite {
+
+  import ResourceMethodSpec.*
+
+  group("DICats.wireResource — companion resource[F] factory") {
+
+    test("uses a constraint-free companion resource[F] to build the root") {
+      val res: Resource[SyncIO, Widget] = DICats.wireResource[SyncIO, Widget]()
+      res.use(w => SyncIO.pure(w)).unsafeRunSync().id ==> 1
+    }
+
+    test("uses a context-bound companion resource[F: Sync] (summoning Sync[F])") {
+      val res: Resource[SyncIO, Gadget] = DICats.wireResource[SyncIO, Gadget]()
+      res.use(g => SyncIO.pure(g)).unsafeRunSync().n ==> 2
+    }
+
+    test("uses a companion resource[F] for a transitive dependency of the root") {
+      // App needs a Widget; Widget has no provider but its companion resource[F] supplies it.
+      val res: Resource[SyncIO, App] = DICats.wireResource[SyncIO, App]()
+      res.use(a => SyncIO.pure(a)).unsafeRunSync().widget.id ==> 1
+    }
+  }
+}
+
+object ResourceMethodSpec {
+
+  final class Widget(val id: Int)
+  object Widget {
+    def resource[F[_]]: Resource[F, Widget] = Resource.pure(new Widget(1))
+  }
+
+  final class Gadget(val n: Int)
+  object Gadget {
+    def resource[F[_]: Sync]: Resource[F, Gadget] = Resource.eval(Sync[F].delay(new Gadget(2)))
+  }
+
+  final class App(val widget: Widget)
+}

--- a/di/src/main/scala-2/hearth/kindlings/di/DICompanionCompat.scala
+++ b/di/src/main/scala-2/hearth/kindlings/di/DICompanionCompat.scala
@@ -4,6 +4,16 @@ import scala.language.experimental.macros
 
 private[di] trait DICompanionCompat {
 
+  /** Start a [[DIPlan]] builder for `A` — Kindlings' own opinionated wiring endpoint (always recursive, always caching,
+    * with customizable storage and per-type construction overrides). Finish the chain with `.build`.
+    */
+  def plan[A]: DIPlan[A] = new DIPlan[A]()
+
+  /** `DI.plan[A]....build`: consume the builder chain and generate the wired `A`. */
+  implicit class DIPlanBuildOps[A](private val plan: DIPlan[A]) {
+    def build: A = macro internal.compiletime.WiringMacros.buildPlanImpl[A]
+  }
+
   /** Construct an `A` by wiring its primary-constructor parameters from values found in the enclosing lexical scope. */
   def wire[A]: A = macro internal.compiletime.WiringMacros.wireImpl[A]
 

--- a/di/src/main/scala-2/hearth/kindlings/di/internal/compiletime/WiringMacros.scala
+++ b/di/src/main/scala-2/hearth/kindlings/di/internal/compiletime/WiringMacros.scala
@@ -20,4 +20,20 @@ final private[di] class WiringMacros(val c: blackbox.Context) extends MacroCommo
     autowireWithMembers[A](dependencies.toList)
 
   def wiredInModuleImpl(in: c.Tree): c.Expr[Wired] = wiredInModule(c.Expr[Any](in))
+
+  /** `DI.plan[A]....build` — the builder chain is the `plan` field of the enclosing `DIPlanBuildOps` value class,
+    * recovered from `c.prefix` (`new DIPlanBuildOps(plan)`), then handed to the shared [[buildPlan]].
+    */
+  def buildPlanImpl[A: c.WeakTypeTag]: c.Expr[A] = {
+    import c.universe.*
+    val planTree: Tree = c.prefix.tree match {
+      case Apply(_, List(inner)) => inner
+      case other                 =>
+        c.abort(
+          c.enclosingPosition,
+          s"`DI.plan(...).build` could not extract the builder chain from: ${showRaw(other)}"
+        )
+    }
+    buildPlan[A](c.Expr[DIPlan[A]](planTree))
+  }
 }

--- a/di/src/main/scala-3/hearth/kindlings/di/DICompanionCompat.scala
+++ b/di/src/main/scala-3/hearth/kindlings/di/DICompanionCompat.scala
@@ -2,6 +2,16 @@ package hearth.kindlings.di
 
 private[di] trait DICompanionCompat {
 
+  /** Start a [[DIPlan]] builder for `A` — Kindlings' own opinionated wiring endpoint (always recursive, always caching,
+    * with customizable storage and per-type construction overrides). Finish the chain with `.build`.
+    */
+  def plan[A]: DIPlan[A] = new DIPlan[A]()
+
+  /** `DI.plan[A]....build`: consume the builder chain and generate the wired `A`. */
+  extension [A](inline plan: DIPlan[A]) {
+    inline def build: A = ${ internal.compiletime.WiringMacros.buildPlanImpl[A]('plan) }
+  }
+
   /** Construct an `A` by wiring its primary-constructor parameters from values found in the enclosing lexical scope. */
   inline def wire[A]: A = ${ internal.compiletime.WiringMacros.wireImpl[A] }
 

--- a/di/src/main/scala-3/hearth/kindlings/di/internal/compiletime/WiringMacros.scala
+++ b/di/src/main/scala-3/hearth/kindlings/di/internal/compiletime/WiringMacros.scala
@@ -29,4 +29,7 @@ private[di] object WiringMacros {
   }
 
   def wiredInModuleImpl(in: Expr[Any])(using q: Quotes): Expr[Wired] = new WiringMacros(q).wiredInModule(in)
+
+  def buildPlanImpl[A: Type](plan: Expr[DIPlan[A]])(using q: Quotes): Expr[A] =
+    new WiringMacros(q).buildPlan[A](plan)
 }

--- a/di/src/main/scala/hearth/kindlings/di/DI.scala
+++ b/di/src/main/scala/hearth/kindlings/di/DI.scala
@@ -31,4 +31,11 @@ object DI extends DICompanionCompat {
     * call at compile time, so this body is never actually evaluated in that position.
     */
   def autowireMembersOf[T](instance: T): T = instance
+
+  /** Special marker type — if its implicit is in scope, the wiring macros log the generated code and the resolution
+    * logic that produced it. Import `hearth.kindlings.di.debug.*` to enable, or set
+    * `-Xmacro-settings:di.logGeneration=true`. Kept outside auto-summoned scope.
+    */
+  sealed trait LogGeneration
+  object LogGeneration extends LogGeneration
 }

--- a/di/src/main/scala/hearth/kindlings/di/DIPlan.scala
+++ b/di/src/main/scala/hearth/kindlings/di/DIPlan.scala
@@ -1,0 +1,57 @@
+package hearth.kindlings.di
+
+/** A fluent builder for [[DI.plan]] — Kindlings' own opinionated wiring endpoint.
+  *
+  * Unlike [[DI.wire]] / [[DI.autowire]] (which follow macwire's conventions), `DI.plan[A]` is always recursive and
+  * always caches: it builds the whole object graph reachable from `A`, instantiating each distinct type exactly once
+  * and sharing it. The builder lets you customise, without touching your domain classes:
+  *
+  *   - the '''storage strategy''' for the whole graph — [[asVals]] (default), [[asLazyVals]], [[asDefs]];
+  *   - a '''per-type storage override''' — [[storeAsVal]], [[storeAsLazyVal]], [[storeAsDef]];
+  *   - a '''per-type construction override''' — [[provide]] (`for type T, initialise it with this factory`);
+  *   - an inline '''wiring-graph dump''' (ZIO-Magic style) — [[debugTree]] / [[debugMermaid]].
+  *
+  * The chain is consumed at compile time by the `build` macro (see the platform-specific `DIPlan` companion); the
+  * methods here are never actually executed at runtime — each simply returns `this` so the chain type-checks.
+  *
+  * {{{
+  * val app: App =
+  *   DI.plan[App]
+  *     .asLazyVals                       // whole-graph default
+  *     .storeAsDef[RequestScoped]        // per-type override
+  *     .provide[Db](Db.connect())        // construction override
+  *     .debugTree                        // print the wiring graph
+  *     .build
+  * }}}
+  */
+final class DIPlan[A] private[di] () {
+
+  /** Store every constructed dependency as a `val` (the default — each is created once, eagerly). */
+  def asVals: DIPlan[A] = this
+
+  /** Store every constructed dependency as a `lazy val` (created once, on first use). */
+  def asLazyVals: DIPlan[A] = this
+
+  /** Store every constructed dependency as a `def` (re-created on every use). */
+  def asDefs: DIPlan[A] = this
+
+  /** Override the storage of `T` to a `val`, regardless of the whole-graph default. */
+  def storeAsVal[T]: DIPlan[A] = this
+
+  /** Override the storage of `T` to a `lazy val`. */
+  def storeAsLazyVal[T]: DIPlan[A] = this
+
+  /** Override the storage of `T` to a `def`. */
+  def storeAsDef[T]: DIPlan[A] = this
+
+  /** Construct `T` with `factory` instead of its constructor — "when you need a `T`, initialise it with this". The
+    * factory is by-name and evaluated according to `T`'s storage (once for `val`/`lazy val`, per-use for `def`).
+    */
+  def provide[T](factory: => T): DIPlan[A] = this
+
+  /** Print the wiring graph as an ASCII dependency tree (ZIO `ZLayer.Debug.tree` analog) at the wiring site. */
+  def debugTree: DIPlan[A] = this
+
+  /** Print the wiring graph as a Mermaid diagram + link (ZIO `ZLayer.Debug.mermaid` analog) at the wiring site. */
+  def debugMermaid: DIPlan[A] = this
+}

--- a/di/src/main/scala/hearth/kindlings/di/debug/package.scala
+++ b/di/src/main/scala/hearth/kindlings/di/debug/package.scala
@@ -1,0 +1,13 @@
+package hearth.kindlings.di
+
+package object debug {
+
+  /** Import into the scope of a wiring call (`DI.wire`/`wireRec`/`autowire`/`DI.plan(...).build`)
+    * to preview how the graph is assembled — the resolution logic and the generated code. Placed
+    * outside the `DI` companion so the implicit is never summoned automatically.
+    *
+    * To see only the wiring *graph* (ZIO-Magic style) rather than the full generation log, use the
+    * `di.logWiring=tree|mermaid` scalac option or a `DI.plan(...).debug(...)` call instead.
+    */
+  implicit val logGenerationForDI: DI.LogGeneration = DI.LogGeneration
+}

--- a/di/src/main/scala/hearth/kindlings/di/debug/package.scala
+++ b/di/src/main/scala/hearth/kindlings/di/debug/package.scala
@@ -2,9 +2,9 @@ package hearth.kindlings.di
 
 package object debug {
 
-  /** Import into the scope of a wiring call (`DI.wire`/`wireRec`/`autowire`/`DI.plan(...).build`)
-    * to preview how the graph is assembled — the resolution logic and the generated code. Placed
-    * outside the `DI` companion so the implicit is never summoned automatically.
+  /** Import into the scope of a wiring call (`DI.wire`/`wireRec`/`autowire`/`DI.plan(...).build`) to preview how the
+    * graph is assembled — the resolution logic and the generated code. Placed outside the `DI` companion so the
+    * implicit is never summoned automatically.
     *
     * To see only the wiring *graph* (ZIO-Magic style) rather than the full generation log, use the
     * `di.logWiring=tree|mermaid` scalac option or a `DI.plan(...).debug(...)` call instead.

--- a/di/src/main/scala/hearth/kindlings/di/internal/compiletime/WiringGraph.scala
+++ b/di/src/main/scala/hearth/kindlings/di/internal/compiletime/WiringGraph.scala
@@ -1,0 +1,172 @@
+package hearth.kindlings.di
+package internal.compiletime
+
+/** A rendered view of how a wiring builds its object graph, inspired by ZIO Magic / ZIO 2.0's
+  * automatic layer wiring (`ZLayer.Debug.tree` and `ZLayer.Debug.mermaid`).
+  *
+  * The macros populate a flat map of [[WiringGraph.RawNode]]s during resolution (keyed by a stable
+  * per-type key), then [[WiringGraph.fromResolved]] assembles a DAG-aware display tree: each shared
+  * dependency is drawn once and later reuses become a [[NodeKind.Reference]] leaf (so a diamond
+  * dependency is not duplicated). [[WiringGraph.renderTree]] prints that as an ASCII tree;
+  * [[WiringGraph.renderMermaid]] prints a Mermaid `graph` you can render as a real diagram.
+  *
+  * This is compile-time-only code (executed by the macro on the JVM), but it lives in shared source
+  * that also links for Scala.js / Scala Native, so it deliberately avoids `java.util.*` (no
+  * `Base64`/`Deflater`, which the JS/Native javalibs do not provide) — the base64 used for the
+  * Mermaid link is a tiny pure-Scala implementation.
+  */
+private[di] sealed trait NodeKind
+private[di] object NodeKind {
+
+  /** The root type the wiring was asked to build. */
+  case object Root extends NodeKind
+
+  /** Built by invoking a public constructor / companion `apply`. */
+  case object Constructed extends NodeKind
+
+  /** Taken from a value found in the enclosing lexical scope (`wire`/`wireRec`). */
+  case object FromScope extends NodeKind
+
+  /** Supplied explicitly — an `autowire` dependency, or a `DI.plan(...).provide[T](...)` override.
+    * `label` describes the source (e.g. `"instance"`, `"factory"`, `"provided"`).
+    */
+  final case class Provided(label: String) extends NodeKind
+
+  /** Resolved by implicit search. */
+  case object Summoned extends NodeKind
+
+  /** A node already wired earlier in the graph — drawn as a leaf to keep the tree a DAG view. */
+  case object Reference extends NodeKind
+}
+
+/** How a constructed value is stored in the generated code. */
+private[di] sealed abstract class Storage(val label: String)
+private[di] object Storage {
+  case object Inline extends Storage("inline")
+  case object Val extends Storage("val")
+  case object LazyVal extends Storage("lazy val")
+  case object Def extends Storage("def")
+}
+
+/** One node of the assembled display tree. */
+private[di] final case class WiringNode(
+    tpe: String,
+    kind: NodeKind,
+    storage: Storage,
+    deps: List[WiringNode]
+)
+
+private[di] object WiringGraph {
+
+  /** A node as collected during resolution, before the DAG-aware tree is assembled. `key` is a
+    * stable identity (a type FQCN); `depKeys` reference other collected nodes.
+    */
+  final case class RawNode(key: String, tpe: String, kind: NodeKind, storage: Storage, depKeys: List[String])
+
+  /** Assemble the display tree rooted at `rootKey`. The first time a key is reached it is expanded
+    * with its dependencies; any later reuse becomes a [[NodeKind.Reference]] leaf so shared
+    * dependencies (diamonds) are drawn exactly once — ZIO `Debug.tree` semantics.
+    */
+  def fromResolved(rootKey: String, nodes: scala.collection.Map[String, RawNode]): Option[WiringNode] = {
+    val seen = scala.collection.mutable.Set.empty[String]
+    def build(key: String): Option[WiringNode] = nodes.get(key).map { raw =>
+      if (seen(key)) WiringNode(raw.tpe, NodeKind.Reference, raw.storage, Nil)
+      else {
+        seen += key
+        WiringNode(raw.tpe, raw.kind, raw.storage, raw.depKeys.flatMap(build))
+      }
+    }
+    build(rootKey)
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // ASCII tree (ZLayer.Debug.tree analog)
+  // ----------------------------------------------------------------------------------------------
+
+  def renderTree(root: WiringNode): String = {
+    val sb = new StringBuilder
+    val _ = sb.append(shortName(root.tpe)).append(annotation(root)).append('\n')
+    renderChildren(root.deps, "", sb)
+    sb.result()
+  }
+
+  private def renderChildren(deps: List[WiringNode], prefix: String, sb: StringBuilder): Unit =
+    deps.zipWithIndex.foreach { case (node, i) =>
+      val last = i == deps.size - 1
+      val _ = sb
+        .append(prefix)
+        .append(if (last) "╰─ " else "├─ ")
+        .append(shortName(node.tpe))
+        .append(annotation(node))
+        .append('\n')
+      renderChildren(node.deps, prefix + (if (last) "   " else "│  "), sb)
+    }
+
+  private def annotation(node: WiringNode): String = node.kind match {
+    case NodeKind.Root          => ""
+    case NodeKind.Reference     => "  ↻ (shared, wired above)"
+    case NodeKind.Provided(lbl) => s"  ⇐ provided ($lbl)"
+    case NodeKind.FromScope     => "  ⇐ from scope"
+    case NodeKind.Summoned      => "  ⇐ implicit"
+    case NodeKind.Constructed   => if (node.storage == Storage.Inline) "" else s"  [${node.storage.label}]"
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // Mermaid (ZLayer.Debug.mermaid analog)
+  // ----------------------------------------------------------------------------------------------
+
+  def renderMermaid(root: WiringNode): String = {
+    val decls = scala.collection.mutable.LinkedHashMap.empty[String, String] // id -> label line
+    val edges = scala.collection.mutable.LinkedHashSet.empty[String]
+    def walk(node: WiringNode): Unit = {
+      val id = mermaidId(node.tpe)
+      val _ = decls.getOrElseUpdate(id, s"  $id[${shortName(node.tpe)}]")
+      node.deps.foreach { dep =>
+        edges += s"  $id --> ${mermaidId(dep.tpe)}"
+        walk(dep)
+      }
+    }
+    walk(root)
+    val source = ("graph TD" :: decls.values.toList ::: edges.toList).mkString("\n")
+    val link = s"https://mermaid.ink/svg/${base64Url(source)}"
+    s"""$source
+       |
+       |Render: $link
+       |(or paste the graph above into https://mermaid.live)""".stripMargin
+  }
+
+  // ----------------------------------------------------------------------------------------------
+  // helpers
+  // ----------------------------------------------------------------------------------------------
+
+  private def shortName(fqcn: String): String = {
+    val noGenerics = fqcn
+    val base = noGenerics.split('.').last
+    base
+  }
+
+  private def mermaidId(fqcn: String): String = {
+    val cleaned = fqcn.map(c => if (c.isLetterOrDigit) c else '_')
+    if (cleaned.headOption.exists(_.isDigit)) s"n$cleaned" else cleaned
+  }
+
+  /** Standard base64url (no padding), pure Scala — avoids `java.util.Base64` for JS/Native linking. */
+  private def base64Url(s: String): String = {
+    val alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789-_"
+    val bytes = s.getBytes("UTF-8")
+    val out = new StringBuilder
+    var i = 0
+    while (i < bytes.length) {
+      val b0 = bytes(i) & 0xff
+      val b1 = if (i + 1 < bytes.length) bytes(i + 1) & 0xff else 0
+      val b2 = if (i + 2 < bytes.length) bytes(i + 2) & 0xff else 0
+      val triple = (b0 << 16) | (b1 << 8) | b2
+      out.append(alphabet((triple >> 18) & 0x3f))
+      out.append(alphabet((triple >> 12) & 0x3f))
+      if (i + 1 < bytes.length) out.append(alphabet((triple >> 6) & 0x3f))
+      if (i + 2 < bytes.length) out.append(alphabet(triple & 0x3f))
+      i += 3
+    }
+    out.result()
+  }
+}

--- a/di/src/main/scala/hearth/kindlings/di/internal/compiletime/WiringMacrosImpl.scala
+++ b/di/src/main/scala/hearth/kindlings/di/internal/compiletime/WiringMacrosImpl.scala
@@ -3,77 +3,23 @@ package internal.compiletime
 
 import hearth.MacroCommons
 import hearth.fp.DirectStyle
+import hearth.kindlings.macros.compiletime.{NodeKind, Storage, WiringGraph}
 
 /** Shared, macro-platform-agnostic implementation of the wiring macros.
   *
   * Mixed into the per-platform macro bundles (`MacroCommonsScala2`/`MacroCommonsScala3`), so every method here can use
   * the full cross-platform Hearth API (`Type`, `Expr`, `Method`, `enclosingScope`, ...).
   */
-private[di] trait WiringMacrosImpl extends hearth.kindlings.macros.compiletime.GenerationLogging { this: MacroCommons =>
+private[di] trait WiringMacrosImpl
+    extends hearth.kindlings.macros.compiletime.GenerationLogging
+    with hearth.kindlings.macros.compiletime.WiringGraphLogging { this: MacroCommons =>
 
   protected val generationLoggingNamespace: String = "di"
+  protected val wiringLoggingNamespace: String = "di"
   protected def generationMarkerImported: Boolean = {
     implicit val tpe: Type[DI.LogGeneration] = Type.of[DI.LogGeneration]
     Expr.summonImplicit[DI.LogGeneration].isDefined
   }
-
-  // -------------------------------------------------------------------------------------------------------------------
-  // Wiring-graph logging (ZIO-Magic style) — see WiringGraph. Independent of the full generation log: `di.logWiring`
-  // shows ONLY how things are wired together for a single DI run.
-  // -------------------------------------------------------------------------------------------------------------------
-
-  sealed protected trait WiringLogMode
-  protected object WiringLogMode {
-    case object Tree extends WiringLogMode
-    case object Mermaid extends WiringLogMode
-  }
-
-  /** `-Xmacro-settings:di.logWiring=tree|mermaid` (or `=true`, meaning `tree`) — request a standalone wiring-graph dump
-    * for every wiring in the compilation unit.
-    */
-  protected def wiringLogModeFromSettings: Option[WiringLogMode] =
-    (for {
-      data <- Environment.typedSettings.toOption
-      di <- data.get("di")
-      v <- di.get("logWiring")
-    } yield v).flatMap { v =>
-      v.asString
-        .map(_.trim.toLowerCase)
-        .collect {
-          case "mermaid" => WiringLogMode.Mermaid
-          case "tree"    => WiringLogMode.Tree
-        }
-        .orElse(v.asBoolean.collect { case true => WiringLogMode.Tree })
-    }
-
-  private def renderWiring(root: WiringNode, mode: WiringLogMode): String = mode match {
-    case WiringLogMode.Tree    => WiringGraph.renderTree(root)
-    case WiringLogMode.Mermaid => WiringGraph.renderMermaid(root)
-  }
-
-  /** Emit a standalone wiring graph (only when `mode` is defined). Roots the tree at `rootKey`, forcing that node's
-    * kind to [[NodeKind.Root]] so the root prints without a storage annotation.
-    */
-  protected def emitWiringGraphIfEnabled(
-      endpoint: String,
-      rootKey: String,
-      nodes: scala.collection.Map[String, WiringGraph.RawNode],
-      mode: Option[WiringLogMode]
-  ): Unit = mode.foreach { m =>
-    WiringGraph.fromResolved(rootKey, nodes).foreach { root =>
-      Environment.reportInfo(s"$endpoint — wiring graph\n${renderWiring(root.copy(kind = NodeKind.Root), m)}")
-    }
-  }
-
-  /** The wiring graph rendered as an ASCII tree, for embedding inside the full generation log (when both are on). */
-  protected def wiringTreeFor(
-      rootKey: String,
-      nodes: scala.collection.Map[String, WiringGraph.RawNode]
-  ): String =
-    WiringGraph
-      .fromResolved(rootKey, nodes)
-      .map(root => WiringGraph.renderTree(root.copy(kind = NodeKind.Root)))
-      .getOrElse("")
 
   /** One in-scope candidate value: the expression that reads it, together with the source-level identifier (member
     * name) it was read from — `theDatabaseAccess`, `theB1`, ... The name is what makes ambiguity errors actionable

--- a/di/src/main/scala/hearth/kindlings/di/internal/compiletime/WiringMacrosImpl.scala
+++ b/di/src/main/scala/hearth/kindlings/di/internal/compiletime/WiringMacrosImpl.scala
@@ -9,7 +9,71 @@ import hearth.fp.DirectStyle
   * Mixed into the per-platform macro bundles (`MacroCommonsScala2`/`MacroCommonsScala3`), so every method here can use
   * the full cross-platform Hearth API (`Type`, `Expr`, `Method`, `enclosingScope`, ...).
   */
-private[di] trait WiringMacrosImpl { this: MacroCommons =>
+private[di] trait WiringMacrosImpl extends hearth.kindlings.macros.compiletime.GenerationLogging { this: MacroCommons =>
+
+  protected val generationLoggingNamespace: String = "di"
+  protected def generationMarkerImported: Boolean = {
+    implicit val tpe: Type[DI.LogGeneration] = Type.of[DI.LogGeneration]
+    Expr.summonImplicit[DI.LogGeneration].isDefined
+  }
+
+  // -------------------------------------------------------------------------------------------------------------------
+  // Wiring-graph logging (ZIO-Magic style) — see WiringGraph. Independent of the full generation log: `di.logWiring`
+  // shows ONLY how things are wired together for a single DI run.
+  // -------------------------------------------------------------------------------------------------------------------
+
+  sealed protected trait WiringLogMode
+  protected object WiringLogMode {
+    case object Tree extends WiringLogMode
+    case object Mermaid extends WiringLogMode
+  }
+
+  /** `-Xmacro-settings:di.logWiring=tree|mermaid` (or `=true`, meaning `tree`) — request a standalone wiring-graph dump
+    * for every wiring in the compilation unit.
+    */
+  protected def wiringLogModeFromSettings: Option[WiringLogMode] =
+    (for {
+      data <- Environment.typedSettings.toOption
+      di <- data.get("di")
+      v <- di.get("logWiring")
+    } yield v).flatMap { v =>
+      v.asString
+        .map(_.trim.toLowerCase)
+        .collect {
+          case "mermaid" => WiringLogMode.Mermaid
+          case "tree"    => WiringLogMode.Tree
+        }
+        .orElse(v.asBoolean.collect { case true => WiringLogMode.Tree })
+    }
+
+  private def renderWiring(root: WiringNode, mode: WiringLogMode): String = mode match {
+    case WiringLogMode.Tree    => WiringGraph.renderTree(root)
+    case WiringLogMode.Mermaid => WiringGraph.renderMermaid(root)
+  }
+
+  /** Emit a standalone wiring graph (only when `mode` is defined). Roots the tree at `rootKey`, forcing that node's
+    * kind to [[NodeKind.Root]] so the root prints without a storage annotation.
+    */
+  protected def emitWiringGraphIfEnabled(
+      endpoint: String,
+      rootKey: String,
+      nodes: scala.collection.Map[String, WiringGraph.RawNode],
+      mode: Option[WiringLogMode]
+  ): Unit = mode.foreach { m =>
+    WiringGraph.fromResolved(rootKey, nodes).foreach { root =>
+      Environment.reportInfo(s"$endpoint — wiring graph\n${renderWiring(root.copy(kind = NodeKind.Root), m)}")
+    }
+  }
+
+  /** The wiring graph rendered as an ASCII tree, for embedding inside the full generation log (when both are on). */
+  protected def wiringTreeFor(
+      rootKey: String,
+      nodes: scala.collection.Map[String, WiringGraph.RawNode]
+  ): String =
+    WiringGraph
+      .fromResolved(rootKey, nodes)
+      .map(root => WiringGraph.renderTree(root.copy(kind = NodeKind.Root)))
+      .getOrElse("")
 
   /** One in-scope candidate value: the expression that reads it, together with the source-level identifier (member
     * name) it was read from — `theDatabaseAccess`, `theB1`, ... The name is what makes ambiguity errors actionable
@@ -22,10 +86,19 @@ private[di] trait WiringMacrosImpl { this: MacroCommons =>
     * that, of a single matching companion `apply`) from a value of a compatible type found in the enclosing lexical
     * scope. Implicit parameters are resolved by implicit search rather than from scope.
     */
-  def wire[A: Type]: Expr[A] = {
+  def wire[A: Type]: Expr[A] = wireLogged("DI.wire", recursive = false)
+
+  private def wireLogged[A: Type](endpoint: String, recursive: Boolean): Expr[A] = {
     val scopes = collectScopes
-    buildInstance[A](scopes, recursive = false, Nil) match {
-      case Right(expr)  => expr
+    buildInstance[A](scopes, recursive = recursive, Nil) match {
+      case Right(expr) =>
+        if (shouldWeLogGeneration) {
+          val trace = new Trace
+          trace.step(s"$endpoint[${Type.prettyPrint[A]}] (recursive=$recursive)")
+          trace.step(s"${scopes.map(_.size).sum} candidate value(s) in ${scopes.size} enclosing scope(s)")
+          emitGenerationLog(endpoint, trace, expr.prettyPrint)
+        }
+        expr
       case Left(errors) => Environment.reportErrorAndAbort(errors)
     }
   }
@@ -34,13 +107,7 @@ private[di] trait WiringMacrosImpl { this: MacroCommons =>
     * enclosing scope is itself constructed recursively (instead of failing), as long as it is "wireable" — i.e. not a
     * `java.*`/`scala.*` library type, mirroring macwire's `isWireable` guard.
     */
-  def wireRec[A: Type]: Expr[A] = {
-    val scopes = collectScopes
-    buildInstance[A](scopes, recursive = true, Nil) match {
-      case Right(expr)  => expr
-      case Left(errors) => Environment.reportErrorAndAbort(errors)
-    }
-  }
+  def wireRec[A: Type]: Expr[A] = wireLogged("DI.wireRec", recursive = true)
 
   /** macwire-style `wireWith[RES](factory)`: resolve each parameter of the supplied factory function from the enclosing
     * scope, then apply the factory to the resolved values. The factory is any `FunctionN` value (a lambda or an
@@ -450,6 +517,9 @@ private[di] trait WiringMacrosImpl { this: MacroCommons =>
   def autowire[A: Type](rawDeps: List[Expr_??]): Expr[A] = {
     checkDuplicateDependencyTypes(rawDeps)
     val used = scala.collection.mutable.Set.empty[Int]
+    // Collected in resolution order, keyed by type FQCN — feeds both the ZIO-Magic wiring graph and the full log.
+    val graphNodes = scala.collection.mutable.LinkedHashMap.empty[String, WiringGraph.RawNode]
+    val rootKey: String = Type.fqcn[A]
 
     val block: Expr[A] = DirectStyle[ValDefs].scoped { runSafe =>
       val memo = scala.collection.mutable.LinkedHashMap.empty[String, Expr_??]
@@ -459,28 +529,40 @@ private[di] trait WiringMacrosImpl { this: MacroCommons =>
         runSafe(ValDefs.createVal[T](built.value.upcast[T])).as_??
       }
 
-      def buildViaMethod(t: ??, method: Method, breadcrumb: List[??]): Expr_?? = {
-        val arguments: Map[String, Expr_??] = method.totalParameters.flatten.toList.map { case (name, parameter) =>
+      // Build via `method`, returning the expression AND the FQCN keys of the dependencies it consumed (for the graph).
+      def buildViaMethod(t: ??, method: Method, breadcrumb: List[??]): (Expr_??, List[String]) = {
+        val params = method.totalParameters.flatten.toList
+        val arguments: Map[String, Expr_??] = params.map { case (name, parameter) =>
           val ref =
-            if (parameter.isImplicit) summonOrAbort(parameter.tpe)
-            else expand(parameter.tpe, breadcrumb :+ t)
+            if (parameter.isImplicit) {
+              val pk = keyOf(parameter.tpe)
+              val _ = graphNodes.getOrElseUpdate(
+                pk,
+                WiringGraph.RawNode(pk, displayOf(parameter.tpe), NodeKind.Summoned, Storage.Inline, Nil)
+              )
+              summonOrAbort(parameter.tpe)
+            } else expand(parameter.tpe, breadcrumb :+ t)
           name -> ref
         }.toMap
+        val depKeys = params.map { case (_, parameter) => keyOf(parameter.tpe) }
         applyArguments(method, arguments) match {
-          case Right(built) => built
+          case Right(built) => (built, depKeys)
           case Left(err)    => Environment.reportErrorAndAbort(err)
         }
       }
 
       def expand(t: ??, breadcrumb: List[??]): Expr_?? = {
         import t.Underlying as T
+        val key = Type.fqcn[T]
         memo.getOrElseUpdate(
-          Type.fqcn[T], {
+          key, {
             verifyNotCyclic(t, breadcrumb)
             verifyNotPrimitive(t, breadcrumb)
             findInstanceProvider(t, rawDeps) match {
               case Some((dep, i)) =>
                 used += i
+                graphNodes(key) =
+                  WiringGraph.RawNode(key, displayOf(t), NodeKind.Provided("instance"), Storage.Inline, Nil)
                 import dep.Underlying
                 dep.value.upcast[T].as_??
               case None =>
@@ -488,11 +570,18 @@ private[di] trait WiringMacrosImpl { this: MacroCommons =>
                   case Some((dep, i, applyM)) =>
                     used += i
                     val applied = applyM.apply(dep.value.asInstanceOf[Expr[applyM.Instance]])
-                    valNode[T](buildViaMethod(t, applied, breadcrumb))
+                    val (built, depKeys) = buildViaMethod(t, applied, breadcrumb)
+                    graphNodes(key) =
+                      WiringGraph.RawNode(key, displayOf(t), NodeKind.Provided("factory"), Storage.Val, depKeys)
+                    valNode[T](built)
                   case None =>
                     providerCallable[T] match {
-                      case Some(method) => valNode[T](buildViaMethod(t, method, breadcrumb))
-                      case None         =>
+                      case Some(method) =>
+                        val (built, depKeys) = buildViaMethod(t, method, breadcrumb)
+                        graphNodes(key) =
+                          WiringGraph.RawNode(key, displayOf(t), NodeKind.Constructed, Storage.Val, depKeys)
+                        valNode[T](built)
+                      case None =>
                         Environment.reportErrorAndAbort(
                           s"cannot find a provided dependency, public constructor or public apply method for: ${Type
                               .prettyPrint[T]}; ${wiringPath(breadcrumb :+ t)}"
@@ -510,7 +599,186 @@ private[di] trait WiringMacrosImpl { this: MacroCommons =>
     }.close
 
     verifyAllDependenciesUsed(rawDeps, used.toSet)
+    emitWiringGraphIfEnabled("DI.autowire", rootKey, graphNodes, wiringLogModeFromSettings)
+    if (shouldWeLogGeneration) {
+      val trace = new Trace
+      trace.step(s"autowire[${Type.prettyPrint[A]}] with ${rawDeps.size} provided dependency(ies)")
+      trace.step("wiring graph:")
+      trace.step(wiringTreeFor(rootKey, graphNodes))
+      emitGenerationLog("DI.autowire", trace, block.prettyPrint)
+    }
     block
+  }
+
+  /** Stable per-type key (FQCN) used to identify nodes in the wiring graph. */
+  private def keyOf(t: ??): String = { import t.Underlying as T; Type.fqcn[T] }
+
+  /** Human-readable type name for the wiring graph (ANSI colour codes from `prettyPrint` stripped for clean output). */
+  private def displayOf(t: ??): String = {
+    import t.Underlying as T
+    Type.prettyPrint[T].replaceAll("\u001b\\[[0-9;]*m", "")
+  }
+
+  // ===================================================================================================================
+  // DI.plan — Kindlings' own opinionated wiring endpoint (NOT macwire): always recursive, always caching, with a
+  // fluent builder for the storage strategy (val / lazy val / def, whole-graph default + per-type override) and
+  // per-type construction overrides (`provide[T]`). See DIPlan.
+  // ===================================================================================================================
+
+  /** One `provide[T](factory)` construction override: the target type and the (by-name) factory expression. */
+  final private case class PlanProvider(tpe: ??, factory: DestructuredExpr)
+
+  /** The configuration recovered from a `DI.plan[A]....` builder chain. */
+  final private case class PlanConfig(
+      default: Storage,
+      overrides: Map[String, Storage],
+      providers: Map[String, PlanProvider],
+      debug: Option[WiringLogMode]
+  ) {
+    def withOverride(key: String, s: Storage): PlanConfig = copy(overrides = overrides.updated(key, s))
+    def withProvider(t: ??, factory: DestructuredExpr): PlanConfig = {
+      import t.Underlying as T
+      copy(providers = providers.updated(Type.fqcn[T], PlanProvider(t, factory)))
+    }
+    def storageFor(key: String): Storage = overrides.getOrElse(key, default)
+  }
+  private object PlanConfig {
+    val empty: PlanConfig = PlanConfig(Storage.Val, Map.empty, Map.empty, None)
+  }
+
+  /** `DI.plan[A]....build`: parse the builder chain, then build a complete, always-cached object graph for `A`,
+    * honouring the requested storage strategy and construction overrides.
+    */
+  def buildPlan[A: Type](plan: Expr[DIPlan[A]]): Expr[A] = {
+    val config = parsePlanConfig[A](plan)
+    val graphNodes = scala.collection.mutable.LinkedHashMap.empty[String, WiringGraph.RawNode]
+    val rootKey: String = Type.fqcn[A]
+
+    val block: Expr[A] = DirectStyle[ValDefs].scoped { runSafe =>
+      val memo = scala.collection.mutable.LinkedHashMap.empty[String, Expr_??]
+
+      def store[T: Type](value: Expr[T], storage: Storage): Expr_?? = {
+        val vd = storage match {
+          case Storage.Val     => ValDefs.createVal[T](value)
+          case Storage.LazyVal => ValDefs.createLazy[T](value)
+          case Storage.Def     => ValDefs.createDef[T](value)
+          case Storage.Inline  => ValDefs.createVal[T](value)
+        }
+        runSafe(vd).as_??
+      }
+
+      def buildViaMethod(t: ??, method: Method, breadcrumb: List[??]): (Expr_??, List[String]) = {
+        val params = method.totalParameters.flatten.toList
+        val arguments: Map[String, Expr_??] = params.map { case (name, parameter) =>
+          val ref =
+            if (parameter.isImplicit) {
+              val pk = keyOf(parameter.tpe)
+              val _ = graphNodes.getOrElseUpdate(
+                pk,
+                WiringGraph.RawNode(pk, displayOf(parameter.tpe), NodeKind.Summoned, Storage.Inline, Nil)
+              )
+              summonOrAbort(parameter.tpe)
+            } else expand(parameter.tpe, breadcrumb :+ t)
+          name -> ref
+        }.toMap
+        val depKeys = params.map { case (_, parameter) => keyOf(parameter.tpe) }
+        applyArguments(method, arguments) match {
+          case Right(built) => (built, depKeys)
+          case Left(err)    => Environment.reportErrorAndAbort(err)
+        }
+      }
+
+      def expand(t: ??, breadcrumb: List[??]): Expr_?? = {
+        import t.Underlying as T
+        val key = Type.fqcn[T]
+        memo.getOrElseUpdate(
+          key, {
+            verifyNotCyclic(t, breadcrumb)
+            verifyNotPrimitive(t, breadcrumb)
+            val storage = config.storageFor(key)
+            config.providers.get(key) match {
+              case Some(provider) =>
+                // Construction override: initialise `T` with the user-supplied factory instead of a constructor.
+                val factory: Expr[T] = provider.factory.toUntypedExpr.asTyped[T]
+                graphNodes(key) = WiringGraph.RawNode(key, displayOf(t), NodeKind.Provided("provide"), storage, Nil)
+                store[T](factory, storage)
+              case None =>
+                providerCallable[T] match {
+                  case Some(method) =>
+                    val (built, depKeys) = buildViaMethod(t, method, breadcrumb)
+                    graphNodes(key) = WiringGraph.RawNode(key, displayOf(t), NodeKind.Constructed, storage, depKeys)
+                    import built.Underlying
+                    store[T](built.value.upcast[T], storage)
+                  case None =>
+                    Environment.reportErrorAndAbort(
+                      s"DI.plan: cannot find a public constructor, companion apply, or `.provide[_]` override for: ${Type
+                          .prettyPrint[T]}; ${wiringPath(breadcrumb :+ t)}"
+                    )
+                }
+            }
+          }
+        )
+      }
+
+      val rootRef = expand(Type[A].as_??, Nil)
+      import rootRef.Underlying
+      rootRef.value.upcast[A]
+    }.close
+
+    emitWiringGraphIfEnabled("DI.plan", rootKey, graphNodes, config.debug.orElse(wiringLogModeFromSettings))
+    if (shouldWeLogGeneration) {
+      val trace = new Trace
+      trace.step(s"plan[${Type.prettyPrint[A]}] (default storage: ${config.default.label})")
+      if (config.overrides.nonEmpty) trace.step(s"storage overrides: ${config.overrides.size}")
+      if (config.providers.nonEmpty) trace.step(s"construction overrides: ${config.providers.keys.mkString(", ")}")
+      trace.step("wiring graph:")
+      trace.step(wiringTreeFor(rootKey, graphNodes))
+      emitGenerationLog("DI.plan", trace, block.prettyPrint)
+    }
+    block
+  }
+
+  /** Walk the `DI.plan[A].asLazyVals.storeAsDef[X].provide[Y](f).debugTree` chain (via [[DestructuredExpr]]) and fold
+    * it into a [[PlanConfig]]. The receiver of each builder call is processed first, so an outer (later) call wins over
+    * an inner (earlier) one for the whole-graph default.
+    */
+  private def parsePlanConfig[A: Type](plan: Expr[DIPlan[A]]): PlanConfig = {
+    implicit val planTpe: Type[DIPlan[A]] = Type.of[DIPlan[A]]
+    def loop(d: DestructuredExpr, acc: PlanConfig): PlanConfig = d match {
+      case mc: DestructuredExpr.MethodCall =>
+        val receiver = mc.applied.collectFirst { case ai: DestructuredExpr.MethodCall.AppliedInstance => ai.value }
+        val base = receiver.map(loop(_, acc)).getOrElse(acc)
+        applyPlanCall(mc, base)
+      case _ => acc
+    }
+    loop(DestructuredExpr.parse[DIPlan[A]](plan), PlanConfig.empty)
+  }
+
+  private def applyPlanCall(mc: DestructuredExpr.MethodCall, acc: PlanConfig): PlanConfig = {
+    def typeArg: Option[??] =
+      mc.applied.collectFirst {
+        case at: DestructuredExpr.MethodCall.AppliedTypes if at.typeArgs.nonEmpty => at.typeArgs.last
+      }
+    def valueArg: Option[DestructuredExpr] =
+      mc.applied.collect { case av: DestructuredExpr.MethodCall.AppliedValues => av.args }.flatten.headOption
+    def overrideStorage(s: Storage): PlanConfig =
+      typeArg.fold(acc) { t => import t.Underlying as T; acc.withOverride(Type.fqcn[T], s) }
+    mc.method.name match {
+      case "asVals"         => acc.copy(default = Storage.Val)
+      case "asLazyVals"     => acc.copy(default = Storage.LazyVal)
+      case "asDefs"         => acc.copy(default = Storage.Def)
+      case "storeAsVal"     => overrideStorage(Storage.Val)
+      case "storeAsLazyVal" => overrideStorage(Storage.LazyVal)
+      case "storeAsDef"     => overrideStorage(Storage.Def)
+      case "provide"        =>
+        (typeArg, valueArg) match {
+          case (Some(t), Some(factory)) => acc.withProvider(t, factory)
+          case _                        => acc
+        }
+      case "debugTree"    => acc.copy(debug = Some(WiringLogMode.Tree))
+      case "debugMermaid" => acc.copy(debug = Some(WiringLogMode.Mermaid))
+      case _              => acc // `plan`, wrappers, etc.
+    }
   }
 
   /** Recover the precise static type of a single provided dependency expression. Both platforms hand the macro the

--- a/di/src/test/scala/hearth/kindlings/di/DIPlanSpec.scala
+++ b/di/src/test/scala/hearth/kindlings/di/DIPlanSpec.scala
@@ -2,8 +2,8 @@ package hearth.kindlings.di
 
 import hearth.MacroSuite
 
-/** Tests for `DI.plan[A]....build` — Kindlings' own opinionated wiring endpoint (always recursive, always caching,
-  * with a customizable storage strategy and per-type construction overrides). Reuses the `RecApp` diamond fixtures from
+/** Tests for `DI.plan[A]....build` — Kindlings' own opinionated wiring endpoint (always recursive, always caching, with
+  * a customizable storage strategy and per-type construction overrides). Reuses the `RecApp` diamond fixtures from
   * [[WiringSpec]] (`RecApp` needs a `RecService` and a `RecHandler`, both of which need a `DatabaseAccess`).
   */
 final class DIPlanSpec extends MacroSuite {

--- a/di/src/test/scala/hearth/kindlings/di/DIPlanSpec.scala
+++ b/di/src/test/scala/hearth/kindlings/di/DIPlanSpec.scala
@@ -1,0 +1,76 @@
+package hearth.kindlings.di
+
+import hearth.MacroSuite
+
+/** Tests for `DI.plan[A]....build` — Kindlings' own opinionated wiring endpoint (always recursive, always caching,
+  * with a customizable storage strategy and per-type construction overrides). Reuses the `RecApp` diamond fixtures from
+  * [[WiringSpec]] (`RecApp` needs a `RecService` and a `RecHandler`, both of which need a `DatabaseAccess`).
+  */
+final class DIPlanSpec extends MacroSuite {
+
+  group("DI.plan storage strategies") {
+
+    test("default (val) storage builds the whole graph and shares each instance exactly once") {
+      val app = DI.plan[WiringSpec.RecApp].build
+      app.service.databaseAccess ==> app.handler.databaseAccess
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+
+    test("asVals shares each instance (same as default)") {
+      val app = DI.plan[WiringSpec.RecApp].asVals.build
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+
+    test("asLazyVals shares each instance (created once, lazily)") {
+      val app = DI.plan[WiringSpec.RecApp].asLazyVals.build
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+
+    test("asDefs re-creates a dependency on each use (not shared)") {
+      val app = DI.plan[WiringSpec.RecApp].asDefs.build
+      // Every node is a `def`, so the two references to DatabaseAccess (one per consumer) each build a fresh instance.
+      assert(app.service.databaseAccess ne app.handler.databaseAccess)
+    }
+
+    test("storeAsDef overrides storage for a single type while the rest stay vals") {
+      val app = DI.plan[WiringSpec.RecApp].storeAsDef[WiringSpec.DatabaseAccess].build
+      // DatabaseAccess is a `def` (re-created per use), so the two consumers get distinct instances...
+      assert(app.service.databaseAccess ne app.handler.databaseAccess)
+      // ...while RecService/RecHandler themselves are still vals (the default), built once inside the single RecApp.
+      app.service ==> app.service
+    }
+  }
+
+  group("DI.plan construction overrides") {
+
+    test("provide supplies a factory used to construct a type instead of its constructor") {
+      val myDb = new WiringSpec.DatabaseAccess()
+      val app = DI.plan[WiringSpec.RecApp].provide[WiringSpec.DatabaseAccess](myDb).build
+      // Both consumers receive the provided instance (stored once as a val by default).
+      assert(app.service.databaseAccess eq myDb)
+      assert(app.handler.databaseAccess eq myDb)
+    }
+
+    test("provide combined with a storage override still wires correctly") {
+      val app = DI
+        .plan[WiringSpec.RecApp]
+        .asLazyVals
+        .provide[WiringSpec.DatabaseAccess](new WiringSpec.DatabaseAccess())
+        .build
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+  }
+
+  group("DI.plan debug") {
+
+    test("debugTree compiles and produces a wired instance") {
+      val app = DI.plan[WiringSpec.RecApp].debugTree.build
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+
+    test("debugMermaid compiles and produces a wired instance") {
+      val app = DI.plan[WiringSpec.RecApp].debugMermaid.build
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+  }
+}

--- a/di/src/test/scala/hearth/kindlings/di/WiringGraphSpec.scala
+++ b/di/src/test/scala/hearth/kindlings/di/WiringGraphSpec.scala
@@ -1,7 +1,7 @@
 package hearth.kindlings.di
 
 import hearth.MacroSuite
-import hearth.kindlings.di.internal.compiletime.{NodeKind, Storage, WiringGraph}
+import hearth.kindlings.macros.compiletime.{NodeKind, Storage, WiringGraph}
 
 /** Pure unit tests for the ZIO-Magic-style wiring-graph renderers (no macro expansion). Exercises a diamond graph
   * (`App` depends on `Service` and `Handler`, both of which depend on the shared `Db`) to prove the tree view is
@@ -10,10 +10,10 @@ import hearth.kindlings.di.internal.compiletime.{NodeKind, Storage, WiringGraph}
 final class WiringGraphSpec extends MacroSuite {
 
   private val diamond: Map[String, WiringGraph.RawNode] = Map(
-    "App"     -> WiringGraph.RawNode("App", "App", NodeKind.Constructed, Storage.Val, List("Service", "Handler")),
+    "App" -> WiringGraph.RawNode("App", "App", NodeKind.Constructed, Storage.Val, List("Service", "Handler")),
     "Service" -> WiringGraph.RawNode("Service", "Service", NodeKind.Constructed, Storage.Val, List("Db")),
     "Handler" -> WiringGraph.RawNode("Handler", "Handler", NodeKind.Constructed, Storage.LazyVal, List("Db")),
-    "Db"      -> WiringGraph.RawNode("Db", "Db", NodeKind.Constructed, Storage.Val, Nil)
+    "Db" -> WiringGraph.RawNode("Db", "Db", NodeKind.Constructed, Storage.Val, Nil)
   )
 
   group("fromResolved") {

--- a/di/src/test/scala/hearth/kindlings/di/WiringGraphSpec.scala
+++ b/di/src/test/scala/hearth/kindlings/di/WiringGraphSpec.scala
@@ -1,0 +1,68 @@
+package hearth.kindlings.di
+
+import hearth.MacroSuite
+import hearth.kindlings.di.internal.compiletime.{NodeKind, Storage, WiringGraph}
+
+/** Pure unit tests for the ZIO-Magic-style wiring-graph renderers (no macro expansion). Exercises a diamond graph
+  * (`App` depends on `Service` and `Handler`, both of which depend on the shared `Db`) to prove the tree view is
+  * DAG-aware: the shared `Db` is expanded once and later referenced, not duplicated.
+  */
+final class WiringGraphSpec extends MacroSuite {
+
+  private val diamond: Map[String, WiringGraph.RawNode] = Map(
+    "App"     -> WiringGraph.RawNode("App", "App", NodeKind.Constructed, Storage.Val, List("Service", "Handler")),
+    "Service" -> WiringGraph.RawNode("Service", "Service", NodeKind.Constructed, Storage.Val, List("Db")),
+    "Handler" -> WiringGraph.RawNode("Handler", "Handler", NodeKind.Constructed, Storage.LazyVal, List("Db")),
+    "Db"      -> WiringGraph.RawNode("Db", "Db", NodeKind.Constructed, Storage.Val, Nil)
+  )
+
+  group("fromResolved") {
+
+    test("assembles a DAG-aware tree, referencing a shared node instead of duplicating it") {
+      val root = WiringGraph.fromResolved("App", diamond).get
+      root.tpe ==> "App"
+      root.deps.map(_.tpe) ==> List("Service", "Handler")
+      // Db is expanded under the first consumer (Service)...
+      val service = root.deps.head
+      service.deps.map(_.tpe) ==> List("Db")
+      service.deps.head.kind ==> NodeKind.Constructed
+      // ...and referenced (not expanded) under the second consumer (Handler).
+      val handler = root.deps(1)
+      handler.deps.map(_.tpe) ==> List("Db")
+      handler.deps.head.kind ==> NodeKind.Reference
+      handler.deps.head.deps ==> Nil
+    }
+
+    test("returns None for an unknown root") {
+      WiringGraph.fromResolved("Missing", diamond) ==> None
+    }
+  }
+
+  group("renderTree") {
+
+    test("renders every node and marks the shared node once") {
+      val tree = WiringGraph.renderTree(WiringGraph.fromResolved("App", diamond).get)
+      assert(tree.contains("App"))
+      assert(tree.contains("Service"))
+      assert(tree.contains("Handler"))
+      assert(tree.contains("Db"))
+      // exactly one "shared" marker (the second, referenced Db)
+      "↻ \\(shared".r.findAllIn(tree).size ==> 1
+    }
+  }
+
+  group("renderMermaid") {
+
+    test("emits a graph definition with deduped nodes, all edges, and a render link") {
+      val mermaid = WiringGraph.renderMermaid(WiringGraph.fromResolved("App", diamond).get)
+      assert(mermaid.contains("graph TD"))
+      assert(mermaid.contains("App --> Service"))
+      assert(mermaid.contains("App --> Handler"))
+      assert(mermaid.contains("Service --> Db"))
+      assert(mermaid.contains("Handler --> Db"))
+      assert(mermaid.contains("mermaid.ink"))
+      // Db is declared exactly once even though two edges point at it.
+      "Db\\[Db\\]".r.findAllIn(mermaid).size ==> 1
+    }
+  }
+}

--- a/docs/user-guide/debugging.md
+++ b/docs/user-guide/debugging.md
@@ -49,6 +49,45 @@ scalacOptions += "-Xmacro-settings:circeDerivation.logDerivation=true"
 | xml-derivation | `hearth.kindlings.xmlderivation.debug._` | `xmlDerivation.logDerivation=true` |
 | fast-show-pretty | `hearth.kindlings.fastshowpretty.debug._` | `fastShowPretty.logDerivation=true` |
 
+## Generation logging for the non-derivation macro modules
+
+`optics`, `mock` and `di` are not type-class derivations, but they still generate code — so they offer the same
+"see the generated code and the logic that led to it" capability under the name **`logGeneration`**. Enable it the same
+two ways (a scoped `debug` import, or a scalac option). The message shows the parsed input (path steps / overridden
+members / resolution) and the pretty-printed generated code.
+
+```scala
+// optics — preview the parsed path + generated PathModify
+import hearth.kindlings.optics.debug._
+
+// mock — preview the overridden members + generated mock
+import hearth.kindlings.mock.debug._
+
+// di — preview the resolution + generated wiring (all endpoints, including DI.plan)
+import hearth.kindlings.di.debug._
+```
+
+| Module | Debug import | Scalac setting |
+|--------|-------------|----------------|
+| optics | `hearth.kindlings.optics.debug._` | `optics.logGeneration=true` |
+| mock | `hearth.kindlings.mock.debug._` | `mock.logGeneration=true` |
+| di | `hearth.kindlings.di.debug._` | `di.logGeneration=true` |
+
+### DI wiring graph (how things combine)
+
+To see **only** how entities/resources are wired together for a single DI run — without the full generation log — `di`
+additionally offers a [ZIO-Magic](https://zio.dev)-style wiring graph (`ZLayer.Debug.tree` / `ZLayer.Debug.mermaid`
+analog). Enable it project-wide with `di.logWiring=tree` (a DAG-aware ASCII dependency tree) or `di.logWiring=mermaid`
+(a Mermaid diagram + render link):
+
+```scala
+// build.sbt
+scalacOptions += "-Xmacro-settings:di.logWiring=tree"
+```
+
+For the `DI.plan` endpoint you can also request it inline with `.debugTree` / `.debugMermaid` — see the
+[DI guide](di.md#seeing-how-things-are-wired-the-wiring-graph).
+
 ## Flame graph generation
 
 Profile how long each derivation step takes using Hearth's built-in flame graph support. Add these scalac options:

--- a/docs/user-guide/debugging.md
+++ b/docs/user-guide/debugging.md
@@ -72,13 +72,14 @@ import hearth.kindlings.di.debug._
 | optics | `hearth.kindlings.optics.debug._` | `optics.logGeneration=true` |
 | mock | `hearth.kindlings.mock.debug._` | `mock.logGeneration=true` |
 | di | `hearth.kindlings.di.debug._` | `di.logGeneration=true` |
+| di-cats | `hearth.kindlings.dicats.debug._` | `diCats.logGeneration=true` |
 
 ### DI wiring graph (how things combine)
 
 To see **only** how entities/resources are wired together for a single DI run — without the full generation log — `di`
-additionally offers a [ZIO-Magic](https://zio.dev)-style wiring graph (`ZLayer.Debug.tree` / `ZLayer.Debug.mermaid`
-analog). Enable it project-wide with `di.logWiring=tree` (a DAG-aware ASCII dependency tree) or `di.logWiring=mermaid`
-(a Mermaid diagram + render link):
+(and `di-cats`, via `diCats.logWiring`) additionally offers a [ZIO-Magic](https://zio.dev)-style wiring graph
+(`ZLayer.Debug.tree` / `ZLayer.Debug.mermaid` analog). Enable it project-wide with `di.logWiring=tree` (a DAG-aware
+ASCII dependency tree) or `di.logWiring=mermaid` (a Mermaid diagram + render link):
 
 ```scala
 // build.sbt

--- a/docs/user-guide/di-cats.md
+++ b/docs/user-guide/di-cats.md
@@ -62,8 +62,8 @@ Each argument to `wireResource` is classified by its type:
 | plain `X`           | used directly — spliced into the construction with no `Resource` wrapping       |
 
 The target itself is built from its **public primary constructor** (or, failing that, a single matching companion
-`apply`). Acquisition happens in the order the dependencies are given and release happens in reverse, exactly as if you
-had written the nested `flatMap`s by hand.
+`apply`, or a companion `resource` factory — see below). Acquisition happens in the order the dependencies are given and
+release happens in reverse, exactly as if you had written the nested `flatMap`s by hand.
 
 ```scala
 import cats.effect.{Resource, SyncIO}
@@ -79,6 +79,45 @@ val cache: SyncIO[Cache] = SyncIO(new Cache)                // effect
 
 val app: Resource[SyncIO, App] = DICats.wireResource[SyncIO, App](config, db, cache)
 ```
+
+## Companion `resource[F]` factories
+
+A very common pattern is for a component to expose its own lifecycle via a companion method
+`def resource[F[_]: <constraints>]: Resource[F, T]`. `wireResource` **discovers and uses it automatically** — when it
+needs a `T` that no dependency provides, and `T`'s companion has a `resource` method, it applies your `F` and lets the
+compiler resolve the context-bound implicits (e.g. `Sync[F]`). You don't have to pass such a component in yourself:
+
+```scala
+import cats.effect.{Resource, Sync, SyncIO}
+
+class Connection
+object Connection {
+  // acquisition/release is defined here; `F` is chosen by whoever calls `wireResource`
+  def resource[F[_]: Sync]: Resource[F, Connection] =
+    Resource.make(Sync[F].delay(new Connection))(_ => Sync[F].unit)
+}
+
+class Service(connection: Connection)
+
+// Connection is built via `Connection.resource[SyncIO]` — no need to provide it explicitly
+val service: Resource[SyncIO, Service] = DICats.wireResource[SyncIO, Service]()
+```
+
+This is a Kindlings extension over macwire's `autocats` (it has no equivalent). Both constraint-free
+(`def resource[F[_]]`) and context-bounded (`def resource[F[_]: Sync]`) shapes are supported; a `resource` method that
+takes explicit value parameters is left to ordinary construction.
+
+## Debugging
+
+`di-cats` has the same debugging capabilities as [`kindlings-di`](di.md):
+
+- **Generation logging** — import `hearth.kindlings.dicats.debug._` (or set `-Xmacro-settings:diCats.logGeneration=true`)
+  to print the resolution logic, the wiring graph, and the generated `Resource` code.
+- **Wiring graph** — set `-Xmacro-settings:diCats.logWiring=tree` (or `=mermaid`) to see *only* how the resources
+  combine, as a ZIO-Magic-style dependency tree (or Mermaid diagram). Provided instances, `Resource`/effect
+  dependencies, factories, and `resource[F]` factories are each labelled in the graph.
+
+See [Debugging & Diagnostics](debugging.md).
 
 ## Errors
 

--- a/docs/user-guide/di.md
+++ b/docs/user-guide/di.md
@@ -193,8 +193,113 @@ class AppModule(dataModule: DataModule) {
 }
 ```
 
+## `DI.plan` — recursive, cached, customizable wiring (Kindlings' own)
+
+`wire` / `wireRec` / `autowire` follow **macwire's** conventions. `DI.plan[A]` is **Kindlings' own opinionated
+endpoint** — it is *always* recursive and *always* caches (each distinct type is built once and shared), and it lets
+you customize how the graph is assembled **without touching your domain classes**. Finish the builder chain with
+`.build`:
+
+```scala
+import hearth.kindlings.di.DI
+
+class DatabaseAccess()
+class UserFinder(databaseAccess: DatabaseAccess)
+class App(userFinder: UserFinder)
+
+object Main {
+  // builds the whole graph from public constructors: App -> UserFinder -> DatabaseAccess
+  val app: App = DI.plan[App].build
+}
+```
+
+### Storage strategy
+
+By default every constructed dependency is stored as a `val`. Change the whole-graph default, or override it per type:
+
+```scala
+import hearth.kindlings.di.DI
+
+class DatabaseAccess()
+class UserFinder(databaseAccess: DatabaseAccess)
+class App(userFinder: UserFinder)
+
+object Main {
+  val app: App =
+    DI.plan[App]
+      .asLazyVals                       // whole-graph default: val | asLazyVals | asDefs
+      .storeAsDef[DatabaseAccess]       // per-type override: storeAsVal | storeAsLazyVal | storeAsDef
+      .build
+}
+```
+
+- **`asVals`** (default) / **`storeAsVal[T]`** — created once, eagerly.
+- **`asLazyVals`** / **`storeAsLazyVal[T]`** — created once, on first use.
+- **`asDefs`** / **`storeAsDef[T]`** — re-created on every use (so a `def`-stored dependency is **not** shared).
+
+### Construction overrides
+
+Tell `plan` to initialise a specific type with your own factory instead of calling its constructor — "when you need a
+`T`, use this":
+
+```scala
+import hearth.kindlings.di.DI
+
+class DatabaseAccess()
+class UserFinder(databaseAccess: DatabaseAccess)
+class App(userFinder: UserFinder)
+
+object Main {
+  val app: App =
+    DI.plan[App]
+      .provide[DatabaseAccess](new DatabaseAccess()) // by-name factory, evaluated per the type's storage
+      .build
+}
+```
+
+## Seeing how things are wired — the wiring graph
+
+Inspired by [ZIO Magic / ZIO 2.0's automatic layer wiring](https://zio.dev) (`ZLayer.Debug.tree` /
+`ZLayer.Debug.mermaid`), every DI endpoint can print how the entities/resources combine, as a DAG-aware ASCII tree or a
+[Mermaid](https://mermaid.live) diagram. For `DI.plan` request it inline with `.debugTree` / `.debugMermaid`:
+
+```scala
+import hearth.kindlings.di.DI
+
+class DatabaseAccess()
+class RecService(databaseAccess: DatabaseAccess)
+class RecHandler(databaseAccess: DatabaseAccess)
+class RecApp(service: RecService, handler: RecHandler)
+
+object Main {
+  val app: RecApp = DI.plan[RecApp].debugTree.build
+}
+```
+
+prints (at compile time) the shared `DatabaseAccess` once, referencing it under the second consumer:
+
+```text
+RecApp
+├─ RecService  [val]
+│  ╰─ DatabaseAccess  [val]
+╰─ RecHandler  [val]
+   ╰─ DatabaseAccess  ↻ (shared, wired above)
+```
+
+For **any** endpoint (including `wire`/`autowire`), enable the graph project-wide with a scalac option — `tree` for the
+ASCII view, `mermaid` for the Mermaid diagram + a render link:
+
+```scala
+scalacOptions += "-Xmacro-settings:di.logWiring=mermaid"
+```
+
+To also see the full generation log (the resolution logic **and** the generated code), enable
+`di.logGeneration` — see [Debugging & Diagnostics](debugging.md).
+
 ## Differences from macwire
 
+- **`DI.plan` is not macwire.** `wire`/`wireRec`/`autowire` mirror macwire; `DI.plan` is Kindlings' own opinionated
+  endpoint (always recursive, always caching, customizable storage + construction overrides).
 - **Cross-platform.** macwire's request/session *scopes* rely on JVM bytecode proxies; this module targets JVM,
   Scala.js and Scala Native, so those JVM-only proxy scopes are intentionally not ported.
 - **Enclosing-method parameters / locals.** Local `val`s declared before the call site are discovered on Scala 2;

--- a/docs/user-guide/mock.md
+++ b/docs/user-guide/mock.md
@@ -185,3 +185,9 @@ every platform Kindlings targets.
 
     The entire test suite for this module (`mock`/`stub`, both DSLs, ordering, matchers) passes on the JVM **and**
     Scala.js, which is exactly the gap this module closes versus ScalaMock's JVM-only proxy backend.
+
+## Debugging
+
+To preview the overridden members and the generated mock for `Mock.mock`/`Mock.stub`, enable **generation logging** —
+either import `hearth.kindlings.mock.debug._` in the file, or set `-Xmacro-settings:mock.logGeneration=true`. See
+[Debugging & Diagnostics](debugging.md).

--- a/docs/user-guide/optics.md
+++ b/docs/user-guide/optics.md
@@ -297,3 +297,9 @@ message naming the unsupported step.
   execution runs in CI.
 </content>
 </invoke>
+
+## Debugging
+
+To preview the parsed path and the generated code for a `modify`/`modifyAll`/`modifyLens`, enable **generation
+logging** — either import `hearth.kindlings.optics.debug._` in the file, or set
+`-Xmacro-settings:optics.logGeneration=true`. See [Debugging & Diagnostics](debugging.md).

--- a/macro-commons/src/main/scala/hearth/kindlings/macros/compiletime/GenerationLogging.scala
+++ b/macro-commons/src/main/scala/hearth/kindlings/macros/compiletime/GenerationLogging.scala
@@ -1,0 +1,88 @@
+package hearth.kindlings.macros.compiletime
+
+/** Shared, opt-in "print the generated code and the logic that led to it" capability for the
+  * direct-style (non-MIO) macro modules — `optics`, `mock`, `di`.
+  *
+  * The derivation modules (fast-show-pretty, cats, circe, ...) already offer this through the
+  * `LogDerivation` marker, but that rides on Hearth's MIO `Log` engine (`Log.namedScope`/`Log.info`
+  * rendered by `runToExprOrFail`). The modules mixing this trait in are plain direct-style macros
+  * (they call `Environment.reportErrorAndAbort` directly, never MIO), so they cannot reuse that
+  * machinery. This trait reproduces the same *user experience* — enable by importing the module's
+  * `debug` implicit OR by setting `-Xmacro-settings:<namespace>.logGeneration=true` — with a tiny
+  * direct-style trace accumulator instead.
+  *
+  * Mixed into a per-platform macro bundle (via the module's `...MacrosImpl` trait). Each module
+  * supplies its settings [[generationLoggingNamespace]] (e.g. `"optics"`) and whether its own
+  * `LogGeneration` marker is [[generationMarkerImported]]; everything else is shared here.
+  */
+private[kindlings] trait GenerationLogging { this: hearth.MacroCommons =>
+
+  /** Per-module settings namespace for `-Xmacro-settings:<ns>.logGeneration=true`, e.g.
+    * `"optics"` | `"mock"` | `"di"`.
+    */
+  protected def generationLoggingNamespace: String
+
+  /** Per-module: is the module's opt-in `LogGeneration` marker implicit currently in scope? Each
+    * module implements this with `Expr.summonImplicit[<its LogGeneration>].isDefined`.
+    */
+  protected def generationMarkerImported: Boolean
+
+  /** A mutable, single-expansion, indented trace of the decisions a macro made while generating
+    * code. Built regardless of whether logging is on (the calls are cheap string appends); it is
+    * only rendered and reported by [[emitGenerationLog]] when logging is enabled.
+    */
+  protected final class Trace {
+    private val sb = new StringBuilder
+    private var depth = 0
+
+    /** Record one decision/step at the current indentation. */
+    def step(message: => String): Unit = {
+      appendLines(message)
+    }
+
+    /** Record `name` as a step, then indent every step emitted inside `body` one level deeper. */
+    def scope[A](name: => String)(body: => A): A = {
+      step(name)
+      depth += 1
+      try body
+      finally depth -= 1
+    }
+
+    def render: String = if (sb.isEmpty) "(no steps recorded)" else sb.result()
+
+    private def appendLines(message: String): Unit = {
+      val indent = "  " * depth
+      // keep multi-line messages (e.g. a small rendered sub-tree) aligned under the current depth
+      message.linesIterator.foreach(line => sb.append(indent).append(line).append('\n'))
+    }
+  }
+
+  /** True when generation logging is enabled — either the module's `LogGeneration` marker is
+    * imported, or `-Xmacro-settings:<namespace>.logGeneration=true` was passed.
+    */
+  protected lazy val shouldWeLogGeneration: Boolean =
+    generationMarkerImported || logGenerationSetGlobally
+
+  private def logGenerationSetGlobally: Boolean =
+    (for {
+      data <- Environment.typedSettings.toOption
+      moduleSettings <- data.get(generationLoggingNamespace)
+      flag <- moduleSettings.get("logGeneration").flatMap(_.asBoolean)
+    } yield flag).getOrElse(false)
+
+  /** Emit the accumulated `trace` and the `generated` code as a single compiler-info message —
+    * but only when [[shouldWeLogGeneration]] is true. `generated` is by-name so the (potentially
+    * expensive) `expr.prettyPrint` is never computed when logging is off.
+    */
+  protected def emitGenerationLog(macroName: String, trace: Trace, generated: => String): Unit =
+    if (shouldWeLogGeneration) {
+      Environment.reportInfo(
+        s"""$macroName — generation log
+           |${trace.render}
+           |Generated code:
+           |$generated
+           |
+           |(enable/disable with: import hearth.kindlings.$generationLoggingNamespace.debug.* or scalac option -Xmacro-settings:$generationLoggingNamespace.logGeneration=true)""".stripMargin
+      )
+    }
+}

--- a/macro-commons/src/main/scala/hearth/kindlings/macros/compiletime/GenerationLogging.scala
+++ b/macro-commons/src/main/scala/hearth/kindlings/macros/compiletime/GenerationLogging.scala
@@ -1,44 +1,41 @@
 package hearth.kindlings.macros.compiletime
 
-/** Shared, opt-in "print the generated code and the logic that led to it" capability for the
-  * direct-style (non-MIO) macro modules — `optics`, `mock`, `di`.
+/** Shared, opt-in "print the generated code and the logic that led to it" capability for the direct-style (non-MIO)
+  * macro modules — `optics`, `mock`, `di`, `di-cats`.
   *
-  * The derivation modules (fast-show-pretty, cats, circe, ...) already offer this through the
-  * `LogDerivation` marker, but that rides on Hearth's MIO `Log` engine (`Log.namedScope`/`Log.info`
-  * rendered by `runToExprOrFail`). The modules mixing this trait in are plain direct-style macros
-  * (they call `Environment.reportErrorAndAbort` directly, never MIO), so they cannot reuse that
-  * machinery. This trait reproduces the same *user experience* — enable by importing the module's
-  * `debug` implicit OR by setting `-Xmacro-settings:<namespace>.logGeneration=true` — with a tiny
+  * The derivation modules (fast-show-pretty, cats, circe, ...) already offer this through the `LogDerivation` marker,
+  * but that rides on Hearth's MIO `Log` engine (`Log.namedScope`/`Log.info` rendered by `runToExprOrFail`). The modules
+  * mixing this trait in are plain direct-style macros (they call `Environment.reportErrorAndAbort` directly, never
+  * MIO), so they cannot reuse that machinery. This trait reproduces the same *user experience* — enable by importing
+  * the module's `debug` implicit OR by setting `-Xmacro-settings:<namespace>.logGeneration=true` — with a tiny
   * direct-style trace accumulator instead.
   *
-  * Mixed into a per-platform macro bundle (via the module's `...MacrosImpl` trait). Each module
-  * supplies its settings [[generationLoggingNamespace]] (e.g. `"optics"`) and whether its own
-  * `LogGeneration` marker is [[generationMarkerImported]]; everything else is shared here.
+  * Mixed into a per-platform macro bundle (via the module's `...MacrosImpl` trait). Each module supplies its settings
+  * [[generationLoggingNamespace]] (e.g. `"optics"`) and whether its own `LogGeneration` marker is
+  * [[generationMarkerImported]]; everything else is shared here.
   */
 private[kindlings] trait GenerationLogging { this: hearth.MacroCommons =>
 
-  /** Per-module settings namespace for `-Xmacro-settings:<ns>.logGeneration=true`, e.g.
-    * `"optics"` | `"mock"` | `"di"`.
+  /** Per-module settings namespace for `-Xmacro-settings:<ns>.logGeneration=true`, e.g. `"optics"` | `"mock"` | `"di"`.
     */
   protected def generationLoggingNamespace: String
 
-  /** Per-module: is the module's opt-in `LogGeneration` marker implicit currently in scope? Each
-    * module implements this with `Expr.summonImplicit[<its LogGeneration>].isDefined`.
+  /** Per-module: is the module's opt-in `LogGeneration` marker implicit currently in scope? Each module implements this
+    * with `Expr.summonImplicit[<its LogGeneration>].isDefined`.
     */
   protected def generationMarkerImported: Boolean
 
-  /** A mutable, single-expansion, indented trace of the decisions a macro made while generating
-    * code. Built regardless of whether logging is on (the calls are cheap string appends); it is
-    * only rendered and reported by [[emitGenerationLog]] when logging is enabled.
+  /** A mutable, single-expansion, indented trace of the decisions a macro made while generating code. Built regardless
+    * of whether logging is on (the calls are cheap string appends); it is only rendered and reported by
+    * [[emitGenerationLog]] when logging is enabled.
     */
-  protected final class Trace {
+  final protected class Trace {
     private val sb = new StringBuilder
     private var depth = 0
 
     /** Record one decision/step at the current indentation. */
-    def step(message: => String): Unit = {
+    def step(message: => String): Unit =
       appendLines(message)
-    }
 
     /** Record `name` as a step, then indent every step emitted inside `body` one level deeper. */
     def scope[A](name: => String)(body: => A): A = {
@@ -57,8 +54,8 @@ private[kindlings] trait GenerationLogging { this: hearth.MacroCommons =>
     }
   }
 
-  /** True when generation logging is enabled — either the module's `LogGeneration` marker is
-    * imported, or `-Xmacro-settings:<namespace>.logGeneration=true` was passed.
+  /** True when generation logging is enabled — either the module's `LogGeneration` marker is imported, or
+    * `-Xmacro-settings:<namespace>.logGeneration=true` was passed.
     */
   protected lazy val shouldWeLogGeneration: Boolean =
     generationMarkerImported || logGenerationSetGlobally
@@ -70,9 +67,9 @@ private[kindlings] trait GenerationLogging { this: hearth.MacroCommons =>
       flag <- moduleSettings.get("logGeneration").flatMap(_.asBoolean)
     } yield flag).getOrElse(false)
 
-  /** Emit the accumulated `trace` and the `generated` code as a single compiler-info message —
-    * but only when [[shouldWeLogGeneration]] is true. `generated` is by-name so the (potentially
-    * expensive) `expr.prettyPrint` is never computed when logging is off.
+  /** Emit the accumulated `trace` and the `generated` code as a single compiler-info message — but only when
+    * [[shouldWeLogGeneration]] is true. `generated` is by-name so the (potentially expensive) `expr.prettyPrint` is
+    * never computed when logging is off.
     */
   protected def emitGenerationLog(macroName: String, trace: Trace, generated: => String): Unit =
     if (shouldWeLogGeneration) {

--- a/macro-commons/src/main/scala/hearth/kindlings/macros/compiletime/WiringGraph.scala
+++ b/macro-commons/src/main/scala/hearth/kindlings/macros/compiletime/WiringGraph.scala
@@ -1,22 +1,20 @@
-package hearth.kindlings.di
-package internal.compiletime
+package hearth.kindlings.macros.compiletime
 
-/** A rendered view of how a wiring builds its object graph, inspired by ZIO Magic / ZIO 2.0's
-  * automatic layer wiring (`ZLayer.Debug.tree` and `ZLayer.Debug.mermaid`).
+/** A rendered view of how a wiring builds its object graph, inspired by ZIO Magic / ZIO 2.0's automatic layer wiring
+  * (`ZLayer.Debug.tree` and `ZLayer.Debug.mermaid`).
   *
-  * The macros populate a flat map of [[WiringGraph.RawNode]]s during resolution (keyed by a stable
-  * per-type key), then [[WiringGraph.fromResolved]] assembles a DAG-aware display tree: each shared
-  * dependency is drawn once and later reuses become a [[NodeKind.Reference]] leaf (so a diamond
-  * dependency is not duplicated). [[WiringGraph.renderTree]] prints that as an ASCII tree;
-  * [[WiringGraph.renderMermaid]] prints a Mermaid `graph` you can render as a real diagram.
+  * The macros populate a flat map of [[WiringGraph.RawNode]]s during resolution (keyed by a stable per-type key), then
+  * [[WiringGraph.fromResolved]] assembles a DAG-aware display tree: each shared dependency is drawn once and later
+  * reuses become a [[NodeKind.Reference]] leaf (so a diamond dependency is not duplicated). [[WiringGraph.renderTree]]
+  * prints that as an ASCII tree; [[WiringGraph.renderMermaid]] prints a Mermaid `graph` you can render as a real
+  * diagram.
   *
-  * This is compile-time-only code (executed by the macro on the JVM), but it lives in shared source
-  * that also links for Scala.js / Scala Native, so it deliberately avoids `java.util.*` (no
-  * `Base64`/`Deflater`, which the JS/Native javalibs do not provide) — the base64 used for the
-  * Mermaid link is a tiny pure-Scala implementation.
+  * This is compile-time-only code (executed by the macro on the JVM), but it lives in shared source that also links for
+  * Scala.js / Scala Native, so it deliberately avoids `java.util.*` (no `Base64`/`Deflater`, which the JS/Native
+  * javalibs do not provide) — the base64 used for the Mermaid link is a tiny pure-Scala implementation.
   */
-private[di] sealed trait NodeKind
-private[di] object NodeKind {
+sealed private[kindlings] trait NodeKind
+private[kindlings] object NodeKind {
 
   /** The root type the wiring was asked to build. */
   case object Root extends NodeKind
@@ -27,8 +25,8 @@ private[di] object NodeKind {
   /** Taken from a value found in the enclosing lexical scope (`wire`/`wireRec`). */
   case object FromScope extends NodeKind
 
-  /** Supplied explicitly — an `autowire` dependency, or a `DI.plan(...).provide[T](...)` override.
-    * `label` describes the source (e.g. `"instance"`, `"factory"`, `"provided"`).
+  /** Supplied explicitly — an `autowire` dependency, or a `DI.plan(...).provide[T](...)` override. `label` describes
+    * the source (e.g. `"instance"`, `"factory"`, `"provided"`).
     */
   final case class Provided(label: String) extends NodeKind
 
@@ -40,8 +38,8 @@ private[di] object NodeKind {
 }
 
 /** How a constructed value is stored in the generated code. */
-private[di] sealed abstract class Storage(val label: String)
-private[di] object Storage {
+sealed abstract private[kindlings] class Storage(val label: String)
+private[kindlings] object Storage {
   case object Inline extends Storage("inline")
   case object Val extends Storage("val")
   case object LazyVal extends Storage("lazy val")
@@ -49,23 +47,23 @@ private[di] object Storage {
 }
 
 /** One node of the assembled display tree. */
-private[di] final case class WiringNode(
+final private[kindlings] case class WiringNode(
     tpe: String,
     kind: NodeKind,
     storage: Storage,
     deps: List[WiringNode]
 )
 
-private[di] object WiringGraph {
+private[kindlings] object WiringGraph {
 
-  /** A node as collected during resolution, before the DAG-aware tree is assembled. `key` is a
-    * stable identity (a type FQCN); `depKeys` reference other collected nodes.
+  /** A node as collected during resolution, before the DAG-aware tree is assembled. `key` is a stable identity (a type
+    * FQCN); `depKeys` reference other collected nodes.
     */
   final case class RawNode(key: String, tpe: String, kind: NodeKind, storage: Storage, depKeys: List[String])
 
-  /** Assemble the display tree rooted at `rootKey`. The first time a key is reached it is expanded
-    * with its dependencies; any later reuse becomes a [[NodeKind.Reference]] leaf so shared
-    * dependencies (diamonds) are drawn exactly once — ZIO `Debug.tree` semantics.
+  /** Assemble the display tree rooted at `rootKey`. The first time a key is reached it is expanded with its
+    * dependencies; any later reuse becomes a [[NodeKind.Reference]] leaf so shared dependencies (diamonds) are drawn
+    * exactly once — ZIO `Debug.tree` semantics.
     */
   def fromResolved(rootKey: String, nodes: scala.collection.Map[String, RawNode]): Option[WiringNode] = {
     val seen = scala.collection.mutable.Set.empty[String]

--- a/macro-commons/src/main/scala/hearth/kindlings/macros/compiletime/WiringGraphLogging.scala
+++ b/macro-commons/src/main/scala/hearth/kindlings/macros/compiletime/WiringGraphLogging.scala
@@ -1,0 +1,66 @@
+package hearth.kindlings.macros.compiletime
+
+/** Shared, opt-in "show how things are wired together" capability for the DI-style macro modules (`di`, `di-cats`),
+  * modelled on ZIO Magic / ZIO 2.0's automatic layer wiring (`ZLayer.Debug.tree` / `ZLayer.Debug.mermaid`).
+  *
+  * A module collects a flat map of [[WiringGraph.RawNode]]s during resolution, then this trait renders it — either as a
+  * DAG-aware ASCII dependency tree or a Mermaid diagram — independently of the full generation log, so a user can see
+  * *only* how a single wiring run combines its entities/resources. Enable per-module with
+  * `-Xmacro-settings:<namespace>.logWiring=tree|mermaid` (or `=true`, meaning `tree`).
+  */
+private[kindlings] trait WiringGraphLogging { this: hearth.MacroCommons =>
+
+  /** Per-module settings namespace for `-Xmacro-settings:<ns>.logWiring=...`, e.g. `"di"` | `"diCats"`. */
+  protected def wiringLoggingNamespace: String
+
+  sealed protected trait WiringLogMode
+  protected object WiringLogMode {
+    case object Tree extends WiringLogMode
+    case object Mermaid extends WiringLogMode
+  }
+
+  /** The wiring-graph mode requested via `-Xmacro-settings:<ns>.logWiring=tree|mermaid` (or `=true` → tree). */
+  protected def wiringLogModeFromSettings: Option[WiringLogMode] =
+    (for {
+      data <- Environment.typedSettings.toOption
+      ns <- data.get(wiringLoggingNamespace)
+      v <- ns.get("logWiring")
+    } yield v).flatMap { v =>
+      v.asString
+        .map(_.trim.toLowerCase)
+        .collect {
+          case "mermaid" => WiringLogMode.Mermaid
+          case "tree"    => WiringLogMode.Tree
+        }
+        .orElse(v.asBoolean.collect { case true => WiringLogMode.Tree })
+    }
+
+  private def renderWiring(root: WiringNode, mode: WiringLogMode): String = mode match {
+    case WiringLogMode.Tree    => WiringGraph.renderTree(root)
+    case WiringLogMode.Mermaid => WiringGraph.renderMermaid(root)
+  }
+
+  /** Emit a standalone wiring graph (only when `mode` is defined). Roots the tree at `rootKey`, forcing that node's
+    * kind to [[NodeKind.Root]] so the root prints without a storage annotation.
+    */
+  protected def emitWiringGraphIfEnabled(
+      endpoint: String,
+      rootKey: String,
+      nodes: scala.collection.Map[String, WiringGraph.RawNode],
+      mode: Option[WiringLogMode]
+  ): Unit = mode.foreach { m =>
+    WiringGraph.fromResolved(rootKey, nodes).foreach { root =>
+      Environment.reportInfo(s"$endpoint — wiring graph\n${renderWiring(root.copy(kind = NodeKind.Root), m)}")
+    }
+  }
+
+  /** The wiring graph rendered as an ASCII tree, for embedding inside a full generation log (when both are on). */
+  protected def wiringTreeFor(
+      rootKey: String,
+      nodes: scala.collection.Map[String, WiringGraph.RawNode]
+  ): String =
+    WiringGraph
+      .fromResolved(rootKey, nodes)
+      .map(root => WiringGraph.renderTree(root.copy(kind = NodeKind.Root)))
+      .getOrElse("")
+}

--- a/mock/src/main/scala/hearth/kindlings/mock/Mock.scala
+++ b/mock/src/main/scala/hearth/kindlings/mock/Mock.scala
@@ -17,4 +17,12 @@ package hearth.kindlings.mock
   * ctx.verifyExpectations()
   * }}}
   */
-object Mock extends MockCompanionCompat
+object Mock extends MockCompanionCompat {
+
+  /** Special marker type — if its implicit is in scope, the mock macros log the generated code and the logic
+    * (overridden members) that produced it. Import `hearth.kindlings.mock.debug.*` to enable, or set
+    * `-Xmacro-settings:mock.logGeneration=true`. Kept outside auto-summoned scope.
+    */
+  sealed trait LogGeneration
+  object LogGeneration extends LogGeneration
+}

--- a/mock/src/main/scala/hearth/kindlings/mock/debug/package.scala
+++ b/mock/src/main/scala/hearth/kindlings/mock/debug/package.scala
@@ -1,0 +1,10 @@
+package hearth.kindlings.mock
+
+package object debug {
+
+  /** Import into the scope of a `Mock.mock`/`Mock.stub` (or `expects`/`when`/`verify`) call to
+    * preview how the mock is synthesized — the overridden members and the generated code. Placed
+    * outside the `Mock` companion so the implicit is never summoned automatically.
+    */
+  implicit val logGenerationForMock: Mock.LogGeneration = Mock.LogGeneration
+}

--- a/mock/src/main/scala/hearth/kindlings/mock/debug/package.scala
+++ b/mock/src/main/scala/hearth/kindlings/mock/debug/package.scala
@@ -2,9 +2,9 @@ package hearth.kindlings.mock
 
 package object debug {
 
-  /** Import into the scope of a `Mock.mock`/`Mock.stub` (or `expects`/`when`/`verify`) call to
-    * preview how the mock is synthesized — the overridden members and the generated code. Placed
-    * outside the `Mock` companion so the implicit is never summoned automatically.
+  /** Import into the scope of a `Mock.mock`/`Mock.stub` (or `expects`/`when`/`verify`) call to preview how the mock is
+    * synthesized — the overridden members and the generated code. Placed outside the `Mock` companion so the implicit
+    * is never summoned automatically.
     */
   implicit val logGenerationForMock: Mock.LogGeneration = Mock.LogGeneration
 }

--- a/mock/src/main/scala/hearth/kindlings/mock/internal/compiletime/MockMacrosImpl.scala
+++ b/mock/src/main/scala/hearth/kindlings/mock/internal/compiletime/MockMacrosImpl.scala
@@ -8,41 +8,54 @@ import hearth.MacroCommons
   * Uses Hearth's [[hearth.typed.Classes.AnonymousInstance]] to synthesize an anonymous subtype of the mocked type whose
   * every abstract member forwards into the runtime [[MockContext]] supplied at the call site.
   */
-private[mock] trait MockMacrosImpl { this: MacroCommons =>
+private[mock] trait MockMacrosImpl extends hearth.kindlings.macros.compiletime.GenerationLogging { this: MacroCommons =>
+
+  protected val generationLoggingNamespace: String = "mock"
+  protected def generationMarkerImported: Boolean = {
+    implicit val tpe: Type[Mock.LogGeneration] = Type.of[Mock.LogGeneration]
+    Expr.summonImplicit[Mock.LogGeneration].isDefined
+  }
 
   def mockType[A: Type](ctx: Expr[MockContext]): Expr[A] =
-    AnonymousInstance.parse[A] match {
-      case ClassViewResult.Incompatible(reason) =>
-        Environment.reportErrorAndAbort(s"Cannot mock ${Type.prettyPrint[A]}: $reason")
-      case ClassViewResult.Compatible(ai) =>
-        val overrides: Map[UntypedMethod, OverrideBody] =
-          ai.mustOverride.map(cm => cm.method.asUntyped -> forwardingBody(ctx, cm)).toMap
-        val (ctor, ctorArgs) = constructorAndArgs(ai.classParent)
-        ai.construct(ctor, ctorArgs, overrides) match {
-          case Right(instance) => instance
-          case Left(errors)    =>
-            Environment.reportErrorAndAbort(s"Cannot mock ${Type.prettyPrint[A]}: ${errors.toVector.mkString("; ")}")
-        }
+    synthesizeMock[A](kind = "mock", ctx, (c, cm) => forwardingBody(c, cm))
+
+  private def synthesizeMock[A: Type](
+      kind: String,
+      ctx: Expr[MockContext],
+      bodyFor: (Expr[MockContext], ClassifiedMethod) => OverrideBody
+  ): Expr[A] = {
+    val trace = new Trace
+    trace.scope(s"$kind[${Type.prettyPrint[A]}]") {
+      AnonymousInstance.parse[A] match {
+        case ClassViewResult.Incompatible(reason) =>
+          Environment.reportErrorAndAbort(s"Cannot $kind ${Type.prettyPrint[A]}: $reason")
+        case ClassViewResult.Compatible(ai) =>
+          val members = ai.mustOverride
+          trace.step(s"overriding ${members.size} member(s): ${members.map(_.method.name).mkString(", ")}")
+          val overrides: Map[UntypedMethod, OverrideBody] =
+            members.map(cm => cm.method.asUntyped -> bodyFor(ctx, cm)).toMap
+          val (ctor, ctorArgs) = constructorAndArgs(ai.classParent)
+          trace.step(ctor match {
+            case Some(_) => s"invoking parent constructor with ${ctorArgs.size} seeded argument(s)"
+            case None    => "trait parent — no constructor to invoke"
+          })
+          ai.construct(ctor, ctorArgs, overrides) match {
+            case Right(instance) =>
+              emitGenerationLog(s"Mock.$kind", trace, instance.prettyPrint)
+              instance
+            case Left(errors) =>
+              Environment.reportErrorAndAbort(s"Cannot $kind ${Type.prettyPrint[A]}: ${errors.toVector.mkString("; ")}")
+          }
+      }
     }
+  }
 
   /** `Mock.stub[A]`: like [[mockType]] but each abstract member forwards into [[MockContext.handleStub]] so unexpected
     * calls return a default (from a summoned [[Defaultable]], or `null`) instead of failing, and behaviour is preset
     * lazily via `when(...)` and checked post-hoc via `verify(...)`.
     */
   def stubType[A: Type](ctx: Expr[MockContext]): Expr[A] =
-    AnonymousInstance.parse[A] match {
-      case ClassViewResult.Incompatible(reason) =>
-        Environment.reportErrorAndAbort(s"Cannot stub ${Type.prettyPrint[A]}: $reason")
-      case ClassViewResult.Compatible(ai) =>
-        val overrides: Map[UntypedMethod, OverrideBody] =
-          ai.mustOverride.map(cm => cm.method.asUntyped -> stubBody(ctx, cm)).toMap
-        val (ctor, ctorArgs) = constructorAndArgs(ai.classParent)
-        ai.construct(ctor, ctorArgs, overrides) match {
-          case Right(instance) => instance
-          case Left(errors)    =>
-            Environment.reportErrorAndAbort(s"Cannot stub ${Type.prettyPrint[A]}: ${errors.toVector.mkString("; ")}")
-        }
-    }
+    synthesizeMock[A](kind = "stub", ctx, (c, cm) => stubBody(c, cm))
 
   /** When mocking a CLASS (not a trait), Hearth's `AnonymousInstance` exposes the parent's accessible constructors in
     * `classParent`; the synthesized subtype must invoke one. We pick the primary (first) constructor and supply a dummy

--- a/mock/src/test/scala/hearth/kindlings/mock/GenerationLoggingSpec.scala
+++ b/mock/src/test/scala/hearth/kindlings/mock/GenerationLoggingSpec.scala
@@ -3,9 +3,8 @@ package hearth.kindlings.mock
 import hearth.MacroSuite
 
 /** Smoke test for the opt-in generation logging: importing `hearth.kindlings.mock.debug.*` puts the `LogGeneration`
-  * marker in scope, so `Mock.mock`/`Mock.stub` emit the overridden members + generated code as a compiler-info
-  * message. Exercising a mock with the import in scope proves the logging path compiles and still generates a working
-  * mock.
+  * marker in scope, so `Mock.mock`/`Mock.stub` emit the overridden members + generated code as a compiler-info message.
+  * Exercising a mock with the import in scope proves the logging path compiles and still generates a working mock.
   */
 final class GenerationLoggingSpec extends MacroSuite {
 

--- a/mock/src/test/scala/hearth/kindlings/mock/GenerationLoggingSpec.scala
+++ b/mock/src/test/scala/hearth/kindlings/mock/GenerationLoggingSpec.scala
@@ -1,0 +1,28 @@
+package hearth.kindlings.mock
+
+import hearth.MacroSuite
+
+/** Smoke test for the opt-in generation logging: importing `hearth.kindlings.mock.debug.*` puts the `LogGeneration`
+  * marker in scope, so `Mock.mock`/`Mock.stub` emit the overridden members + generated code as a compiler-info
+  * message. Exercising a mock with the import in scope proves the logging path compiles and still generates a working
+  * mock.
+  */
+final class GenerationLoggingSpec extends MacroSuite {
+
+  import hearth.kindlings.mock.debug.* // enables the generation log for macros in this scope
+
+  group("mock with generation logging enabled") {
+
+    test("still generates a working mock") {
+      implicit val ctx: MockContext = new MockContext
+      val greeter = Mock.mock[GenerationLoggingSpec.Greeter]
+      val _ = ctx.expecting("greet", "world").returning("hello, world")
+      greeter.greet("world") ==> "hello, world"
+      ctx.verifyExpectations()
+    }
+  }
+}
+
+object GenerationLoggingSpec {
+  trait Greeter { def greet(name: String): String }
+}

--- a/optics/src/main/scala/hearth/kindlings/optics/LogGeneration.scala
+++ b/optics/src/main/scala/hearth/kindlings/optics/LogGeneration.scala
@@ -1,0 +1,11 @@
+package hearth.kindlings.optics
+
+/** Special marker type — if its implicit is in scope, the optics macros (`modify`/`modifyAll`/
+  * `modifyLens`) log the generated code and the logic (parsed path steps) that produced it.
+  *
+  * Enable by importing `hearth.kindlings.optics.debug.*`, or globally with the scalac option
+  * `-Xmacro-settings:optics.logGeneration=true`. Kept out of the `optics` package object so it is
+  * never summoned automatically.
+  */
+sealed trait LogGeneration
+object LogGeneration extends LogGeneration

--- a/optics/src/main/scala/hearth/kindlings/optics/LogGeneration.scala
+++ b/optics/src/main/scala/hearth/kindlings/optics/LogGeneration.scala
@@ -1,11 +1,11 @@
 package hearth.kindlings.optics
 
-/** Special marker type — if its implicit is in scope, the optics macros (`modify`/`modifyAll`/
-  * `modifyLens`) log the generated code and the logic (parsed path steps) that produced it.
+/** Special marker type — if its implicit is in scope, the optics macros (`modify`/`modifyAll`/ `modifyLens`) log the
+  * generated code and the logic (parsed path steps) that produced it.
   *
   * Enable by importing `hearth.kindlings.optics.debug.*`, or globally with the scalac option
-  * `-Xmacro-settings:optics.logGeneration=true`. Kept out of the `optics` package object so it is
-  * never summoned automatically.
+  * `-Xmacro-settings:optics.logGeneration=true`. Kept out of the `optics` package object so it is never summoned
+  * automatically.
   */
 sealed trait LogGeneration
 object LogGeneration extends LogGeneration

--- a/optics/src/main/scala/hearth/kindlings/optics/debug/package.scala
+++ b/optics/src/main/scala/hearth/kindlings/optics/debug/package.scala
@@ -1,0 +1,10 @@
+package hearth.kindlings.optics
+
+package object debug {
+
+  /** Import into the scope of a `modify`/`modifyAll`/`modifyLens` call to preview how the optics
+    * macro rewrites your path — the parsed steps and the generated code. Placed outside the `optics`
+    * package object so the implicit is never summoned automatically.
+    */
+  implicit val logGenerationForOptics: LogGeneration = LogGeneration
+}

--- a/optics/src/main/scala/hearth/kindlings/optics/debug/package.scala
+++ b/optics/src/main/scala/hearth/kindlings/optics/debug/package.scala
@@ -2,9 +2,9 @@ package hearth.kindlings.optics
 
 package object debug {
 
-  /** Import into the scope of a `modify`/`modifyAll`/`modifyLens` call to preview how the optics
-    * macro rewrites your path — the parsed steps and the generated code. Placed outside the `optics`
-    * package object so the implicit is never summoned automatically.
+  /** Import into the scope of a `modify`/`modifyAll`/`modifyLens` call to preview how the optics macro rewrites your
+    * path — the parsed steps and the generated code. Placed outside the `optics` package object so the implicit is
+    * never summoned automatically.
     */
   implicit val logGenerationForOptics: LogGeneration = LogGeneration
 }

--- a/optics/src/main/scala/hearth/kindlings/optics/internal/compiletime/ModifyMacrosImpl.scala
+++ b/optics/src/main/scala/hearth/kindlings/optics/internal/compiletime/ModifyMacrosImpl.scala
@@ -30,7 +30,14 @@ import _root_.hearth.kindlings.optics.IsEither as OpticsEither
   * `value match { case s: Subtype => f(s); case other => other }` built via [[MatchCase.typeMatch]]. `modifyAll` and
   * lens composition (`modifyLens`/`andThenModify`) build on the same steps.
   */
-private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
+private[optics] trait ModifyMacrosImpl extends hearth.kindlings.macros.compiletime.GenerationLogging {
+  this: MacroCommons & StdExtensions =>
+
+  protected val generationLoggingNamespace: String = "optics"
+  protected def generationMarkerImported: Boolean = {
+    implicit val tpe: Type[LogGeneration] = Type.of[LogGeneration]
+    Expr.summonImplicit[LogGeneration].isDefined
+  }
 
   // optics consumes Hearth's collection/map/option/either SPI (`IsCollection`/`IsMap`/`IsOption`/`IsEither`) to traverse
   // `.each`/`.eachLeft`/... over ANY supported container — built-ins plus anything a provider jar on the classpath
@@ -105,9 +112,33 @@ private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
     * so even leaf `.each`/`.eachWhere` paths produce a precise `A`. The macro additionally re-derives the element type
     * from the parsed container, so the codegen never depends on `A`'s inference being perfect.
     */
+  /** A compact human-readable rendering of a parsed path, for the generation log (e.g. `.a.xs.each.b`). */
+  private def describeSteps(steps: List[PathStep]): String =
+    if (steps.isEmpty) "(identity)" else steps.map(describeStep).mkString
+  private def describeStep(step: PathStep): String = step match {
+    case PathStep.Field(name)                  => s".$name"
+    case PathStep.Each(_, _, predicate, isMap) =>
+      val base = if (isMap) ".eachValue" else ".each"
+      if (predicate.isDefined) s"$base(where)" else base
+    case PathStep.At(_, _, kind, shape, _, _) =>
+      val k = kind match {
+        case PathStep.AtKind.At       => "at"
+        case PathStep.AtKind.Index    => "index"
+        case PathStep.AtKind.AtOrElse => "atOrElse"
+      }
+      s".$k<$shape>"
+    case PathStep.EachEither(_, _, isLeft) => if (isLeft) ".eachLeft" else ".eachRight"
+    case PathStep.When(subtype)            =>
+      import subtype.Underlying as T
+      s".when[${Type.prettyPrint[T]}]"
+  }
+
   def modify[S: Type, A: Type](obj: Expr[S], path: Expr[S => A]): Expr[PathModify[S, A]] = {
     ensureStdExtensionsLoaded()
+    val trace = new Trace
     val steps: List[PathStep] = parsePath[S, A](path)
+    trace.step(s"modify[${Type.prettyPrint[S]} => ${Type.prettyPrint[A]}]")
+    trace.step(s"parsed path: ${describeSteps(steps)}")
     // Build the copy-with-modification function `(s, mod) => <rebuilt s>`, where the leaf transformation applied at the
     // focus is exactly `mod(<leaf>)`. The lambda parameters `s`/`mod` are quote-bound; their `Expr` handles are
     // recovered for the macro-side `buildModify` via `Expr.quote(s)` / `Expr.quote(mod)` (the standard Hearth cross-quote
@@ -121,7 +152,9 @@ private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
         }
       }
 
-    Expr.quote(PathModify[S, A](Expr.splice(obj), Expr.splice(doModify)))
+    val result = Expr.quote(PathModify[S, A](Expr.splice(obj), Expr.splice(doModify)))
+    emitGenerationLog("modify", trace, result.prettyPrint)
+    result
   }
 
   /** Materialize the `.each` evidence `IsElementOf.Aux[C, Elem]` by checking the std SPI: `Elem` is the value type of
@@ -239,7 +272,10 @@ private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
   def modifyAll[S: Type, A: Type](obj: Expr[S], paths: List[Expr[S => A]]): Expr[PathModify[S, A]] = {
     ensureStdExtensionsLoaded()
     if (paths.isEmpty) abort("`modifyAll` requires at least one path")
+    val trace = new Trace
     val pathSteps: List[List[PathStep]] = paths.map(parsePath[S, A])
+    trace.step(s"modifyAll[${Type.prettyPrint[S]} => ${Type.prettyPrint[A]}] over ${pathSteps.size} path(s)")
+    pathSteps.foreach(steps => trace.step(s"  parsed path: ${describeSteps(steps)}"))
     val doModify: Expr[(S, A => A) => S] =
       Expr.quote { (s: S, mod: A => A) =>
         Expr.splice {
@@ -248,7 +284,9 @@ private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
           }
         }
       }
-    Expr.quote(PathModify[S, A](Expr.splice(obj), Expr.splice(doModify)))
+    val result = Expr.quote(PathModify[S, A](Expr.splice(obj), Expr.splice(doModify)))
+    emitGenerationLog("modifyAll", trace, result.prettyPrint)
+    result
   }
 
   /** `modifyLens[T](_.a.b)` → `PathLazyModify[T, U]`: a reusable lens NOT bound to an object. Same machinery as
@@ -256,7 +294,10 @@ private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
     */
   def modifyLens[T: Type, Foc: Type](path: Expr[T => Foc]): Expr[PathLazyModify[T, Foc]] = {
     ensureStdExtensionsLoaded()
+    val trace = new Trace
     val steps: List[PathStep] = parsePath[T, Foc](path)
+    trace.step(s"modifyLens[${Type.prettyPrint[T]} => ${Type.prettyPrint[Foc]}]")
+    trace.step(s"parsed path: ${describeSteps(steps)}")
     val doModify: Expr[(T, Foc => Foc) => T] =
       Expr.quote { (t: T, mod: Foc => Foc) =>
         Expr.splice {
@@ -265,7 +306,9 @@ private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
           }
         }
       }
-    Expr.quote(PathLazyModify[T, Foc](Expr.splice(doModify)))
+    val result = Expr.quote(PathLazyModify[T, Foc](Expr.splice(doModify)))
+    emitGenerationLog("modifyLens", trace, result.prettyPrint)
+    result
   }
 
   /** `modifyAllLens[T](_.a, _.b)` → `PathLazyModify[T, Foc]`: the multi-path reusable lens form. Same shared-prefix
@@ -274,7 +317,10 @@ private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
   def modifyAllLens[T: Type, Foc: Type](paths: List[Expr[T => Foc]]): Expr[PathLazyModify[T, Foc]] = {
     ensureStdExtensionsLoaded()
     if (paths.isEmpty) abort("`modifyAllLens` requires at least one path")
+    val trace = new Trace
     val pathSteps: List[List[PathStep]] = paths.map(parsePath[T, Foc])
+    trace.step(s"modifyAllLens[${Type.prettyPrint[T]} => ${Type.prettyPrint[Foc]}] over ${pathSteps.size} path(s)")
+    pathSteps.foreach(steps => trace.step(s"  parsed path: ${describeSteps(steps)}"))
     val doModify: Expr[(T, Foc => Foc) => T] =
       Expr.quote { (t: T, mod: Foc => Foc) =>
         Expr.splice {
@@ -283,7 +329,9 @@ private[optics] trait ModifyMacrosImpl { this: MacroCommons & StdExtensions =>
           }
         }
       }
-    Expr.quote(PathLazyModify[T, Foc](Expr.splice(doModify)))
+    val result = Expr.quote(PathLazyModify[T, Foc](Expr.splice(doModify)))
+    emitGenerationLog("modifyAllLens", trace, result.prettyPrint)
+    result
   }
 
   /** Rebuild `sExpr: S` applying `transformLeaf` at the focus of EVERY path in `paths`, sharing common `Field` prefixes

--- a/optics/src/test/scala/hearth/kindlings/optics/GenerationLoggingSpec.scala
+++ b/optics/src/test/scala/hearth/kindlings/optics/GenerationLoggingSpec.scala
@@ -1,0 +1,28 @@
+package hearth.kindlings.optics
+
+import hearth.MacroSuite
+
+/** Smoke test for the opt-in generation logging: importing `hearth.kindlings.optics.debug.*` puts the `LogGeneration`
+  * marker in scope, which makes the `modify` macro emit the parsed path + generated code as a compiler-info message.
+  * The message never fails compilation, so exercising the macro with the import in scope both proves the logging path
+  * compiles and that the generated code is still correct.
+  */
+final class GenerationLoggingSpec extends MacroSuite {
+
+  import hearth.kindlings.optics.syntax.*
+  import hearth.kindlings.optics.debug.* // enables the generation log for macros in this scope
+
+  group("modify with generation logging enabled") {
+
+    test("still generates correct code for a nested field modify") {
+      val p = GenerationLoggingSpec.Person("a", GenerationLoggingSpec.Address("OldCity"))
+      p.modify(_.address.city).setTo("NewCity") ==>
+        GenerationLoggingSpec.Person("a", GenerationLoggingSpec.Address("NewCity"))
+    }
+  }
+}
+
+object GenerationLoggingSpec {
+  final case class Address(city: String)
+  final case class Person(name: String, address: Address)
+}


### PR DESCRIPTION
## What & why

Our type-class derivation modules already let users preview *how* an instance is derived and *what code* is generated (`LogDerivation`). This PR extends that to the macro modules that are **not** derivations, and adds two DI-specific capabilities requested alongside it.

### 1. Generation logging for optics / mock / di
These are direct-style macros (no MIO/`Log` engine), so they didn't get `LogDerivation` for free. New shared **`kindlings-macro-commons`** module hosts a lightweight `GenerationLogging` tracer; each of `optics`/`mock`/`di` gains a `LogGeneration` marker + `debug/` opt-in package. Enable via import **or** `-Xmacro-settings:<optics|mock|di>.logGeneration=true`. Prints the parsed input (path steps / overridden members / resolution) plus the pretty-printed generated code — same UX as `logDerivation`.

### 2. DI wiring graph (ZIO-Magic style)
`di` can now print how entities/resources combine, modelled on ZIO 2.0's `ZLayer.Debug.tree` / `ZLayer.Debug.mermaid`:
- **`tree`** — DAG-aware ASCII dependency tree (a shared/diamond dependency is drawn once, later reused as `↻ (shared, wired above)`).
- **`mermaid`** — a Mermaid graph + render link.

Viewable standalone for a single run via `-Xmacro-settings:di.logWiring=tree|mermaid`, and inline on the new endpoint via `.debugTree` / `.debugMermaid`.

```text
RecApp
├─ RecService  [val]
│  ╰─ DatabaseAccess  [val]
╰─ RecHandler  [val]
   ╰─ DatabaseAccess  ↻ (shared, wired above)
```

### 3. `DI.plan[A]` — opinionated, recursive, cached, customizable
A new endpoint distinct from macwire's `wire`/`autowire` (which are left untouched and re-documented as macwire-faithful). Always recursive, always caching, with a fluent builder — no domain-class edits:
- **storage strategy** — `asVals` (default) / `asLazyVals` / `asDefs`, with per-type overrides `storeAsVal[T]`/`storeAsLazyVal[T]`/`storeAsDef[T]` (backed by `ValDefs.createVal`/`createLazy`/`createDef`).
- **construction overrides** — `provide[T](factory)` ("when you need a `T`, use this").
- **inline graph** — `debugTree` / `debugMermaid`.

```scala
DI.plan[App]
  .asLazyVals
  .storeAsDef[RequestScoped]
  .provide[Db](Db.connect())
  .debugTree
  .build
```

The builder chain is parsed at compile time via `DestructuredExpr` (the same technique optics uses for its path DSL).

## Notes
- New `kindlings-macro-commons` module (kept separate from `derivation-commons`, which is derivation-specific and would drag in unrelated machinery). `optics`/`mock`/`di` depend on it.
- `WiringGraph` is compile-time-only but lives in shared source, so it uses a pure-Scala base64 (no `java.util.Base64`/`Deflater`) to keep Scala.js/Native linking clean.

## Testing
- `DIPlanSpec` (storage variants incl. shared-vs-not, `provide`, caching, debug), `WiringGraphSpec` (tree + mermaid, diamond dedup), and generation-logging smoke specs for optics/mock.
- Green on **Scala 2.13 + 3, JVM**; JS compile + di specs green; `di-cats` (dependent) compiles. Formatting via scalafmt.