### PR TITLE
feat(cats-integration): IsCollection providers for NonEmptySeq and NonEmptyLazyList

### DIFF
--- a/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/CatsCollectionAndMapProviders.scala
+++ b/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/CatsCollectionAndMapProviders.scala
@@ -3,8 +3,9 @@ package hearth.kindlings.catsintegration.internal.compiletime
 import hearth.MacroCommons
 import hearth.std.{ProviderResult, StandardMacroExtension, StdExtensions}
 
-/** Registers IsCollection providers for Cats data types: NonEmptyList, NonEmptyVector, NonEmptyChain, Chain. Registers
-  * IsMap provider (via IsCollection) for NonEmptyMap. Registers IsCollection provider for NonEmptySet.
+/** Registers IsCollection providers for Cats data types: NonEmptyList, NonEmptyVector, NonEmptySeq, NonEmptyLazyList,
+  * NonEmptyChain, Chain. Registers IsMap provider (via IsCollection) for NonEmptyMap. Registers IsCollection provider
+  * for NonEmptySet.
   *
   * All `Expr.quote` blocks are inside helper methods where element types are regular type parameters (not
   * path-dependent from `elem.Underlying`). This avoids Scala 2 reification failures ("not found: value elem").
@@ -83,6 +84,72 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
                 if (list.nonEmpty)
                   Right(cats.data.NonEmptyVector.fromVectorUnsafe(list.toVector).asInstanceOf[A])
                 else Left("Cannot create NonEmptyVector from empty collection")
+              },
+            None
+          )
+      })
+    }
+
+    @scala.annotation.nowarn("msg=is never used")
+    def mkNESeq[A, E](AT: Type[A], elemType: Type[E]): IsCollection[A] = {
+      implicit val eType: Type[E] = elemType
+      implicit val aType: Type[A] = AT
+      implicit val listEType: Type[List[E]] = ListType[E]
+      implicit val builderType: Type[scala.collection.mutable.Builder[E, List[E]]] = BuilderType[E, List[E]]
+
+      Existential[IsCollectionOf[A, *], E](new IsCollectionOf[A, E] {
+        override def asIterable(value: Expr[A]): Expr[Iterable[E]] =
+          Expr.quote(Expr.splice(value).asInstanceOf[cats.data.NonEmptySeq[E]].toSeq)
+        override type CtorResult = List[E]
+        implicit override val CtorResult: Type[CtorResult] = listEType
+        override def factory: Expr[scala.collection.Factory[E, CtorResult]] = Expr.quote {
+          new scala.collection.Factory[E, List[E]] {
+            override def newBuilder: scala.collection.mutable.Builder[E, List[E]] = List.newBuilder[E]
+            override def fromSpecific(it: IterableOnce[E]): List[E] = List.from(it)
+          }
+        }
+        override def build: CtorLikeOf[scala.collection.mutable.Builder[E, CtorResult], A] =
+          CtorLikeOf.EitherStringOrValue(
+            (builder: Expr[scala.collection.mutable.Builder[E, List[E]]]) =>
+              Expr.quote {
+                val list = Expr.splice(builder).result()
+                if (list.nonEmpty)
+                  Right(cats.data.NonEmptySeq.fromSeqUnsafe(list).asInstanceOf[A])
+                else Left("Cannot create NonEmptySeq from empty collection")
+              },
+            None
+          )
+      })
+    }
+
+    @scala.annotation.nowarn("msg=is never used")
+    def mkNELL[A, E](AT: Type[A], elemType: Type[E]): IsCollection[A] = {
+      implicit val eType: Type[E] = elemType
+      implicit val aType: Type[A] = AT
+      implicit val listEType: Type[List[E]] = ListType[E]
+      implicit val builderType: Type[scala.collection.mutable.Builder[E, List[E]]] = BuilderType[E, List[E]]
+
+      Existential[IsCollectionOf[A, *], E](new IsCollectionOf[A, E] {
+        override def asIterable(value: Expr[A]): Expr[Iterable[E]] =
+          Expr.quote(
+            hearth.kindlings.catsintegration.internal.runtime.CatsConversions
+              .nonEmptyLazyListToIterable[E](Expr.splice(value))
+          )
+        override type CtorResult = List[E]
+        implicit override val CtorResult: Type[CtorResult] = listEType
+        override def factory: Expr[scala.collection.Factory[E, CtorResult]] = Expr.quote {
+          new scala.collection.Factory[E, List[E]] {
+            override def newBuilder: scala.collection.mutable.Builder[E, List[E]] = List.newBuilder[E]
+            override def fromSpecific(it: IterableOnce[E]): List[E] = List.from(it)
+          }
+        }
+        override def build: CtorLikeOf[scala.collection.mutable.Builder[E, CtorResult], A] =
+          CtorLikeOf.EitherStringOrValue(
+            (builder: Expr[scala.collection.mutable.Builder[E, List[E]]]) =>
+              Expr.quote {
+                hearth.kindlings.catsintegration.internal.runtime.CatsConversions
+                  .buildNonEmptyLazyList(Expr.splice(builder).result().asInstanceOf[List[Any]])
+                  .asInstanceOf[Either[String, A]]
               },
             None
           )
@@ -282,6 +349,40 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
         NEVCtor.unapply(tpe) match {
           case Some(elem) => ProviderResult.Matched(mkNEV(tpe, elem.Underlying))
           case None       => skipped(s"${tpe.prettyPrint} is not a NonEmptyVector")
+        }
+    })
+
+    // --- NonEmptySeq ---
+    IsCollection.registerProvider(new IsCollection.Provider {
+      override def name: String = s"${loader.getClass.getName}#NonEmptySeq"
+
+      private lazy val NESeqCtor = {
+        val impl = Type.Ctor1.of[cats.data.NonEmptySeq]
+        Type.Ctor1.fromUntyped[cats.data.NonEmptySeq](impl.asUntyped)
+      }
+
+      @scala.annotation.nowarn("msg=is never used")
+      override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] =
+        NESeqCtor.unapply(tpe) match {
+          case Some(elem) => ProviderResult.Matched(mkNESeq(tpe, elem.Underlying))
+          case None       => skipped(s"${tpe.prettyPrint} is not a NonEmptySeq")
+        }
+    })
+
+    // --- NonEmptyLazyList ---
+    IsCollection.registerProvider(new IsCollection.Provider {
+      override def name: String = s"${loader.getClass.getName}#NonEmptyLazyList"
+
+      private lazy val NELLCtor = {
+        val impl = Type.Ctor1.of[cats.data.NonEmptyLazyList]
+        Type.Ctor1.fromUntyped[cats.data.NonEmptyLazyList](impl.asUntyped)
+      }
+
+      @scala.annotation.nowarn("msg=is never used")
+      override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] =
+        NELLCtor.unapply(tpe) match {
+          case Some(elem) => ProviderResult.Matched(mkNELL(tpe, elem.Underlying))
+          case None       => skipped(s"${tpe.prettyPrint} is not a NonEmptyLazyList")
         }
     })
 

--- a/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/runtime/CatsConversions.scala
+++ b/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/runtime/CatsConversions.scala
@@ -32,6 +32,14 @@ object CatsConversions {
         Left("Cannot create NonEmptyMap from empty collection")
     }
 
+  def nonEmptyLazyListToIterable[A](a: Any): Iterable[A] =
+    a.asInstanceOf[cats.data.NonEmptyLazyList[A]].toLazyList.toList
+
+  def buildNonEmptyLazyList(list: List[Any]): Either[String, Any] =
+    if (list.nonEmpty) {
+      Right(cats.data.NonEmptyLazyList.fromLazyListUnsafe(scala.collection.immutable.LazyList.from(list)))
+    } else Left("Cannot create NonEmptyLazyList from empty collection")
+
   def nonEmptySetToIterable[A](a: Any): Iterable[A] =
     a.asInstanceOf[cats.data.NonEmptySet[A]].toSortedSet.toList
 

--- a/integration-tests/src/test/scala/hearth/kindlings/integrationtests/CatsJsoniterSpec.scala
+++ b/integration-tests/src/test/scala/hearth/kindlings/integrationtests/CatsJsoniterSpec.scala
@@ -1,6 +1,16 @@
 package hearth.kindlings.integrationtests
 
-import cats.data.{Chain, Const, NonEmptyChain, NonEmptyList, NonEmptyMap, NonEmptySet, NonEmptyVector}
+import cats.data.{
+  Chain,
+  Const,
+  NonEmptyChain,
+  NonEmptyLazyList,
+  NonEmptyList,
+  NonEmptyMap,
+  NonEmptySeq,
+  NonEmptySet,
+  NonEmptyVector
+}
 import hearth.MacroSuite
 import hearth.kindlings.jsoniterderivation.KindlingsJsonValueCodec
 import com.github.plokhotnyuk.jsoniter_scala.core.*
@@ -29,6 +39,26 @@ final class CatsJsoniterSpec extends MacroSuite {
         val v = WithNEV(NonEmptyVector.of(10, 20))
         val decoded = roundTrip(v)
         decoded.values ==> NonEmptyVector.of(10, 20)
+      }
+    }
+
+    group("NonEmptySeq") {
+
+      test("round-trip") {
+        implicit val codec: JsonValueCodec[WithNESeq] = KindlingsJsonValueCodec.derived[WithNESeq]
+        val v = WithNESeq(NonEmptySeq.of(10, 20, 30))
+        val decoded = roundTrip(v)
+        decoded.values ==> NonEmptySeq.of(10, 20, 30)
+      }
+    }
+
+    group("NonEmptyLazyList") {
+
+      test("round-trip") {
+        implicit val codec: JsonValueCodec[WithNELL] = KindlingsJsonValueCodec.derived[WithNELL]
+        val v = WithNELL(NonEmptyLazyList(5, 6, 7))
+        val decoded = roundTrip(v)
+        assert(decoded.values.toLazyList.toList == List(5, 6, 7))
       }
     }
 

--- a/integration-tests/src/test/scala/hearth/kindlings/integrationtests/catsExamples.scala
+++ b/integration-tests/src/test/scala/hearth/kindlings/integrationtests/catsExamples.scala
@@ -4,8 +4,10 @@ import cats.data.{
   Chain,
   Const,
   NonEmptyChain,
+  NonEmptyLazyList,
   NonEmptyList,
   NonEmptyMap,
+  NonEmptySeq,
   NonEmptySet,
   NonEmptyVector,
   Validated,
@@ -14,6 +16,8 @@ import cats.data.{
 
 case class WithNEL(values: NonEmptyList[Int])
 case class WithNEV(values: NonEmptyVector[Int])
+case class WithNESeq(values: NonEmptySeq[Int])
+case class WithNELL(values: NonEmptyLazyList[Int])
 case class WithNEC(values: NonEmptyChain[Int])
 case class WithChain(values: Chain[Int])
 case class WithNEM(values: NonEmptyMap[String, Int])


### PR DESCRIPTION
## What

Adds `IsCollection` providers for `cats.data.NonEmptySeq` and `cats.data.NonEmptyLazyList` to `kindlings-cats-integration`, next to the existing providers for `NonEmptyList`, `NonEmptyVector`, `NonEmptyChain`, `Chain`, `NonEmptyMap` and `NonEmptySet`.

## How

- **`NonEmptySeq`** is a plain value class (`extends AnyVal`), so it follows the existing **`NonEmptyVector`** pattern — direct references inside the cross-quotes and `fromSeqUnsafe` for the smart constructor (`mkNESeq`).
- **`NonEmptyLazyList`** is a newtype, so it follows the **`NonEmptyChain`** pattern — the cross-quote bodies delegate to runtime helpers in `CatsConversions` (`nonEmptyLazyListToIterable` / `buildNonEmptyLazyList`) to keep the quoted code free of the newtype alias, which otherwise fails Scala 2 reification.

Both providers register via `Type.Ctor1.of[...] + fromUntyped` unapply, mirroring the surrounding code.

## Tests

Added `WithNESeq` / `WithNELL` fixtures and round-trip tests in `CatsJsoniterSpec`. Full `CatsJsoniterSpec` passes on both Scala 2.13 and Scala 3 (10/10 each).

## Context

Closes the Chimney 2.0.0 gap for `NonEmptySeq` / `NonEmptyLazyList` (`catsNonEmptySeqIsPartiallyBuildIterable` / `catsNonEmptyLazyListIsPartiallyBuildIterable` in Chimney 1.x), pinned via `compileErrors` in `CatsDataSpec`.

Fixes #161