### PR TITLE
Resolve 5 post-#159 follow-ups: case-object cats derivation, DI.plan enum DSL, di-cats explicit resource params, Hearth #331 + tapir docs

### DIFF
--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FoldableMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FoldableMacrosImpl.scala
@@ -345,34 +345,38 @@ trait FoldableMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorS
                 childInfo.get(cn) match {
                   case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Foldable", cn))
                   case Some(info) =>
-                    parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
-                      val fields = cc.caseFieldValuesAt(caseValue).toList
-                      var result: Expr[Any] = bExpr
-                      fields
-                        .traverse { case (fn, fv) =>
-                          import fv.Underlying as Field
-                          val fe = fv.value.asInstanceOf[Expr[Field]]
-                          if (info.directFields.contains(fn)) {
-                            result = Expr.quote(Expr.splice(fExpr)(Expr.splice(result), Expr.splice(fe.upcast[Any])))
-                            MIO.void
-                          } else if (info.selfRecursiveFields.contains(fn) || info.nestedFoldables.contains(fn)) {
-                            val foldableEMIO: MIO[Expr[Any]] =
-                              if (info.selfRecursiveFields.contains(fn)) selfOrFail
-                              else MIO.pure(info.nestedFoldables(fn))
-                            foldableEMIO.map { foldableE =>
-                              result = Expr.quote {
-                                hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                                  .foldLeftNested(
-                                    Expr.splice(foldableE),
-                                    Expr.splice(fe.upcast[Any]),
-                                    Expr.splice(result),
-                                    Expr.splice(fExpr)
-                                  )
+                    // A case object / parameterless singleton case is NOT a case class: it carries no `A`,
+                    // so folding leaves the accumulator untouched (identity).
+                    CaseClass.parse[CT].toEither match {
+                      case Left(_)   => MIO.pure(bExpr)
+                      case Right(cc) =>
+                        val fields = cc.caseFieldValuesAt(caseValue).toList
+                        var result: Expr[Any] = bExpr
+                        fields
+                          .traverse { case (fn, fv) =>
+                            import fv.Underlying as Field
+                            val fe = fv.value.asInstanceOf[Expr[Field]]
+                            if (info.directFields.contains(fn)) {
+                              result = Expr.quote(Expr.splice(fExpr)(Expr.splice(result), Expr.splice(fe.upcast[Any])))
+                              MIO.void
+                            } else if (info.selfRecursiveFields.contains(fn) || info.nestedFoldables.contains(fn)) {
+                              val foldableEMIO: MIO[Expr[Any]] =
+                                if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                                else MIO.pure(info.nestedFoldables(fn))
+                              foldableEMIO.map { foldableE =>
+                                result = Expr.quote {
+                                  hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                    .foldLeftNested(
+                                      Expr.splice(foldableE),
+                                      Expr.splice(fe.upcast[Any]),
+                                      Expr.splice(result),
+                                      Expr.splice(fExpr)
+                                    )
+                                }
                               }
-                            }
-                          } else MIO.void
-                        }
-                        .map(_ => result)
+                            } else MIO.void
+                          }
+                          .map(_ => result)
                     }
                 }
               }
@@ -399,44 +403,48 @@ trait FoldableMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorS
                 childInfo.get(cn) match {
                   case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Foldable", cn))
                   case Some(info) =>
-                    parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
-                      val fields = cc.caseFieldValuesAt(caseValue).toList
-                      val foldableMIO: MIO[List[Option[(String, Expr[Any], Option[Expr[Any]])]]] =
-                        fields.traverse { case (fn, fv) =>
-                          import fv.Underlying as Field
-                          if (info.directFields.contains(fn))
-                            MIO.pure(
-                              Option(
-                                (fn, fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option.empty[Expr[Any]])
+                    // A case object / parameterless singleton case is NOT a case class: it carries no `A`,
+                    // so folding leaves the accumulator untouched (identity).
+                    CaseClass.parse[CT].toEither match {
+                      case Left(_)   => MIO.pure(lbExpr)
+                      case Right(cc) =>
+                        val fields = cc.caseFieldValuesAt(caseValue).toList
+                        val foldableMIO: MIO[List[Option[(String, Expr[Any], Option[Expr[Any]])]]] =
+                          fields.traverse { case (fn, fv) =>
+                            import fv.Underlying as Field
+                            if (info.directFields.contains(fn))
+                              MIO.pure(
+                                Option(
+                                  (fn, fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option.empty[Expr[Any]])
+                                )
                               )
-                            )
-                          else if (info.selfRecursiveFields.contains(fn) || info.nestedFoldables.contains(fn)) {
-                            val feMIO: MIO[Expr[Any]] =
-                              if (info.selfRecursiveFields.contains(fn)) selfOrFail
-                              else MIO.pure(info.nestedFoldables(fn))
-                            feMIO.map { fe =>
-                              Option((fn, fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option(fe)))
-                            }
-                          } else MIO.pure(Option.empty[(String, Expr[Any], Option[Expr[Any]])])
-                        }
-                      foldableMIO.map { foldableOpts =>
-                        foldableOpts.flatten.foldRight(lbExpr) { case ((_, fieldExpr, foldableOpt), acc) =>
-                          foldableOpt match {
-                            case None =>
-                              Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr), Expr.splice(acc)))
-                            case Some(foldableE) =>
-                              Expr.quote {
-                                hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                                  .foldRightNested(
-                                    Expr.splice(foldableE),
-                                    Expr.splice(fieldExpr),
-                                    Expr.splice(acc),
-                                    Expr.splice(fExpr)
-                                  )
+                            else if (info.selfRecursiveFields.contains(fn) || info.nestedFoldables.contains(fn)) {
+                              val feMIO: MIO[Expr[Any]] =
+                                if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                                else MIO.pure(info.nestedFoldables(fn))
+                              feMIO.map { fe =>
+                                Option((fn, fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option(fe)))
                               }
+                            } else MIO.pure(Option.empty[(String, Expr[Any], Option[Expr[Any]])])
+                          }
+                        foldableMIO.map { foldableOpts =>
+                          foldableOpts.flatten.foldRight(lbExpr) { case ((_, fieldExpr, foldableOpt), acc) =>
+                            foldableOpt match {
+                              case None =>
+                                Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr), Expr.splice(acc)))
+                              case Some(foldableE) =>
+                                Expr.quote {
+                                  hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                    .foldRightNested(
+                                      Expr.splice(foldableE),
+                                      Expr.splice(fieldExpr),
+                                      Expr.splice(acc),
+                                      Expr.splice(fExpr)
+                                    )
+                                }
+                            }
                           }
                         }
-                      }
                     }
                 }
               }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
@@ -387,54 +387,59 @@ trait FunctorMacrosImpl
                     case None =>
                       failDerivation(CatsDerivationError.MissingDerivationInfo("Functor", childName))
                     case Some(info) =>
