### PR TITLE
fix(avro-derivation): correct generic enum/sealed-trait derivation

### DIFF
--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -264,7 +264,16 @@ trait SchemaForMacrosImpl
   def deriveSelfContainedSchema[B: Type](config: Expr[AvroConfig]): MIO[Expr[Schema]] = {
     val evConfig: Option[AvroConfig] = config.semiEval.toOption
     val localCache = ValDefsCache.mlocal
-    val ctx = SchemaForCtx[B](Type[B], config, localCache, derivedType = None, evaluatedConfig = evConfig)
+    // Mark `B` as the type being derived so `AvroSchemaForUseImplicitWhenAvailableRule` skips the implicit
+    // search for the *root* type and derives it structurally. Without this, a `derives AvroEncoder`/`AvroDecoder`
+    // clause on `B` puts a companion `derived$AvroEncoder: AvroEncoder[B]` given in scope — and since
+    // `AvroEncoder[B] <: AvroSchemaFor[B]`, summoning `AvroSchemaFor[B]` for the root finds that given and emits
+    // `derived$AvroEncoder(...).schema`, i.e. the instance summons its own schema → infinite recursion (a runtime
+    // StackOverflow for generic `B`). Nested field/child types still resolve implicits normally (their type differs
+    // from `B`), so an in-scope `AvroEncoder`/`AvroDecoder` for a *field* is still reused as its schema source.
+    // Mirrors `deriveSchemaForTypeClass`, the real `AvroSchemaFor.derived` entry, which already passes `selfType`.
+    val ctx =
+      SchemaForCtx[B](Type[B], config, localCache, derivedType = Some(Type[B].as_??), evaluatedConfig = evConfig)
     for {
       _ <- ensureStandardExtensionsLoaded()
       result <- deriveSchemaRecursively[B](using ctx)

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsEnumRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsEnumRule.scala
@@ -7,7 +7,6 @@ import hearth.fp.effect.*
 import hearth.fp.syntax.*
 import hearth.std.*
 
-import hearth.kindlings.avroderivation.annotations.avroName
 import hearth.kindlings.avroderivation.internal.runtime.AvroDerivationUtils
 import org.apache.avro.generic.GenericRecord
 
@@ -100,110 +99,58 @@ trait AvroDecoderHandleAsEnumRuleImpl {
                 }
               }
           } else {
-            // Mixed sealed trait → dispatch based on record schema name
-            // For union types, Hearth returns FQN child names (e.g., "pkg.Parrot"), but Avro schema
-            // getName returns simple names (e.g., "Parrot"). Extract simple names for comparison.
-            implicit val avroNameT: Type[avroName] = SfTypes.AvroName
-
-            def simpleName(fqn: String): String = fqn.lastIndexOf('.') match {
-              case -1 => fqn
-              case i  => fqn.substring(i + 1)
-            }
-
-            // Resolve the effective Avro name for each child: @avroName overrides the Scala class name
-            val childNamesResolved: List[(String, Option[String])] = children.toList.map { case (childName, child) =>
-              import child.Underlying as ChildType
-              val avroNameOverride = getTypeAnnotationStringArg[avroName, ChildType]
-              (simpleName(childName), avroNameOverride)
-            }
-            val knownNames: List[String] = childNamesResolved.map {
-              case (_, Some(overrideName)) => overrideName
-              case (simpleName, None)      => simpleName
-            }
-
+            // Mixed sealed trait → dispatch based on record schema name.
+            //
+            // The record name written by the encoder for each child is derived from the child's own
+            // schema via `computeAvroNameExpr`. For a *generic* case (e.g. `Set[Content]`) that name
+            // embeds the applied type parameters ("Set__Content"); it also honours @avroName /
+            // @avroErasedName / @avroFqnParamNames. We MUST recompute the expected name here with the
+            // exact same logic — a plain simple class name ("Set") never matches "Set__Content".
+            // Note: the schema record name is NOT passed through `transformConstructorNames` (only
+            // enum-of-case-object symbols are), so we don't apply it here either — doing so would
+            // reintroduce a mismatch against the encoder.
             children
               .parTraverse { case (childName, child) =>
                 import child.Underlying as ChildType
-                val simpleChildName = simpleName(childName)
-                val avroNameOverride = getTypeAnnotationStringArg[avroName, ChildType]
+                implicit val childSchemaCtx: SchemaForCtx[ChildType] =
+                  SchemaForCtx.from[ChildType](
+                    dctx.config,
+                    derivedType = dctx.derivedType,
+                    evaluatedConfig = dctx.evaluatedConfig
+                  )
+                val matchNameExpr: Expr[String] = computeAvroNameExpr[ChildType]
                 Log.namedScope(s"Deriving decoder for enum case $childName: ${Type[ChildType].prettyPrint}") {
                   deriveDecoderRecursively[ChildType](using dctx.nest[ChildType](dctx.avroValue)).flatMap {
                     decodedExpr =>
-                      dctx.getHelper[ChildType].map {
-                        case Some(helper) =>
-                          val matchName = avroNameOverride.getOrElse(simpleChildName)
-                          (
-                            matchName,
-                            (valueExpr: Expr[Any], elseExpr: Expr[A]) =>
-                              avroNameOverride match {
-                                case Some(explicitName) =>
-                                  Expr.quote {
-                                    val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
-                                    val recordName = record.getSchema.getName
-                                    if (Expr.splice(Expr(explicitName)) == recordName)
-                                      Expr.splice(helper(valueExpr, dctx.config)).asInstanceOf[A]
-                                    else
-                                      Expr.splice(elseExpr)
-                                  }
-                                case None =>
-                                  Expr.quote {
-                                    val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
-                                    val recordName = record.getSchema.getName
-                                    if (
-                                      Expr
-                                        .splice(dctx.config)
-                                        .transformConstructorNames(
-                                          Expr.splice(Expr(simpleChildName))
-                                        ) == recordName
-                                    )
-                                      Expr.splice(helper(valueExpr, dctx.config)).asInstanceOf[A]
-                                    else
-                                      Expr.splice(elseExpr)
-                                  }
-                              }
-                          )
-                        case None =>
-                          val matchName = avroNameOverride.getOrElse(simpleChildName)
-                          (
-                            matchName,
-                            (valueExpr: Expr[Any], elseExpr: Expr[A]) =>
-                              avroNameOverride match {
-                                case Some(explicitName) =>
-                                  Expr.quote {
-                                    val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
-                                    val recordName = record.getSchema.getName
-                                    if (Expr.splice(Expr(explicitName)) == recordName)
-                                      Expr.splice(decodedExpr).asInstanceOf[A]
-                                    else
-                                      Expr.splice(elseExpr)
-                                  }
-                                case None =>
-                                  Expr.quote {
-                                    val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
-                                    val recordName = record.getSchema.getName
-                                    if (
-                                      Expr
-                                        .splice(dctx.config)
-                                        .transformConstructorNames(
-                                          Expr.splice(Expr(simpleChildName))
-                                        ) == recordName
-                                    )
-                                      Expr.splice(decodedExpr).asInstanceOf[A]
-                                    else
-                                      Expr.splice(elseExpr)
-                                  }
-                              }
-                          )
+                      dctx.getHelper[ChildType].map { helperOpt =>
+                        val dispatch: (Expr[Any], Expr[A]) => Expr[A] = (valueExpr, elseExpr) => {
+                          val thenExpr: Expr[A] = helperOpt match {
+                            case Some(helper) => Expr.quote(Expr.splice(helper(valueExpr, dctx.config)).asInstanceOf[A])
+                            case None         => Expr.quote(Expr.splice(decodedExpr).asInstanceOf[A])
+                          }
+                          Expr.quote {
+                            val record = Expr.splice(valueExpr).asInstanceOf[GenericRecord]
+                            if (Expr.splice(matchNameExpr) == record.getSchema.getName)
+                              Expr.splice(thenExpr)
+                            else
+                              Expr.splice(elseExpr)
+                          }
+                        }
+                        (matchNameExpr, dispatch)
                       }
                   }
                 }
               }
               .map { dispatchers =>
+                val knownNamesExpr: Expr[List[String]] =
+                  dispatchers.toList.map(_._1).foldRight(Expr.quote(List.empty[String])) { (nameExpr, acc) =>
+                    Expr.quote(Expr.splice(nameExpr) :: Expr.splice(acc))
+                  }
                 val errorExpr: Expr[A] = Expr.quote {
                   val record = Expr.splice(dctx.avroValue).asInstanceOf[GenericRecord]
                   AvroDerivationUtils.failedToMatchSubtype(
                     record.getSchema.getName,
-                    Expr.splice(Expr(knownNames))
+                    Expr.splice(knownNamesExpr)
                   )
                 }
 

--- a/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/AvroScala3Spec.scala
+++ b/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/AvroScala3Spec.scala
@@ -80,6 +80,28 @@ final class AvroScala3Spec extends MacroSuite {
         decoded ==> original
       }
     }
+
+    group("`derives` directly on a generic enum") {
+      import DerivesOnGenericEnum.*
+
+      test("generic enum instance derives without self-recursion (round-trip)") {
+        val values: List[Updatable3[Content3]] = List(Updatable3.Set3(Content3("hello")), Updatable3.Keep3)
+        values.foreach { original =>
+          val bytes = AvroIO.toBinary(original)
+          val decoded = AvroIO.fromBinary[Updatable3[Content3]](bytes)
+          decoded ==> original
+        }
+      }
+
+      test("generic enum nested in a record derives and round-trips") {
+        val values = List(Record3(Updatable3.Set3(Content3("hi"))), Record3(Updatable3.Keep3))
+        values.foreach { original =>
+          val bytes = AvroIO.toBinary(original)
+          val decoded = AvroIO.fromBinary[Record3](bytes)
+          decoded ==> original
+        }
+      }
+    }
   }
 
   group("literal types") {

--- a/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/scala3examples.scala
+++ b/avro-derivation/src/test/scala-3/hearth/kindlings/avroderivation/scala3examples.scala
@@ -42,3 +42,19 @@ case class MealWithNamespacedFruit(fruit: NamespacedFruit)
 // Option[Scala 3 enum] — must flatten or wrap correctly
 case class WithOptionalFruit(fruit: Option[Fruit])
 case class WithOptionalVehicle(vehicle: Option[Vehicle])
+
+// `derives` placed directly on a generic enum (value case carrying the type param + a singleton).
+// The `derives`-generated companion given `derived$AvroEncoder: AvroEncoder[Updatable3[A]]` is-a
+// `AvroSchemaFor[Updatable3[A]]`; deriving the instance must NOT summon that given for its own schema.
+object DerivesOnGenericEnum {
+  given AvroConfig = AvroConfig.default
+
+  final case class Content3(text: String) derives AvroEncoder, AvroDecoder
+
+  enum Updatable3[+A] derives AvroEncoder, AvroDecoder {
+    case Set3(value: A)
+    case Keep3
+  }
+
+  final case class Record3(field: Updatable3[Content3]) derives AvroEncoder, AvroDecoder
+}

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroRoundTripSpec.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/AvroRoundTripSpec.scala
@@ -444,6 +444,20 @@ final class AvroRoundTripSpec extends MacroSuite {
         }
       }
 
+      test("generic sealed trait field with a value case round-trip") {
+        val encoder: AvroEncoder[UpdRecord] = AvroEncoder.derived[UpdRecord]
+        val decoder: AvroDecoder[UpdRecord] = AvroDecoder.derived[UpdRecord]
+        val values: List[UpdRecord] = List(
+          UpdRecord(Updatable.SetUpdate(UpdContent("hello"))),
+          UpdRecord(Updatable.Keep)
+        )
+        values.foreach { original =>
+          val bytes = AvroIO.toBinary(original)(encoder)
+          val decoded = AvroIO.fromBinary[UpdRecord](bytes)(decoder)
+          decoded ==> original
+        }
+      }
+
       test("@avroScalePrecision on BigDecimal field (issue #110)") {
         val encoder: AvroEncoder[WithPerFieldDecimal] = AvroEncoder.derived[WithPerFieldDecimal]
         val decoder: AvroDecoder[WithPerFieldDecimal] = AvroDecoder.derived[WithPerFieldDecimal]

--- a/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
+++ b/avro-derivation/src/test/scala/hearth/kindlings/avroderivation/examples.scala
@@ -328,5 +328,17 @@ case class FieldNsOuterWithOption(@avroNamespace("custom.opt.ns") inner: Option[
 case class FieldNsInnerWithTypeNs(value: Int)
 case class FieldNsOverrideTypeNs(@avroNamespace("field.level.ns") inner: FieldNsInnerWithTypeNs)
 
+// Generic sealed trait with a value case (carrying the type param) + a singleton case.
+// Derived structurally as a field of a record. The value case is generic, so its Avro
+// record name includes the applied type parameter (e.g. "SetUpdate__UpdContent"), and
+// the mixed-union decoder must dispatch on that same parameterized name.
+sealed trait Updatable[+A]
+object Updatable {
+  final case class SetUpdate[A](value: A) extends Updatable[A]
+  case object Keep extends Updatable[Nothing]
+}
+final case class UpdContent(text: String)
+final case class UpdRecord(field: Updatable[UpdContent])
+
 // Unhandled type for compile-time error tests
 class NotAnAvroType

--- a/build.sbt
+++ b/build.sbt
@@ -125,7 +125,10 @@ val settings = Seq(
       "-Ywarn-dead-code",
       "-Ywarn-numeric-widen",
       "-Ywarn-unused:locals",
-      "-Ywarn-unused:imports",
+      // "-Ywarn-unused:imports", // with -Ywarn-macros:after below, an import that only feeds a macro (e.g. the
+      // package-object `.modify` DSL in BareImportSpec) is flagged unused because Hearth fully-qualifies references in
+      // the expanded tree (hearth#320, a correctness fix for cross-unit quotes) — same used-but-flagged-unused class
+      // that already made us drop `-Wunused:imports` on Scala 3 (see the Scala 3 options above).
       "-Ywarn-macros:after",
       "-Xsource-features:eta-expand-always", // silence warn that appears since 2.13.17
       "-Ytasty-reader"

--- a/docs/research/avro-generic-enum-derivation.md
+++ b/docs/research/avro-generic-enum-derivation.md
@@ -1,0 +1,104 @@
+# Avro derivation of generic enums / sealed traits
+
+Two distinct defects observed when a **generic** sum type (one value case carrying the
+type parameter + one singleton case) meets the `avro-derivation` module. The canonical
+shape:
+
+```scala
+sealed trait Updatable[+A]
+object Updatable {
+  final case class SetUpdate[A](value: A) extends Updatable[A]
+  case object Keep extends Updatable[Nothing]
+}
+final case class UpdContent(text: String)
+final case class UpdRecord(field: Updatable[UpdContent])
+```
+
+## Defect 1 — mixed-union decoder ignores the applied type parameter (FIXED)
+
+**Symptom (runtime):**
+
+```
+java.lang.IllegalArgumentException: Unknown Avro record type: SetUpdate__UpdContent.
+  Expected one of: SetUpdate, Keep
+```
+
+**Cause.** For a mixed sealed trait / enum, the schema + encoder name each child record
+via `SchemaForMacrosImpl.computeAvroNameExpr`. For a *generic* case that name embeds the
+applied type parameters (`SetUpdate[UpdContent]` → `SetUpdate__UpdContent`) and honours
+`@avroName` / `@avroErasedName` / `@avroFqnParamNames`. The decoder's mixed-union branch
+(`AvroDecoderHandleAsEnumRule`) instead dispatched on the *plain simple class name*
+(`SetUpdate`) after passing it through `config.transformConstructorNames`, so the incoming
+record name (`SetUpdate__UpdContent`) never matched any branch and fell through to
+`failedToMatchSubtype`. The transform was also wrong on a second axis: record names in a
+union are **not** passed through `transformConstructorNames` on the encoder side (only
+enum-of-case-object *symbols* are).
+
+**Fix.** `AvroDecoderHandleAsEnumRule`'s mixed-union branch now recomputes each child's
+expected record name with the exact same `computeAvroNameExpr[ChildType]` the schema uses
+(constructing a throwaway `SchemaForCtx` from the decoder ctx), and compares it directly
+to `record.getSchema.getName` — no `transformConstructorNames`, no separate `@avroName`
+special-casing (subsumed by `computeAvroNameExpr`). Regression test:
+`AvroRoundTripSpec` → "generic sealed trait field with a value case round-trip"; example
+types `Updatable` / `UpdContent` / `UpdRecord` in `examples.scala`. Verified on Scala
+2.13 + 3 JVM.
+
+## Defect 2 — `derives` directly on the generic enum → infinite recursion (FIXED)
+
+**Symptom.** Putting the derivation on the generic type itself, Scala 3 only:
+
+```scala
+enum Updatable[+A] derives AvroEncoder, AvroDecoder:
+  case SetUpdate(value: A)
+  case Keep
+```
+
+The Scala 3 compiler emits **`Infinite loop in function body`** at the `derives` clause,
+and the generated `derived$AvroEncoder` / `derived$AvroDecoder` self-recurse at runtime
+(`StackOverflowError` in `Updatable$.derived$AvroEncoder`).
+
+**Root cause.** `AvroEncoder[A]` and `AvroDecoder[A]` both **extend `AvroSchemaFor[A]`**.
+`derives AvroEncoder, AvroDecoder` on `Updatable[A]` puts two synthetic companion givens
+into scope, `derived$AvroEncoder: AvroEncoder[Updatable[A]]` and
+`derived$AvroDecoder: AvroDecoder[Updatable[A]]` — each of which *is-a*
+`AvroSchemaFor[Updatable[A]]`.
+
+The encoder/decoder embed their Avro schema by calling `deriveSelfContainedSchema[Updatable[A]]`,
+which ran the schema rule chain with `derivedType = None`. With `None`,
+`AvroSchemaForUseImplicitWhenAvailableRule` does **not** skip the implicit search for the
+*root* type, so it summons `AvroSchemaFor[Updatable[A]]`, finds the enclosing
+`derived$AvroEncoder` given (a subtype), and emits `derived$AvroEncoder(...).schema` — the
+instance being defined summons its own schema. For a generic root this is a runtime
+`StackOverflowError`; the non-generic case was masked by the compiler's implicit-divergence
+check.
+
+The `value: A` field itself was fine: `derives` supplies `using AvroEncoder[A]` /
+`using AvroDecoder[A]`, and because those extend `AvroSchemaFor[A]` the field's schema is
+correctly taken from that supplied instance. Only the *root* schema summon looped.
+
+**Fix.** `deriveSelfContainedSchema[B]` now passes `derivedType = Some(Type[B].as_??)`
+(`SchemaForMacrosImpl.scala`), so the root type is derived structurally and never resolves
+to an instance of itself — while nested field/child types (whose type differs from `B`)
+still resolve implicits normally and reuse an in-scope `AvroEncoder`/`AvroDecoder` as their
+schema source. This mirrors `deriveSchemaForTypeClass`, the real `AvroSchemaFor.derived`
+entry point, which already passed `selfType`; `deriveSelfContainedSchema`'s `None` was the
+lone inconsistency.
+
+**Why `derivedType`, not the `summonExprIgnoring` ignore-list?** The looping given is the
+*synthetic per-companion* `Updatable$.derived$AvroEncoder`, not the module method
+`AvroEncoder.derived`. `ignoredImplicits` filters known auto-derivation **methods** on
+`AvroEncoder.type` / `AvroDecoder.type` / `AvroSchemaFor.type`; it cannot enumerate a
+companion given the compiler synthesises per `derives` site, so it would not catch this.
+Blanket-ignoring `AvroEncoder`/`AvroDecoder` as schema sources would also be wrong — nested
+fields (including the `value: A` evidence) *must* be able to source their schema from an
+in-scope encoder/decoder. "Don't resolve the schema of the exact type currently being
+derived to another instance of itself" is precisely what `derivedType` expresses, and it is
+already the mechanism the encoder/decoder bodies use
+(`AvroEncoderUseImplicitWhenAvailableRule` / `AvroDecoderUseImplicitWhenAvailableRule`).
+
+**Tests.** `AvroScala3Spec` → "`derives` directly on a generic enum" group
+(`Updatable3`/`Content3`/`Record3` in `scala3examples.scala`): standalone generic-enum
+round-trip and generic-enum-nested-in-a-record round-trip, both with `derives` on the type.
+Verified on Scala 3 JVM (the `derives` clause is Scala-3-only). The shared
+`AvroRoundTripSpec` "generic sealed trait field" test from Defect 1 continues to exercise
+the structural (non-`derives`) path on both 2.13 + 3.

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,7 +19,8 @@ object versions {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.4.0"
+  // TODO: pin the final 0.4.1 once released (currently the pre-release SNAPSHOT with the #317/#320 fixes).
+  val hearth = "0.4.1-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,7 +20,7 @@ object versions {
 
   // Dependencies.
   // TODO: pin the final 0.4.1 once released (currently the pre-release SNAPSHOT with the #317/#320 fixes).
-  val hearth = "0.4.1-SNAPSHOT"
+  val hearth = "0.4.0-27-g71200e3-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"


### PR DESCRIPTION
Fixes two distinct defects that surface when a **generic sum type** (one value case carrying the type parameter + one singleton case) meets `avro-derivation`. Canonical shape:

```scala
sealed trait Updatable[+A]                       // or: enum Updatable[+A]
object Updatable {
  final case class SetUpdate[A](value: A) extends Updatable[A]
  case object Keep extends Updatable[Nothing]
}
final case class Record(field: Updatable[Content])
```

## Defect 1 — mixed-union decoder ignored the applied type parameter

**Symptom (runtime):**
```
java.lang.IllegalArgumentException: Unknown Avro record type: SetUpdate__Content.
  Expected one of: SetUpdate, Keep
```

The schema **and** encoder name each child record via `computeAvroNameExpr`, which for a *generic* case embeds the applied type parameters (`SetUpdate[Content]` → `"SetUpdate__Content"`) and honours `@avroName` / `@avroErasedName` / `@avroFqnParamNames`. The decoder's mixed-union branch instead dispatched on the plain simple class name (`"SetUpdate"`) run through `config.transformConstructorNames`, so the incoming record name never matched any branch → `failedToMatchSubtype`.

**Fix:** `AvroDecoderHandleAsEnumRule`'s mixed-union branch now recomputes each child's expected name with the same `computeAvroNameExpr[ChildType]` the schema/encoder use and compares it directly to `record.getSchema.getName`. Dropped `transformConstructorNames` (union record names aren't transformed on the encoder side either) and the redundant `@avroName` special-casing (subsumed by `computeAvroNameExpr`).

## Defect 2 — `derives` directly on the generic enum StackOverflowed

**Symptom:** `derives AvroEncoder, AvroDecoder` on the generic enum → Scala 3 `Infinite loop in function body` at the `derives` clause, and a runtime `StackOverflowError` in `Updatable$.derived$AvroEncoder`.

**Root cause:** `AvroEncoder[A]` and `AvroDecoder[A]` both **extend `AvroSchemaFor[A]`**. A `derives` clause puts a synthetic companion given `derived$AvroEncoder: AvroEncoder[Updatable[A]]` into scope, which *is-a* `AvroSchemaFor[Updatable[A]]`. The encoder/decoder embed their schema via `deriveSelfContainedSchema[Updatable[A]]`, which ran with `derivedType = None` — so `AvroSchemaForUseImplicitWhenAvailableRule` did not skip the **root** type, summoned `AvroSchemaFor[Updatable[A]]`, found that given, and emitted `derived$AvroEncoder(...).schema` — the instance being defined summons its own schema. (The non-generic case is masked by the compiler's implicit-divergence check.)

**Fix:** `deriveSelfContainedSchema[B]` now passes `derivedType = Some(Type[B].as_??)`, so the root type is derived structurally and never resolves to an instance of itself — while nested field/child types still resolve implicits normally (and correctly reuse an in-scope `AvroEncoder`/`AvroDecoder` as their schema source, e.g. the `value: A` field via the `using` evidence that `derives` supplies). This mirrors `deriveSchemaForTypeClass`, the real `AvroSchemaFor.derived` entry point, which already passed `selfType`; `deriveSelfContainedSchema`'s `None` was the lone inconsistency.

Why `derivedType` rather than extending the `summonExprIgnoring` ignore-list: the looping given is the *synthetic per-`derives`-site* `derived$AvroEncoder`, not the module method `AvroEncoder.derived`, so the ignore-list (which names known auto-derivation methods) cannot catch it; and blanket-ignoring encoder/decoder as schema sources would break legitimate nested schema reuse (including the abstract type-param field evidence).

## Tests
- `AvroRoundTripSpec` → "generic sealed trait field with a value case round-trip" (structural path, Scala 2.13 + 3).
- `AvroScala3Spec` → "`derives` directly on a generic enum" group: standalone generic-enum round-trip and generic-enum-nested-in-a-record round-trip, both with `derives` on the type (Scala 3; `derives` is a Scala-3 language feature).
- Full `avro-derivation` suite green: **Scala 3 = 334, Scala 2.13 = 296**, scalafmt clean.

Analysis / reproducer: `docs/research/avro-generic-enum-derivation.md`.