### PR TITLE
Prepare for hearth 0.4.1

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,10 @@ val settings = Seq(
       "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-Ywarn-unused:locals",
-      "-Ywarn-unused:imports",
+      // "-Ywarn-unused:imports", // with -Ywarn-macros:after below, an import that only feeds a macro (e.g. the
+      // package-object `.modify` DSL in BareImportSpec) is flagged unused because Hearth fully-qualifies references in
+      // the expanded tree (hearth#320, a correctness fix for cross-unit quotes) — same used-but-flagged-unused class
+      // that already made us drop `-Wunused:imports` on Scala 3 (see the Scala 3 options above).
       "-Ywarn-macros:after",
       "-Xsource-features:eta-expand-always", // silence warn that appears since 2.13.17
       "-Ytasty-reader"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,7 +19,8 @@ object versions {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.4.0"
+  // TODO: pin the final 0.4.1 once released (currently the pre-release SNAPSHOT with the #317/#320 fixes).
+  val hearth = "0.4.1-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"


### PR DESCRIPTION
WIP — pending the hearth 0.4.1(-SNAPSHOT) publish; CI will resolve once it is on the repo (currently pins `0.4.1-SNAPSHOT`).

Adopts hearth 0.4.1, which fixes:
- **#317 follow-up**: fresh `ValDefs` symbols were owned by native quoted-lambda `$anonfun` instead of the enclosing splice, aborting `yaml-derivation` on Scala 3 (`Block contains definition with different owners`).
- **#320**: cross-unit quotes fully-qualify object references (correct), which under `-Ywarn-macros:after` makes a macro-feeding `import` read as unused.

Changes:
- bump `hearth` → `0.4.1-SNAPSHOT` (`project/Versions.scala`; pin final 0.4.1 on release).
- Scala 2: comment out `-Ywarn-unused:imports` — same used-but-flagged-unused false-positive class that already made us drop `-Wunused:imports` on Scala 3 (see the Scala 3 options in `build.sbt`). Verified: `optics` compiles + all optics/yaml-derivation tests pass both Scala versions against the pre-release snapshot.