-                      parseCaseClassMIO[ChildType](s"child $childName").flatMap { childCC =>
-                        val fields = childCC.caseFieldValuesAt(caseValue).toList
-                        if (fields.isEmpty) {
+                      // A case object / parameterless singleton case (`case Nope`, no parens) is NOT a case class,
+                      // so `CaseClass.parse` fails; it carries no `A` and maps to identity (like a fieldless case).
+                      CaseClass.parse[ChildType].toEither match {
+                        case Left(_) =>
                           MIO.pure(caseValue.upcast[F[Any]])
-                        } else {
-                          val mappedMIO: MIO[List[(String, Expr_??)]] = fields.traverse {
-                            case (fieldName, fieldValue) =>
-                              import fieldValue.Underlying as Field
-                              val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
-                              if (info.directFields.contains(fieldName)) {
-                                val m: Expr[Any] =
-                                  Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.upcast[Any])))
-                                val typedM: Expr[Field] = Expr.quote(Expr.splice(m).asInstanceOf[Field])
-                                MIO.pure((fieldName, typedM.as_??))
-                              } else if (
-                                info.selfRecursiveFields.contains(fieldName) ||
-                                info.nestedFieldFunctors.contains(fieldName)
-                              ) {
-                                val functorExprMIO: MIO[Expr[Any]] =
-                                  if (info.selfRecursiveFields.contains(fieldName)) {
-                                    selfOpt match {
-                                      case Some(self) => MIO.pure(self)
-                                      case None       =>
-                                        failDerivation(CatsDerivationError.MissingSelfReference("Functor"))
+                        case Right(childCC) =>
+                          val fields = childCC.caseFieldValuesAt(caseValue).toList
+                          if (fields.isEmpty) {
+                            MIO.pure(caseValue.upcast[F[Any]])
+                          } else {
+                            val mappedMIO: MIO[List[(String, Expr_??)]] = fields.traverse {
+                              case (fieldName, fieldValue) =>
+                                import fieldValue.Underlying as Field
+                                val fieldExpr = fieldValue.value.asInstanceOf[Expr[Field]]
+                                if (info.directFields.contains(fieldName)) {
+                                  val m: Expr[Any] =
+                                    Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr.upcast[Any])))
+                                  val typedM: Expr[Field] = Expr.quote(Expr.splice(m).asInstanceOf[Field])
+                                  MIO.pure((fieldName, typedM.as_??))
+                                } else if (
+                                  info.selfRecursiveFields.contains(fieldName) ||
+                                  info.nestedFieldFunctors.contains(fieldName)
+                                ) {
+                                  val functorExprMIO: MIO[Expr[Any]] =
+                                    if (info.selfRecursiveFields.contains(fieldName)) {
+                                      selfOpt match {
+                                        case Some(self) => MIO.pure(self)
+                                        case None       =>
+                                          failDerivation(CatsDerivationError.MissingSelfReference("Functor"))
+                                      }
+                                    } else MIO.pure(info.nestedFieldFunctors(fieldName))
+                                  functorExprMIO.map { functorExpr =>
+                                    val nested: Expr[Any] = Expr.quote {
+                                      hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                        .mapNested(
+                                          Expr.splice(functorExpr),
+                                          Expr.splice(fieldExpr.upcast[Any]),
+                                          Expr.splice(fExpr)
+                                        )
                                     }
-                                  } else MIO.pure(info.nestedFieldFunctors(fieldName))
-                                functorExprMIO.map { functorExpr =>
-                                  val nested: Expr[Any] = Expr.quote {
-                                    hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                                      .mapNested(
-                                        Expr.splice(functorExpr),
-                                        Expr.splice(fieldExpr.upcast[Any]),
-                                        Expr.splice(fExpr)
-                                      )
+                                    val typedNested: Expr[Field] =
+                                      Expr.quote(Expr.splice(nested).asInstanceOf[Field])
+                                    (fieldName, typedNested.as_??)
                                   }
-                                  val typedNested: Expr[Field] =
-                                    Expr.quote(Expr.splice(nested).asInstanceOf[Field])
-                                  (fieldName, typedNested.as_??)
+                                } else {
+                                  MIO.pure((fieldName, fieldExpr.as_??))
                                 }
-                              } else {
-                                MIO.pure((fieldName, fieldExpr.as_??))
-                              }
+                            }
+                            mappedMIO.flatMap { mapped =>
+                              constructInstanceFree(childCC.primaryConstructor, "Constructor", childName)(mapped.toMap)
+                                .map(expr => expr.value.asInstanceOf[Expr[F[Any]]])
+                            }
                           }
-                          mappedMIO.flatMap { mapped =>
-                            constructInstanceFree(childCC.primaryConstructor, "Constructor", childName)(mapped.toMap)
-                              .map(expr => expr.value.asInstanceOf[Expr[F[Any]]])
-                          }
-                        }
                       }
                   }
                 }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/TraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/TraverseMacrosImpl.scala
@@ -524,109 +524,116 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorS
               childInfo.get(cn) match {
                 case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Traverse", cn))
                 case Some(info) =>
-                  parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
-                    val fields = cc.caseFieldValuesAt(caseValue).toList
-                    if (fields.isEmpty) {
+                  // A case object / parameterless singleton case is NOT a case class: it carries no `A`,
+                  // so traversing wraps it unchanged with `pure` (like a fieldless case).
+                  CaseClass.parse[CT].toEither match {
+                    case Left(_) =>
                       val gE =
                         Expr.quote(Expr.splice(gExpr).asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]])
                       MIO.pure(Expr.quote(Expr.splice(gE).pure(Expr.splice(caseValue.upcast[Any]))).upcast[Any])
-                    } else {
-                      val gFieldExprsMIO: MIO[List[Option[Expr[CatsDerivationFactories.AnyF[Any]]]]] =
-                        fields.traverse { case (fn, fv) =>
-                          import fv.Underlying as Field
-                          if (info.directFields.contains(fn)) {
-                            val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
-                            MIO.pure(
-                              Option(
-                                Expr.quote(
-                                  Expr
-                                    .splice(fExpr)
-                                    .asInstanceOf[Any => CatsDerivationFactories.AnyF[Any]](Expr.splice(fe))
+                    case Right(cc) =>
+                      val fields = cc.caseFieldValuesAt(caseValue).toList
+                      if (fields.isEmpty) {
+                        val gE =
+                          Expr.quote(Expr.splice(gExpr).asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]])
+                        MIO.pure(Expr.quote(Expr.splice(gE).pure(Expr.splice(caseValue.upcast[Any]))).upcast[Any])
+                      } else {
+                        val gFieldExprsMIO: MIO[List[Option[Expr[CatsDerivationFactories.AnyF[Any]]]]] =
+                          fields.traverse { case (fn, fv) =>
+                            import fv.Underlying as Field
+                            if (info.directFields.contains(fn)) {
+                              val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
+                              MIO.pure(
+                                Option(
+                                  Expr.quote(
+                                    Expr
+                                      .splice(fExpr)
+                                      .asInstanceOf[Any => CatsDerivationFactories.AnyF[Any]](Expr.splice(fe))
+                                  )
                                 )
                               )
-                            )
-                          } else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
-                            val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
-                            val travEMIO: MIO[Expr[Any]] =
-                              if (info.selfRecursiveFields.contains(fn)) selfOrFail
-                              else MIO.pure(info.nestedInstances(fn))
-                            travEMIO.map { travE =>
-                              Option(
-                                Expr.quote(
-                                  hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                                    .traverseNested(
-                                      Expr.splice(travE),
-                                      Expr.splice(fe),
-                                      Expr.splice(fExpr),
-                                      Expr.splice(gExpr)
-                                    )
-                                    .asInstanceOf[CatsDerivationFactories.AnyF[Any]]
+                            } else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
+                              val fe = fv.value.asInstanceOf[Expr[Field]].upcast[Any]
+                              val travEMIO: MIO[Expr[Any]] =
+                                if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                                else MIO.pure(info.nestedInstances(fn))
+                              travEMIO.map { travE =>
+                                Option(
+                                  Expr.quote(
+                                    hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                      .traverseNested(
+                                        Expr.splice(travE),
+                                        Expr.splice(fe),
+                                        Expr.splice(fExpr),
+                                        Expr.splice(gExpr)
+                                      )
+                                      .asInstanceOf[CatsDerivationFactories.AnyF[Any]]
+                                  )
                                 )
-                              )
-                            }
-                          } else MIO.pure(Option.empty[Expr[CatsDerivationFactories.AnyF[Any]]])
-                        }
-                      gFieldExprsMIO.flatMap { gFieldOpts =>
-                        val gFieldExprs = gFieldOpts.flatten
-                        val traversableFields =
-                          info.directFields ++ info.nestedInstances.keySet ++ info.selfRecursiveFields
-
-                        // LambdaBuilder callbacks are synchronous and cannot return MIO, so failures
-                        // inside the callback throw the typed CatsDerivationError; the enclosing
-                        // MIO(...) converts the NonFatal throw into an MIO error-channel failure.
-                        val reconLambda: Expr[List[Any] => Any] = runSafe {
-                          MIO {
-                            LambdaBuilder.of1[List[Any]]("newVals").buildWith { newValsExpr =>
-                              var currentList: Expr[List[Any]] = newValsExpr
-                              val fieldExprs: List[(String, Expr_??)] = fields.map { case (fn2, fv2) =>
-                                import fv2.Underlying as Field2
-                                if (traversableFields.contains(fn2)) {
-                                  val headExpr: Expr[Any] = Expr.quote(Expr.splice(currentList).head)
-                                  val tailExpr: Expr[List[Any]] = Expr.quote(Expr.splice(currentList).tail)
-                                  currentList = tailExpr
-                                  val typed: Expr[Field2] = Expr.quote(Expr.splice(headExpr).asInstanceOf[Field2])
-                                  (fn2, typed.as_??)
-                                } else {
-                                  (fn2, fv2.value.asInstanceOf[Expr[Field2]].as_??)
-                                }
                               }
-                              foldInstanceFree(cc.primaryConstructor, "Constructor")(
-                                onTypes = _ => Map.empty,
-                                onValues = _ => fieldExprs.toMap
-                              ) match {
-                                case Right(expr) => expr.value.asInstanceOf[Expr[Any]]
-                                case Left(err)   => throw CatsDerivationError.CannotConstructResult(cn, err)
+                            } else MIO.pure(Option.empty[Expr[CatsDerivationFactories.AnyF[Any]]])
+                          }
+                        gFieldExprsMIO.flatMap { gFieldOpts =>
+                          val gFieldExprs = gFieldOpts.flatten
+                          val traversableFields =
+                            info.directFields ++ info.nestedInstances.keySet ++ info.selfRecursiveFields
+
+                          // LambdaBuilder callbacks are synchronous and cannot return MIO, so failures
+                          // inside the callback throw the typed CatsDerivationError; the enclosing
+                          // MIO(...) converts the NonFatal throw into an MIO error-channel failure.
+                          val reconLambda: Expr[List[Any] => Any] = runSafe {
+                            MIO {
+                              LambdaBuilder.of1[List[Any]]("newVals").buildWith { newValsExpr =>
+                                var currentList: Expr[List[Any]] = newValsExpr
+                                val fieldExprs: List[(String, Expr_??)] = fields.map { case (fn2, fv2) =>
+                                  import fv2.Underlying as Field2
+                                  if (traversableFields.contains(fn2)) {
+                                    val headExpr: Expr[Any] = Expr.quote(Expr.splice(currentList).head)
+                                    val tailExpr: Expr[List[Any]] = Expr.quote(Expr.splice(currentList).tail)
+                                    currentList = tailExpr
+                                    val typed: Expr[Field2] = Expr.quote(Expr.splice(headExpr).asInstanceOf[Field2])
+                                    (fn2, typed.as_??)
+                                  } else {
+                                    (fn2, fv2.value.asInstanceOf[Expr[Field2]].as_??)
+                                  }
+                                }
+                                foldInstanceFree(cc.primaryConstructor, "Constructor")(
+                                  onTypes = _ => Map.empty,
+                                  onValues = _ => fieldExprs.toMap
+                                ) match {
+                                  case Right(expr) => expr.value.asInstanceOf[Expr[Any]]
+                                  case Left(err)   => throw CatsDerivationError.CannotConstructResult(cn, err)
+                                }
                               }
                             }
                           }
-                        }
 
-                        val gListExpr = gFieldExprs.foldRight(
-                          Expr.quote(
+                          val gListExpr = gFieldExprs.foldRight(
+                            Expr.quote(
+                              Expr
+                                .splice(gExpr)
+                                .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
+                                .pure(Nil: List[Any])
+                            )
+                          ) { (gvExpr, accExpr) =>
+                            Expr.quote(
+                              Expr
+                                .splice(gExpr)
+                                .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
+                                .map2[Any, List[Any], List[Any]](Expr.splice(gvExpr), Expr.splice(accExpr))(_ :: _)
+                            )
+                          }
+                          val result = Expr.quote {
+                            val recon: List[Any] => Any = Expr.splice(reconLambda)
+                            val _ = recon
                             Expr
                               .splice(gExpr)
                               .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
-                              .pure(Nil: List[Any])
-                          )
-                        ) { (gvExpr, accExpr) =>
-                          Expr.quote(
-                            Expr
-                              .splice(gExpr)
-                              .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
-                              .map2[Any, List[Any], List[Any]](Expr.splice(gvExpr), Expr.splice(accExpr))(_ :: _)
-                          )
+                              .map[List[Any], Any](Expr.splice(gListExpr))(newVals => recon(newVals))
+                          }
+                          MIO.pure(result.upcast[Any])
                         }
-                        val result = Expr.quote {
-                          val recon: List[Any] => Any = Expr.splice(reconLambda)
-                          val _ = recon
-                          Expr
-                            .splice(gExpr)
-                            .asInstanceOf[cats.Applicative[CatsDerivationFactories.AnyF]]
-                            .map[List[Any], Any](Expr.splice(gListExpr))(newVals => recon(newVals))
-                        }
-                        MIO.pure(result.upcast[Any])
                       }
-                    }
                   }
               }
             }
@@ -653,34 +660,37 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorS
               childInfo.get(cn) match {
                 case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Traverse", cn))
                 case Some(info) =>
-                  parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
-                    val fields = cc.caseFieldValuesAt(caseValue).toList
-                    var result: Expr[Any] = bExpr
-                    fields
-                      .traverse { case (fn, fv) =>
-                        import fv.Underlying as Field
-                        val fe = fv.value.asInstanceOf[Expr[Field]]
-                        if (info.directFields.contains(fn)) {
-                          result = Expr.quote(Expr.splice(fExpr)(Expr.splice(result), Expr.splice(fe.upcast[Any])))
-                          MIO.void
-                        } else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
-                          val foldEMIO: MIO[Expr[Any]] =
-                            if (info.selfRecursiveFields.contains(fn)) selfOrFail
-                            else MIO.pure(info.nestedInstances(fn))
-                          foldEMIO.map { foldE =>
-                            result = Expr.quote(
-                              hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                                .foldLeftNested(
-                                  Expr.splice(foldE),
-                                  Expr.splice(fe.upcast[Any]),
-                                  Expr.splice(result),
-                                  Expr.splice(fExpr)
-                                )
-                            )
-                          }
-                        } else MIO.void
-                      }
-                      .map(_ => result)
+                  // Case object / parameterless singleton case: no `A`, folding is identity on the accumulator.
+                  CaseClass.parse[CT].toEither match {
+                    case Left(_)   => MIO.pure(bExpr)
+                    case Right(cc) =>
+                      val fields = cc.caseFieldValuesAt(caseValue).toList
+                      var result: Expr[Any] = bExpr
+                      fields
+                        .traverse { case (fn, fv) =>
+                          import fv.Underlying as Field
+                          val fe = fv.value.asInstanceOf[Expr[Field]]
+                          if (info.directFields.contains(fn)) {
+                            result = Expr.quote(Expr.splice(fExpr)(Expr.splice(result), Expr.splice(fe.upcast[Any])))
+                            MIO.void
+                          } else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
+                            val foldEMIO: MIO[Expr[Any]] =
+                              if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                              else MIO.pure(info.nestedInstances(fn))
+                            foldEMIO.map { foldE =>
+                              result = Expr.quote(
+                                hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                  .foldLeftNested(
+                                    Expr.splice(foldE),
+                                    Expr.splice(fe.upcast[Any]),
+                                    Expr.splice(result),
+                                    Expr.splice(fExpr)
+                                  )
+                              )
+                            }
+                          } else MIO.void
+                        }
+                        .map(_ => result)
                   }
               }
             }
@@ -707,42 +717,45 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorS
               childInfo.get(cn) match {
                 case None       => failDerivation(CatsDerivationError.MissingDerivationInfo("Traverse", cn))
                 case Some(info) =>
-                  parseCaseClassMIO[CT](s"child $cn").flatMap { cc =>
-                    val fields = cc.caseFieldValuesAt(caseValue).toList
-                    val foldableMIO: MIO[List[Option[(Expr[Any], Option[Expr[Any]])]]] =
-                      fields.traverse { case (fn, fv) =>
-                        import fv.Underlying as Field
-                        if (info.directFields.contains(fn))
-                          MIO.pure(
-                            Option((fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option.empty[Expr[Any]]))
-                          )
-                        else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
-                          val feMIO: MIO[Expr[Any]] =
-                            if (info.selfRecursiveFields.contains(fn)) selfOrFail
-                            else MIO.pure(info.nestedInstances(fn))
-                          feMIO.map { fe =>
-                            Option((fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option(fe)))
-                          }
-                        } else MIO.pure(Option.empty[(Expr[Any], Option[Expr[Any]])])
-                      }
-                    foldableMIO.map { foldableOpts =>
-                      foldableOpts.flatten.foldRight(lbExpr) { case ((fieldExpr, foldableOpt), acc) =>
-                        foldableOpt match {
-                          case None =>
-                            Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr), Expr.splice(acc)))
-                          case Some(foldableE) =>
-                            Expr.quote(
-                              hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
-                                .foldRightNested(
-                                  Expr.splice(foldableE),
-                                  Expr.splice(fieldExpr),
-                                  Expr.splice(acc),
-                                  Expr.splice(fExpr)
-                                )
+                  // Case object / parameterless singleton case: no `A`, folding is identity on the accumulator.
+                  CaseClass.parse[CT].toEither match {
+                    case Left(_)   => MIO.pure(lbExpr)
+                    case Right(cc) =>
+                      val fields = cc.caseFieldValuesAt(caseValue).toList
+                      val foldableMIO: MIO[List[Option[(Expr[Any], Option[Expr[Any]])]]] =
+                        fields.traverse { case (fn, fv) =>
+                          import fv.Underlying as Field
+                          if (info.directFields.contains(fn))
+                            MIO.pure(
+                              Option((fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option.empty[Expr[Any]]))
                             )
+                          else if (info.selfRecursiveFields.contains(fn) || info.nestedInstances.contains(fn)) {
+                            val feMIO: MIO[Expr[Any]] =
+                              if (info.selfRecursiveFields.contains(fn)) selfOrFail
+                              else MIO.pure(info.nestedInstances(fn))
+                            feMIO.map { fe =>
+                              Option((fv.value.asInstanceOf[Expr[Field]].upcast[Any], Option(fe)))
+                            }
+                          } else MIO.pure(Option.empty[(Expr[Any], Option[Expr[Any]])])
+                        }
+                      foldableMIO.map { foldableOpts =>
+                        foldableOpts.flatten.foldRight(lbExpr) { case ((fieldExpr, foldableOpt), acc) =>
+                          foldableOpt match {
+                            case None =>
+                              Expr.quote(Expr.splice(fExpr)(Expr.splice(fieldExpr), Expr.splice(acc)))
+                            case Some(foldableE) =>
+                              Expr.quote(
+                                hearth.kindlings.catsderivation.internal.runtime.HktNestedRuntime
+                                  .foldRightNested(
+                                    Expr.splice(foldableE),
+                                    Expr.splice(fieldExpr),
+                                    Expr.splice(acc),
+                                    Expr.splice(fExpr)
+                                  )
+                              )
+                          }
                         }
                       }
-                    }
                   }
               }
             }

--- a/cats-derivation/src/test/scala/hearth/kindlings/catsderivation/CatsDerivationSpec.scala
+++ b/cats-derivation/src/test/scala/hearth/kindlings/catsderivation/CatsDerivationSpec.scala
@@ -430,6 +430,16 @@ final class CatsDerivationSpec extends MacroSuite {
           List(examples.Search(40, None, List(examples.Search(50, None, Nil))))
         )
     }
+
+    test("sealed trait with case-object child: case class case") {
+      val p: examples.Perhaps[Int] = examples.Definitely(1)
+      examples.Perhaps.functorPerhaps.map(p)(_ * 10) ==> examples.Definitely(10)
+    }
+
+    test("sealed trait with case-object child: singleton case maps to identity") {
+      val p: examples.Perhaps[Int] = examples.Nope
+      examples.Perhaps.functorPerhaps.map(p)(_ * 10) ==> examples.Nope
+    }
   }
 
   group("Contravariant") {
@@ -634,6 +644,11 @@ final class CatsDerivationSpec extends MacroSuite {
         .value
       result ==> List(1, 2)
     }
+
+    test("foldLeft sealed trait with case-object child") {
+      examples.Perhaps.foldablePerhaps.foldLeft(examples.Definitely(42): examples.Perhaps[Int], 0)(_ + _) ==> 42
+      examples.Perhaps.foldablePerhaps.foldLeft(examples.Nope: examples.Perhaps[Int], 0)(_ + _) ==> 0
+    }
   }
 
   group("Traverse") {
@@ -743,6 +758,13 @@ final class CatsDerivationSpec extends MacroSuite {
       val list: examples.IList[Int] = examples.ICons(1, examples.ICons(2, examples.INil()))
       examples.IList.traverseIList.map(list)(_ * 10) ==>
         examples.ICons(10, examples.ICons(20, examples.INil()))
+    }
+
+    test("traverse sealed trait with case-object child") {
+      examples.Perhaps.traversePerhaps.traverse(examples.Definitely(1): examples.Perhaps[Int])(a => Option(a * 10)) ==>
+        Some(examples.Definitely(10))
+      examples.Perhaps.traversePerhaps.traverse(examples.Nope: examples.Perhaps[Int])(a => Option(a * 10)) ==>
+        Some(examples.Nope)
     }
   }
 

--- a/cats-derivation/src/test/scala/hearth/kindlings/catsderivation/examples.scala
+++ b/cats-derivation/src/test/scala/hearth/kindlings/catsderivation/examples.scala
@@ -205,6 +205,18 @@ object examples {
     implicit val traverseIList: cats.Traverse[IList] = cats.Traverse.derived
   }
 
+  // Regression (kubuszok/kindlings): polymorphic sealed trait with a case-object (singleton) child.
+  // A parameterless enum case (`case Nope`, no parens) / case object must map to identity, unlike a
+  // parameterless case *class* (`case INil()`, with parens) which parses as a case class.
+  sealed trait Perhaps[+A]
+  final case class Definitely[+A](value: A) extends Perhaps[A]
+  case object Nope extends Perhaps[Nothing]
+  object Perhaps {
+    implicit val functorPerhaps: cats.Functor[Perhaps] = cats.Functor.derived
+    implicit val foldablePerhaps: cats.Foldable[Perhaps] = cats.Foldable.derived
+    implicit val traversePerhaps: cats.Traverse[Perhaps] = cats.Traverse.derived
+  }
+
   // Bifunctor examples — case classes with two type parameters
   final case class Pair[A, B](first: A, second: B)
   object Pair {

--- a/di-cats/src/main/scala-2/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacros.scala
+++ b/di-cats/src/main/scala-2/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacros.scala
@@ -9,19 +9,61 @@ final private[dicats] class ResourceWiringMacros(val c: blackbox.Context)
     extends MacroCommonsScala2
     with ResourceWiringMacrosImpl {
 
-  protected def companionResourceCall(
+  protected def companionResourceExplicitParamTypes(
       companion: Expr_??,
       methodName: String,
       fType: ??,
       expected: ??
+  ): Option[List[??]] = {
+    import c.universe.*
+    import companion.Underlying as Comp
+    val fTpe: c.Type = fType.asUntyped
+    val expectedTpe: c.Type = expected.asUntyped
+    // The companion tree from `Type.companionObject` is untyped on Scala 2 (`tree.tpe` is null), so read the owner type
+    // from the existential's `Underlying` (the companion object's type) rather than the tree.
+    val ownerTpe: c.Type = Type[Comp].asUntyped
+    val memberSym = ownerTpe.member(TermName(methodName))
+    val alts = if (memberSym == NoSymbol) Nil else memberSym.alternatives
+    // For each `resource` alternative: substitute our `F` for the method's type parameter, then walk the clauses,
+    // skipping IMPLICIT/`using` clauses (summoned later) and collecting EXPLICIT ones. We only support a single explicit
+    // clause; the (F-substituted) result must conform to `expected` (`Resource[F, <:T]`).
+    def tryOne(info: c.Type): Option[List[??]] = info match {
+      case PolyType(List(fSym), body) =>
+        def sub(tp: c.Type): c.Type = tp.substituteTypes(List(fSym), List(fTpe))
+        def collect(tpe: c.Type, clauses: List[List[c.Type]]): (List[List[c.Type]], c.Type) = tpe match {
+          case MethodType(params, res) =>
+            val isImplicit = params.nonEmpty && params.head.isImplicit
+            if (isImplicit) collect(res, clauses)
+            else collect(res, clauses :+ params.map(p => sub(p.typeSignature)))
+          case NullaryMethodType(res) => collect(res, clauses)
+          case other                  => (clauses, sub(other))
+        }
+        val (clauses, result) = collect(body, Nil)
+        if (clauses.sizeIs <= 1 && result <:< expectedTpe) Some(clauses.flatten.map(t => UntypedType.as_??(t)))
+        else None
+      case _ => None
+    }
+    alts.iterator.map(m => tryOne(m.infoIn(ownerTpe))).collectFirst { case Some(r) => r }
+  }
+
+  protected def companionResourceCall(
+      companion: Expr_??,
+      methodName: String,
+      fType: ??,
+      expected: ??,
+      explicitArgs: List[Expr_??]
   ): Option[Expr_??] = {
     import c.universe.*
     val companionTree: Tree = companion.value.tree
     val fTpe: c.Type = fType.asUntyped
     val expectedTpe: c.Type = expected.asUntyped
-    // `(companion.resource[F]): Resource[F, T]` — the ascription drives the compiler to insert any `implicit Sync[F]`
-    // clause via its own implicit search; typecheck validates the whole thing (and yields `None` if unsuitable).
-    val ascribed = q"($companionTree.${TermName(methodName)}[$fTpe]): $expectedTpe"
+    val argTrees: List[Tree] = explicitArgs.map(_.value.tree)
+    // `(companion.resource[F](args)): Resource[F, T]` — the applied `args` fill the explicit value clause; the ascription
+    // drives the compiler to insert any `implicit Sync[F]` clause via its own implicit search; typecheck validates the
+    // whole thing (and yields `None` if unsuitable).
+    val base = q"$companionTree.${TermName(methodName)}[$fTpe]"
+    val applied = if (argTrees.isEmpty) base else q"$base(..$argTrees)"
+    val ascribed = q"($applied): $expectedTpe"
     scala.util.Try(c.typecheck(ascribed)).toOption.map(typed => UntypedExpr.as_??(typed))
   }
 

--- a/di-cats/src/main/scala-3/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacros.scala
+++ b/di-cats/src/main/scala-3/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacros.scala
@@ -12,19 +12,46 @@ final private[dicats] class ResourceWiringMacros(q: Quotes)
   /** Create Type.Ctor1[G] — the cross-quotes plugin rewrites Type.Ctor1.of[G] here because MacroCommons is in scope. */
   def mkCtor1[G[_]](using scala.quoted.Type[G]): Type.Ctor1[G] = Type.Ctor1.of[G]
 
-  protected def companionResourceCall(
+  protected def companionResourceExplicitParamTypes(
       companion: Expr_??,
       methodName: String,
       fType: ??,
       expected: ??
+  ): Option[List[??]] = {
+    import quotes.reflect.*
+    val companionTerm = companion.value.asTerm
+    val fRepr = fType.asUntyped
+    val expectedRepr = expected.asUntyped
+    // Walk the (F-applied) clauses: skip IMPLICIT/`using` clauses (summoned later in companionResourceCall), collect
+    // EXPLICIT value clauses. We only support a single explicit clause; the final result must conform to `expected`.
+    def collect(tpe: TypeRepr, clauses: List[List[TypeRepr]]): (List[List[TypeRepr]], TypeRepr) = tpe.widen match {
+      case mt: MethodType if mt.isImplicit => collect(mt.resType, clauses)
+      case mt: MethodType                  => collect(mt.resType, clauses :+ mt.paramTypes)
+      case other                           => (clauses, other)
+    }
+    companionTerm.tpe.typeSymbol.methodMember(methodName).headOption.flatMap { sym =>
+      scala.util.Try(companionTerm.select(sym).appliedToType(fRepr)).toOption.flatMap { applied =>
+        val (clauses, result) = collect(applied.tpe.widen, Nil)
+        if clauses.sizeIs <= 1 && result <:< expectedRepr then Some(clauses.flatten.map(UntypedType.as_??))
+        else None
+      }
+    }
+  }
+
+  protected def companionResourceCall(
+      companion: Expr_??,
+      methodName: String,
+      fType: ??,
+      expected: ??,
+      explicitArgs: List[Expr_??]
   ): Option[Expr_??] = {
     import quotes.reflect.*
     val companionTerm = companion.value.asTerm
     val fRepr = fType.asUntyped
-    // Apply our `F`, then apply each remaining IMPLICIT/`using` clause by running the compiler's implicit search on its
-    // (now `F`-substituted) parameter types. A remaining EXPLICIT clause means the method needs arguments we cannot
-    // supply here, so we bail (`None`) and let ordinary construction take over.
-    def applyClauses(term: Term): Option[Term] = term.tpe.widen match {
+    val argTerms: List[Term] = explicitArgs.map(_.value.asTerm)
+    // Apply our `F`, then walk each remaining clause: an EXPLICIT clause consumes the next `n` resolved `argTerms`; an
+    // IMPLICIT/`using` clause is filled by the compiler's implicit search on its (now `F`-substituted) parameter types.
+    def applyClauses(term: Term, remaining: List[Term]): Option[Term] = term.tpe.widen match {
       case mt: MethodType if mt.isImplicit =>
         val maybeArgs = mt.paramTypes.foldRight(Option(List.empty[Term])) { (pt, acc) =>
           acc.flatMap { rest =>
@@ -34,15 +61,18 @@ final private[dicats] class ResourceWiringMacros(q: Quotes)
             }
           }
         }
-        maybeArgs.flatMap(args => applyClauses(Apply(term, args)))
-      case _: MethodType => None
-      case _             => Some(term)
+        maybeArgs.flatMap(args => applyClauses(Apply(term, args), remaining))
+      case mt: MethodType =>
+        val (these, rest) = remaining.splitAt(mt.paramTypes.size)
+        if these.sizeIs < mt.paramTypes.size then None
+        else applyClauses(Apply(term, these), rest)
+      case _ => if remaining.isEmpty then Some(term) else None
     }
     companionTerm.tpe.typeSymbol.methodMember(methodName).headOption.flatMap { sym =>
       scala.util
         .Try(companionTerm.select(sym).appliedToType(fRepr))
         .toOption
-        .flatMap(applyClauses)
+        .flatMap(applyClauses(_, argTerms))
         .flatMap { fullyApplied =>
           import expected.Underlying as R
           scala.util.Try(fullyApplied.asExprOf[R]).toOption.map(_.as_??)

--- a/di-cats/src/main/scala/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacrosImpl.scala
+++ b/di-cats/src/main/scala/hearth/kindlings/dicats/internal/compiletime/ResourceWiringMacrosImpl.scala
@@ -531,33 +531,87 @@ private[dicats] trait ResourceWiringMacrosImpl
     (bound: Map[String, Expr_??]) => bound(key)
   }
 
-  /** Kindlings extension over macwire's autocats: use a companion `object T { def resource[F[_]: <constraints>]:
-    * Resource[F, T] }` factory when present. We apply OUR `F` as the method's type argument and summon its
-    * context-bound implicits (which Hearth does not auto-supply), then hand back the folded `Resource[F, T]`. Only
-    * methods whose sole value parameters are implicit (i.e. context bounds) are used — a `resource` method with
-    * explicit value parameters is left to ordinary construction. Returns the `Resource[F, T]` expression, or `None` if
-    * no suitable method exists.
+  /** Kindlings extension over macwire's autocats: use a companion `object T { def resource[F[_]:
+    * <constraints>](<explicit value params>): Resource[F, T] }` factory when present. We apply OUR `F` as the method's
+    * type argument, resolve any EXPLICIT value parameters from the wiring graph (just like a factory method's params),
+    * and summon its context-bound implicits (which Hearth does not auto-supply), then register the folded
+    * `Resource[F, T]` as a shared node. Returns a node builder, or `None` if no suitable `resource` method exists.
     */
   private def tryCompanionResource[F[_]](
-      t: ??
-  )(implicit FCtor: Type.Ctor1[F], fAnyType: Type[F[Any]], anyType: Type[Any]): Option[Expr_??] = {
+      resolver: Resolver,
+      t: ??,
+      path: List[String],
+      missing: scala.collection.mutable.LinkedHashSet[String]
+  )(implicit
+      FCtor: Type.Ctor1[F],
+      fAnyType: Type[F[Any]],
+      anyType: Type[Any]
+  ): Option[Map[String, Expr_??] => Expr_??] = {
     import t.Underlying as X
+    val key = Type.fqcn[X]
     implicit val resourceFX: Type[Resource[F, X]] = Type.of[Resource[F, X]]
     Type.companionObject[X].flatMap { companion =>
-      companionResourceCall(companion, "resource", FCtor.asUntyped.as_??, Type[Resource[F, X]].as_??)
+      companionResourceExplicitParamTypes(companion, "resource", FCtor.asUntyped.as_??, Type[Resource[F, X]].as_??)
+        .map { explicitTypes =>
+          // Resolve the resource method's EXPLICIT value params from the graph now (records their nodes + any missing
+          // paths). Its implicit / context-bound clauses are summoned by the compiler inside companionResourceCall.
+          val paramResolvers: List[Map[String, Expr_??] => Expr_??] =
+            explicitTypes.zipWithIndex.map { case (ptype, i) =>
+              resolveTypeViaResolver[F](resolver, ptype, path :+ s"[method resource].arg$i", missing)
+                .getOrElse((_: Map[String, Expr_??]) => nullPlaceholder(ptype))
+            }
+          val depKeys = explicitTypes.flatMap(pt => resolvedKeyOf(resolver, pt))
+          recordGraphNode(resolver, key, t, NodeKind.Provided("resource"), depKeys)
+          ensureNode(resolver, key, t) { bound =>
+            val explicitArgs = paramResolvers.map(_(bound))
+            companionResourceCall(
+              companion,
+              "resource",
+              FCtor.asUntyped.as_??,
+              Type[Resource[F, X]].as_??,
+              explicitArgs
+            ).getOrElse(
+              Environment.reportErrorAndAbort(s"Could not build [${Type.prettyPrint[X]}.resource[F]] from the graph.")
+            )
+          }
+          (bound: Map[String, Expr_??]) => bound(key)
+        }
     }
   }
 
-  /** Build `T.resource[F]` from `companion` (the companion object of `T`) and let the compiler apply the type argument
-    * `F` and resolve any context-bound implicits (`Sync[F]`, ...), ascribing the result to `expected` (`Resource[F,
-    * T]`). Returns `None` when there is no such method or it does not yield a `Resource[F, <:T]`.
+  /** Reflectively inspect `companion.resource[F]` and, if it exists and (after applying `F`) yields a subtype of
+    * `expected` (`Resource[F, <:T]`), return the F-substituted types of its single EXPLICIT value-parameter clause
+    * (empty when it only has implicit / context-bound clauses). Returns `None` when there is no such method, its result
+    * does not conform, or it has more than one explicit value clause.
+    *
+    * Platform specific for the same reason as [[companionResourceCall]]: Hearth's `Method` API drops a value/implicit
+    * clause that follows a type-parameter clause (see `UntypedMethodsScala3.methodExpectations`; upstream
+    * kubuszok/hearth#331), so we read the clause structure by raw reflection.
+    */
+  protected def companionResourceExplicitParamTypes(
+      companion: Expr_??,
+      methodName: String,
+      fType: ??,
+      expected: ??
+  ): Option[List[??]]
+
+  /** Build `T.resource[F](<explicitArgs>)` from `companion` (the companion object of `T`): apply the type argument `F`,
+    * apply the already-resolved `explicitArgs` (in declared order) for the explicit value clause, and let the compiler
+    * resolve any context-bound implicits (`Sync[F]`, ...), ascribing the result to `expected` (`Resource[F, T]`).
+    * Returns `None` when there is no such method or it does not yield a `Resource[F, <:T]`.
     *
     * Platform specific: Hearth's `Method` API cannot supply an implicit/`using` clause that follows a type-parameter
     * clause (it exposes it as an empty parameter list — see `UntypedMethodsScala3.methodExpectations`), so we build the
     * call by raw reflection and rely on the compiler's own implicit search, which is exactly what the user's
     * `def resource[F[_]: Sync]` expects anyway.
     */
-  protected def companionResourceCall(companion: Expr_??, methodName: String, fType: ??, expected: ??): Option[Expr_??]
+  protected def companionResourceCall(
+      companion: Expr_??,
+      methodName: String,
+      fType: ??,
+      expected: ??,
+      explicitArgs: List[Expr_??]
+  ): Option[Expr_??]
 
   /** Construct a value of type `t` via its primary constructor (or a single companion `apply`), resolving each
     * parameter via `resolveType`. Returns a builder producing the (constructed) value, or `None` if missing deps were
@@ -577,14 +631,12 @@ private[dicats] trait ResourceWiringMacrosImpl
     import t.Underlying as P
     val key = Type.fqcn[P]
     if (resolver.planned.contains(key)) return Some((bound: Map[String, Expr_??]) => bound(key))
-    // Kindlings extension over macwire's autocats: prefer a companion `T.resource[F]: Resource[F, T]` factory if one
-    // exists — apply our `F`, summon its context-bound implicits, and fold the whole construction as a Resource node.
-    tryCompanionResource[F](t) match {
-      case Some(resExpr) =>
-        ensureNode(resolver, key, t)(_ => resExpr)
-        recordGraphNode(resolver, key, t, NodeKind.Provided("resource"), Nil)
-        return Some((bound: Map[String, Expr_??]) => bound(key))
-      case None => ()
+    // Kindlings extension over macwire's autocats: prefer a companion `T.resource[F](...): Resource[F, T]` factory if one
+    // exists — apply our `F`, resolve its explicit value params from the graph, summon its context-bound implicits, and
+    // fold the whole construction as a shared Resource node.
+    tryCompanionResource[F](resolver, t, path, missing) match {
+      case Some(builder) => return Some(builder)
+      case None          => ()
     }
     // Cycle guard: a type re-entered while still under construction (its node not yet `planned`) is a dependency
     // cycle. Without this the DFS recurses forever — a compile-time StackOverflow. Mirrors di's `verifyNotCyclic`.

--- a/di-cats/src/test/scala/hearth/kindlings/dicats/ResourceMethodSpec.scala
+++ b/di-cats/src/test/scala/hearth/kindlings/dicats/ResourceMethodSpec.scala
@@ -27,6 +27,39 @@ final class ResourceMethodSpec extends MacroSuite {
       val res: Resource[SyncIO, App] = DICats.wireResource[SyncIO, App]()
       res.use(a => SyncIO.pure(a)).unsafeRunSync().widget.id ==> 1
     }
+
+    test("resolves an explicit value parameter of resource[F: Sync](config) from provided deps") {
+      val config = new Config("jdbc://root")
+      val res: Resource[SyncIO, Service] = DICats.wireResource[SyncIO, Service](config)
+      val s = res.use(SyncIO.pure).unsafeRunSync()
+      s.config.url ==> "jdbc://root"
+      s.n ==> 3
+    }
+
+    test("resolves an explicit resource[F] value parameter transitively") {
+      // Server needs a Service; Service has no provider but its companion resource[F](config) supplies it, with the
+      // explicit `config` resolved from the provided Config.
+      val config = new Config("jdbc://transitive")
+      val res: Resource[SyncIO, Server] = DICats.wireResource[SyncIO, Server](config)
+      res.use(SyncIO.pure).unsafeRunSync().service.config.url ==> "jdbc://transitive"
+    }
+
+    test("reports the explicit resource param via the graph path when it cannot be resolved") {
+      // Service.resource's explicit `config` param is resolved from the graph: with no Config provided it is recursively
+      // constructed, which fails on its non-wireable `String` — the path proves the arg is threaded through the graph.
+      compileErrors(
+        """
+        import hearth.kindlings.dicats.DICats
+        import cats.effect.{Resource, SyncIO}
+        import hearth.kindlings.dicats.ResourceMethodSpec.*
+        DICats.wireResource[SyncIO, Service]()
+        """
+      ).check(
+        "Missing dependency of type [java.lang.String].",
+        "[method resource].arg0",
+        "[constructor hearth.kindlings.dicats.ResourceMethodSpec.Config].url"
+      )
+    }
   }
 }
 
@@ -43,4 +76,15 @@ object ResourceMethodSpec {
   }
 
   final class App(val widget: Widget)
+
+  final class Config(val url: String)
+
+  // Companion `resource[F: Sync]` with an EXPLICIT value parameter resolved from the graph.
+  final class Service(val config: Config, val n: Int)
+  object Service {
+    def resource[F[_]: Sync](config: Config): Resource[F, Service] =
+      Resource.eval(Sync[F].delay(new Service(config, 3)))
+  }
+
+  final class Server(val service: Service)
 }

--- a/di/src/main/scala/hearth/kindlings/di/DIPlan.scala
+++ b/di/src/main/scala/hearth/kindlings/di/DIPlan.scala
@@ -26,6 +26,24 @@ package hearth.kindlings.di
   */
 final class DIPlan[A] private[di] () {
 
+  /** Set the whole-graph default storage strategy (enum-argument form of [[asVals]] / [[asLazyVals]] / [[asDefs]]).
+    *
+    * {{{DI.plan[App].defaultStorage(PlanStorage.LazyVal).build}}}
+    */
+  def defaultStorage(storage: PlanStorage): DIPlan[A] = this
+
+  /** Override the storage of `T` (enum-argument form of [[storeAsVal]] / [[storeAsLazyVal]] / [[storeAsDef]]).
+    *
+    * {{{DI.plan[App].storeAs[RequestScoped](PlanStorage.Def).build}}}
+    */
+  def storeAs[T](storage: PlanStorage): DIPlan[A] = this
+
+  /** Dump the wiring graph at the wiring site (enum-argument form of [[debugTree]] / [[debugMermaid]]).
+    *
+    * {{{DI.plan[App].debug(PlanDebug.Mermaid).build}}}
+    */
+  def debug(mode: PlanDebug): DIPlan[A] = this
+
   /** Store every constructed dependency as a `val` (the default — each is created once, eagerly). */
   def asVals: DIPlan[A] = this
 
@@ -54,4 +72,31 @@ final class DIPlan[A] private[di] () {
 
   /** Print the wiring graph as a Mermaid diagram + link (ZIO `ZLayer.Debug.mermaid` analog) at the wiring site. */
   def debugMermaid: DIPlan[A] = this
+}
+
+/** Storage strategy for a `DI.plan` graph, for the enum-argument builder methods [[DIPlan.defaultStorage]] /
+  * [[DIPlan.storeAs]]. `case object`s (not a Scala 3 `enum`) so the same values cross-compile to Scala 2.13 + 3.
+  */
+sealed trait PlanStorage
+object PlanStorage {
+
+  /** Store as a `val` — created once, eagerly. */
+  case object Val extends PlanStorage
+
+  /** Store as a `lazy val` — created once, on first use. */
+  case object LazyVal extends PlanStorage
+
+  /** Store as a `def` — re-created on every use. */
+  case object Def extends PlanStorage
+}
+
+/** Wiring-graph dump format for the enum-argument builder method [[DIPlan.debug]]. */
+sealed trait PlanDebug
+object PlanDebug {
+
+  /** ASCII dependency tree (ZIO `ZLayer.Debug.tree` analog). */
+  case object Tree extends PlanDebug
+
+  /** Mermaid diagram + link (ZIO `ZLayer.Debug.mermaid` analog). */
+  case object Mermaid extends PlanDebug
 }

--- a/di/src/main/scala/hearth/kindlings/di/internal/compiletime/WiringMacrosImpl.scala
+++ b/di/src/main/scala/hearth/kindlings/di/internal/compiletime/WiringMacrosImpl.scala
@@ -709,6 +709,21 @@ private[di] trait WiringMacrosImpl
       mc.applied.collect { case av: DestructuredExpr.MethodCall.AppliedValues => av.args }.flatten.headOption
     def overrideStorage(s: Storage): PlanConfig =
       typeArg.fold(acc) { t => import t.Underlying as T; acc.withOverride(Type.fqcn[T], s) }
+    // Enum-argument DSL: read the `PlanStorage.*` / `PlanDebug.*` case-object passed as the value argument by matching
+    // its (singleton) static type. Returns None if the argument is not one of the known singletons.
+    def storageArg: Option[Storage] = valueArg.flatMap { d =>
+      import d.tpe.Underlying as V
+      if (Type[V] <:< Type.of[PlanStorage.Val.type]) Some(Storage.Val)
+      else if (Type[V] <:< Type.of[PlanStorage.LazyVal.type]) Some(Storage.LazyVal)
+      else if (Type[V] <:< Type.of[PlanStorage.Def.type]) Some(Storage.Def)
+      else None
+    }
+    def debugArg: Option[WiringLogMode] = valueArg.flatMap { d =>
+      import d.tpe.Underlying as V
+      if (Type[V] <:< Type.of[PlanDebug.Tree.type]) Some(WiringLogMode.Tree)
+      else if (Type[V] <:< Type.of[PlanDebug.Mermaid.type]) Some(WiringLogMode.Mermaid)
+      else None
+    }
     mc.method.name match {
       case "asVals"         => acc.copy(default = Storage.Val)
       case "asLazyVals"     => acc.copy(default = Storage.LazyVal)
@@ -716,6 +731,10 @@ private[di] trait WiringMacrosImpl
       case "storeAsVal"     => overrideStorage(Storage.Val)
       case "storeAsLazyVal" => overrideStorage(Storage.LazyVal)
       case "storeAsDef"     => overrideStorage(Storage.Def)
+      // Enum-argument forms (Issue #4): the same effect, chosen by a `PlanStorage` / `PlanDebug` value.
+      case "defaultStorage" => storageArg.fold(acc)(s => acc.copy(default = s))
+      case "storeAs"        => storageArg.fold(acc)(overrideStorage)
+      case "debug"          => debugArg.fold(acc)(m => acc.copy(debug = Some(m)))
       case "provide"        =>
         (typeArg, valueArg) match {
           case (Some(t), Some(factory)) => acc.withProvider(t, factory)

--- a/di/src/test/scala/hearth/kindlings/di/DIPlanSpec.scala
+++ b/di/src/test/scala/hearth/kindlings/di/DIPlanSpec.scala
@@ -73,4 +73,32 @@ final class DIPlanSpec extends MacroSuite {
       assert(app.service.databaseAccess eq app.handler.databaseAccess)
     }
   }
+
+  group("DI.plan enum-argument DSL (Issue #4)") {
+
+    test("defaultStorage(LazyVal) sets the whole-graph default (shared)") {
+      val app = DI.plan[WiringSpec.RecApp].defaultStorage(PlanStorage.LazyVal).build
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+
+    test("defaultStorage(Def) re-creates a dependency on each use (not shared)") {
+      val app = DI.plan[WiringSpec.RecApp].defaultStorage(PlanStorage.Def).build
+      assert(app.service.databaseAccess ne app.handler.databaseAccess)
+    }
+
+    test("storeAs[T](Def) overrides storage for a single type while the rest stay vals") {
+      val app = DI.plan[WiringSpec.RecApp].storeAs[WiringSpec.DatabaseAccess](PlanStorage.Def).build
+      assert(app.service.databaseAccess ne app.handler.databaseAccess)
+    }
+
+    test("debug(Tree) compiles and produces a wired instance") {
+      val app = DI.plan[WiringSpec.RecApp].debug(PlanDebug.Tree).build
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+
+    test("debug(Mermaid) combined with defaultStorage still wires correctly") {
+      val app = DI.plan[WiringSpec.RecApp].defaultStorage(PlanStorage.LazyVal).debug(PlanDebug.Mermaid).build
+      assert(app.service.databaseAccess eq app.handler.databaseAccess)
+    }
+  }
 }

--- a/docs/research/hearth-method-fold-implicit-after-typeparams.md
+++ b/docs/research/hearth-method-fold-implicit-after-typeparams.md
@@ -1,0 +1,125 @@
+# Hearth gap: `Method.fold` drops an implicit clause that follows a type-parameter clause
+
+**Status:** reproducer for an upstream Hearth bug — filed as
+[kubuszok/hearth#331](https://github.com/kubuszok/hearth/issues/331).
+**Discovered by:** the `di-cats` companion `resource[F]` auto-discovery work (kindlings PR #159).
+**Hearth version:** see `versions.hearth` in `build.sbt`.
+
+## Symptom
+
+Given a polymorphic factory method whose *implicit* (context-bound / `using`) parameter clause
+comes **after** a type-parameter clause, e.g.
+
+```scala
+object Widget {
+  def resource[F[_]: Sync]: Resource[F, Widget] = ???
+  //                ^^^^^  ->  desugars to  (implicit ev: Sync[F])  AFTER the [F[_]] clause
+}
+```
+
+Hearth's `Method` API cannot build a call to it. When you `Method.fold` over the method and apply
+the type argument `F` via `onTypes`, the trailing `implicit Sync[F]` clause is **never offered** to
+`onValues` — the fold sees an *empty* value clause instead of one containing `ev: Sync[F]`. There is
+therefore no way to supply the `Sync[F]` instance through the `Method` API, and the call cannot be
+constructed.
+
+The same happens for an *explicit* value clause after a type-param clause
+(`def make[F[_]](config: Config): F[Widget]`): `onValues` is handed `List.empty`, so the `config`
+parameter is invisible.
+
+## Minimal reproducer
+
+A method shape that triggers it (type-param clause, then a value/implicit clause that references the
+type parameter):
+
+```scala
+trait Sync[F[_]]
+
+final case class Widget()
+object Widget {
+  // implicit clause AFTER the type-param clause — `Sync[F]` mentions the just-introduced `F`
+  def resource[F[_]](implicit ev: Sync[F]): F[Widget] = ???
+}
+```
+
+Macro-side (pseudo-code against the Hearth `Method` API):
+
+```scala
+val method: Method = /* the `resource` method of Widget's companion */
+method.fold(
+  onInstance = ...,
+  onTypes    = clause => /* apply F := SomeEffect */ ...,
+  onValues   = clause => {
+    // BUG: for the `(implicit ev: Sync[F])` clause, `clause` is EMPTY here.
+    //      Expected: a single parameter `ev: Sync[SomeEffect]` to be summoned & supplied.
+    ...
+  }
+)
+```
+
+`onValues` is invoked with an empty clause, so the derivation cannot summon `Sync[SomeEffect]` and
+apply it. A value clause that appears *before* any type-param clause is handled correctly — the gap
+is specifically "a value/implicit clause that follows a type-parameter clause."
+
+## Root cause (Hearth source)
+
+`hearth/src/main/scala-3/hearth/untyped/UntypedMethodsScala3.scala`.
+
+`UntypedMethod.methodExpectations` (~L279) walks `paramSymss` **in order** and correctly emits the
+trailing clause as `NeedsValues(...)` with the (still-abstract) parameter types — e.g. `Sync[F]`
+where `F` is the not-yet-applied type parameter (L306–320).
+
+The information is then **thrown away** in `UntypedMethod.toTyped` (~L764), which maps the untyped
+expectations to typed ones:
+
+```scala
+var seenTypeParams = false
+val typedExpectations = untypedExpectations.map {
+  case NeedsInstance   => MethodExpectation.NeedsInstance
+  case NeedsTypes(utp) => seenTypeParams = true; MethodExpectation.NeedsTypes(...)
+  case NeedsValues(up) =>
+    if (seenTypeParams) MethodExpectation.NeedsValues(List.empty)   // <-- the gap (L781-783)
+    else                MethodExpectation.NeedsValues(up.asTyped[Instance])
+}
+```
+
+Once a type-parameter clause has been seen, any following value clause is collapsed to
+`NeedsValues(List.empty)`. The reason it is dropped rather than typed is that `up.asTyped[Instance]`
+would try to resolve the parameter types (`Sync[F]`) against `Instance` while `F` is still an
+un-applied abstract type parameter — Hearth does not substitute the type arguments applied via
+`onTypes` into the param types of subsequent clauses, so it cannot produce a well-typed parameter and
+bails out to an empty list.
+
+The Scala 2 path has the analogous limitation.
+
+## Ideal fix (upstream)
+
+When `onTypes` applies type arguments for a `NeedsTypes` clause, **substitute** those arguments into
+the parameter types of all subsequent `NeedsValues` clauses, so that `toTyped`/`asTyped` can present
+`Sync[SomeEffect]` (concrete) to `onValues`. Equivalently, expose a mode where the remaining
+implicit clauses are resolved by the compiler's own implicit search after the type arguments are
+fixed.
+
+## Current workaround in kindlings (di-cats)
+
+`di-cats` bypasses the `Method` API entirely for `resource[F]` and builds the call by **raw
+per-platform reflection**, applying `F` first and then filling the now-`F`-substituted clauses:
+
+- Scala 3 — `ResourceWiringMacros.companionResourceCall`
+  (`di-cats/src/main/scala-3/.../ResourceWiringMacros.scala`): `companionTerm.select(sym)
+  .appliedToType(fRepr)` to apply `F`, then a recursive `applyClauses` that walks each remaining
+  `MethodType`, runs `Implicits.search(paramType)` on the (already `F`-substituted) param types, and
+  `Apply`s the results. An explicit (non-implicit) clause makes it bail with `None`.
+- Scala 2 — `ResourceWiringMacros.companionResourceCall`
+  (`di-cats/src/main/scala-2/.../ResourceWiringMacros.scala`): builds `q"($companion.$method[$F]):
+  $expected"` and lets `c.typecheck` insert the implicit `Sync[F]` clause via its own implicit search.
+
+If/when Hearth substitutes applied type args into subsequent clause param types, both
+`companionResourceCall` implementations can be simplified back to a single `Method.fold`.
+
+## Related
+
+- `docs/research/HANDOFF-next-session.md` issue #3.
+- kindlings `di-cats` `resource[F]` support (PR #159).
+</content>
+</invoke>

--- a/docs/research/tapir-schema-2_13-cyclic-reference-jdk25.md
+++ b/docs/research/tapir-schema-2_13-cyclic-reference-jdk25.md
@@ -1,0 +1,111 @@
+# `tapir-schema-derivation` Scala 2.13 `illegal cyclic reference` — a JDK-25/GraalVM artifact
+
+**Status:** investigated; **not a code defect** and **not reliably reproducible**. CI (Temurin 17) is
+green; a clean isolated compile is green even locally (GraalVM CE 25). No source change is made — see
+"Decision" below.
+
+## Symptom
+
+During the *full* parallel `publish-local-for-tests` on the local dev JVM (GraalVM CE 25),
+`tapirSchemaDerivation2_13` intermittently failed with:
+
+```
+illegal cyclic reference involving <refinement of
+  SchemaMacrosImpl with MacroCommons with StdExtensions with JsonSchemaConfigs with AnnotationSupport>
+(position: unknown)
+```
+
+It blocked the *full* local `publish-local-for-tests` (and thus a full local `just test-snippets`);
+the local workaround was to `publishLocal` only the modules a given docs file needs.
+
+**Reproduction attempt (this investigation):** a clean isolated
+`tapirSchemaDerivation2_13/clean ; tapirSchemaDerivation2_13/compile` on GraalVM CE 25 **succeeded**
+(`done compiling`, `[success]`). So the error does **not** reproduce for an isolated module compile —
+it only surfaced under the full, parallel multi-module publish. This is exactly the fingerprint of a
+**nondeterministic symbol-completer ordering** issue (see hypothesis below), not a deterministic cake
+defect.
+
+**Key facts:**
+- PR #159's `Scala: 2.13 / jvm / temurin:1.17` CI job was green with the *same* sources.
+- A fresh isolated clean compile is green locally too (GraalVM CE 25).
+The failure is JVM- *and* build-order-specific, not a master regression.
+
+## Structure of the macro cake (all sound)
+
+Scala 2 bundle — `.../scala-2/.../internal/compiletime/SchemaMacros.scala`:
+
+```scala
+final private[tapirschemaderivation] class SchemaMacros(val c: blackbox.Context)
+    extends MacroCommonsScala2
+    with AnnotationSupport
+    with JsonSchemaConfigs
+    with SchemaMacrosImpl
+```
+
+`SchemaMacrosImpl` (shared) declares the self-type named in the error:
+
+```scala
+trait SchemaMacrosImpl extends … {
+  this: MacroCommons & StdExtensions & JsonSchemaConfigs & AnnotationSupport =>
+```
+
+- `AnnotationSupport` (tapir) → thin delegate to `derivation-commons` `AnnotationSupport`; self-type
+  `this: MacroCommons & StdExtensions =>`.
+- `JsonSchemaConfigs` (from `json-schema-config-macro-providers`); self-type
+  `this: MacroCommons & StdExtensions =>`.
+
+Neither config trait references `SchemaMacrosImpl` or each other. The bundle satisfies
+`SchemaMacrosImpl`'s self-type by listing `AnnotationSupport`/`JsonSchemaConfigs` *before* it in the
+parent list — the ordinary Hearth cake pattern. The Scala 3 bundle uses the identical parent order.
+
+**No source-level cycle exists.** The refinement in the error message is exactly the compiler-synthesized
+"self of `SchemaMacrosImpl`" intersection; it is not a type spelled anywhere in the sources.
+
+## Comparison with working modules
+
+| Module | `*Impl` self-type width | `AnnotationSupport` before `*Impl`? |
+|---|---|---|
+| **tapir** `SchemaMacros` | **4** (`MacroCommons & StdExtensions & JsonSchemaConfigs & AnnotationSupport`) | yes |
+| jsoniter `CodecMacros` | 3 (`… & AnnotationSupport`) | yes — compiles fine |
+| circe `CodecMacros` | mixed | yes — compiles fine |
+| cats `ShowMacros` | 2 | no (`Impl` first) — compiles fine |
+
+- The `AnnotationSupport`-before-`Impl` ordering is **not** unique to tapir (jsoniter/circe do it too and
+  compile), so parent ordering is not the trigger.
+- tapir's only structural distinction: it is the **only** module whose cake also mixes in
+  `JsonSchemaConfigs` (from a separate module), giving `SchemaMacrosImpl` the **widest self-type
+  intersection (4 components)** in the codebase.
+
+## Root-cause hypothesis
+
+A **scalac-2.13-on-JDK-25/GraalVM artifact**, not a code defect:
+
+1. Identical sources compile on Temurin 17 (CI) and fail only on GraalVM CE 25 — a genuine cake cycle
+   would fail on every JDK, deterministically.
+2. `position: unknown` is the signature of a cycle detected inside the symbol *completer*
+   (base-type/self-type completion), where scalac has no source position — i.e. compiler-internal
+   completion-order nondeterminism, not a user-visible loop.
+3. Completing `SchemaMacrosImpl`'s self-type re-enters completion of `SchemaMacrosImpl`; whether the
+   completer's cycle guard trips can depend on symbol-forcing order, which can depend on hash-map
+   iteration order and thus on JDK internals. Scala 2.13.x predates and is not validated on JDK 25.
+4. tapir has the widest / only cross-module self-type intersection, so it is the most likely module to
+   hit a latent completion-order edge case first when iteration order shifts under a new JDK, while the
+   2–3-component cakes in cats/jsoniter/circe stay under the threshold.
+
+## Decision
+
+**No source change.** The cake is structurally sound and consistent with the working modules (same
+pattern, one extra legitimately-ordered trait). CI on the project's target JDK (Temurin 17) is green,
+so the PR's CI is unaffected. Rewriting the cake to dodge a compiler completion-order bug would paper
+over a scalac/JDK issue and risk a real regression across the cross-compiled matrix.
+
+If a local workaround is ever needed (to run the full local publish on JDK 25), the lowest-risk nudge —
+not applied here — would be to narrow `SchemaMacrosImpl`'s self-type to a single named aggregate trait
+(e.g. `trait SchemaMacroBundle extends MacroCommons with StdExtensions with JsonSchemaConfigs with
+AnnotationSupport`, self-type `this: SchemaMacroBundle =>`) so the completer resolves one named symbol
+instead of a 4-way structural refinement. Prefer instead to build locally on Temurin 17.
+
+## Related
+
+- `docs/research/HANDOFF-next-session.md` issue #2.
+</content>


### PR DESCRIPTION
Resolves the five follow-ups tracked after PR #159.

## 1. Fix: polymorphic cats derivation on case-object / parameterless enum cases (primary, user-reported)
`Functor`/`Foldable`/`Traverse` derivation aborted when a sealed trait / enum had a **case object** or
**parameterless enum case** (`case Nope`, no parens — a singleton, not a case class). The enum
map/fold/traverse bodies called `parseCaseClassMIO` on each matched child and failed on the singleton
*before* reaching the fieldless-identity path (which only handled parameterless case *classes*,
`case Foo()`).

Each matched child is now guarded with `CaseClass.parse[Child].toEither`, short-circuiting a `Left`
(singleton) to identity: unchanged value for `Functor`, untouched accumulator for `foldLeft`/`foldRight`,
`pure(value)` for `traverse` — mirroring the existing guard in the `Bi*` impls. The other polymorphic
impls were audited; only these three shared the gap (the `Bi*` ones already guarded). Adds a
`Perhaps[+A]` (`Definitely[+A]` + `case object Nope`) regression example with Functor/Foldable/Traverse
tests.

## 2. Investigate: tapir Scala 2.13 `illegal cyclic reference` (JDK-25 artifact) — no code change
Documented in `docs/research/tapir-schema-2_13-cyclic-reference-jdk25.md`. The macro cake is
structurally sound and consistent with the working modules (just the widest self-type intersection).
A clean isolated `tapirSchemaDerivation2_13/compile` **succeeds** even on the local GraalVM CE 25; the
error only ever surfaced under the full parallel publish — the fingerprint of a nondeterministic
scalac-2.13-on-JDK-25 symbol-completer ordering issue, not a code defect. CI (Temurin 17) is green.
Decision: no source change (cake surgery would paper over a compiler bug and risk the cross-compiled
matrix).

## 3. Reproducer + upstream issue: Hearth `Method.fold` drops an implicit clause after type-params
`docs/research/hearth-method-fold-implicit-after-typeparams.md`. `Method.fold`'s `onValues` is handed an
empty clause for a value/implicit clause that follows a type-parameter clause
(`UntypedMethodsScala3.toTyped` L781-783), so `Sync[F]` for `def resource[F[_]: Sync]` cannot be supplied
via the `Method` API. Filed upstream as **kubuszok/hearth#331**; di-cats works around it with raw
per-platform reflection.

## 4. Feature: enum-argument DSL for `DI.plan`
Adds the enum-argument builder form the original design wanted, **alongside** the existing method-name
DSL (no breaking change):

```scala
DI.plan[App]
  .defaultStorage(PlanStorage.LazyVal)
  .storeAs[RequestScoped](PlanStorage.Def)
  .debug(PlanDebug.Mermaid)
  .build
```

New public `PlanStorage` (`Val`/`LazyVal`/`Def`) and `PlanDebug` (`Tree`/`Mermaid`) case objects (not a
Scala 3 `enum`, so they cross-compile). `applyPlanCall` extracts the passed singleton by matching its
`DestructuredExpr`'s (singleton) static type.

## 5. Feature: di-cats `resource[F]` with explicit value parameters
A companion `def resource[F[_]: Sync](config: Config): Resource[F, T]` can now be used: the explicit
value params of its single explicit clause are resolved from the wiring graph (like a factory method's
params) and applied alongside the compiler-summoned implicits. New per-platform
`companionResourceExplicitParamTypes` reads the F-substituted explicit param types;
`companionResourceCall` takes and applies the resolved args. (Both still use raw reflection because of
kubuszok/hearth#331.)

## Verification
All three touched modules pass on Scala 2.13 **and** 3 (JVM): `cats-derivation` (incl. new `Perhaps`
regression tests), `di` (incl. `WiringSpec` + new `DIPlanSpec` enum-DSL tests), `di-cats` (incl. new
`ResourceMethodSpec` explicit-param tests). Formatting checked (`scalafmtCheckAll`). JS/Native covered by
CI (the changed logic is macro-time/JVM; generated code is standard).
