### PR TITLE
Perf: lazy provider registration + unsortedMethods on implicit ignore-sets

### DIFF
--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -484,21 +484,21 @@ trait DecoderMacrosImpl
     def AvroDecoder: Type.Ctor1[AvroDecoder] = Type.Ctor1.of[AvroDecoder]
     val DecoderLogDerivation: Type[hearth.kindlings.avroderivation.AvroDecoder.LogDerivation] =
       Type.of[hearth.kindlings.avroderivation.AvroDecoder.LogDerivation]
-    val Schema: Type[Schema] = Type.of[Schema]
-    val AvroConfig: Type[AvroConfig] = Type.of[AvroConfig]
-    val DecimalConfig: Type[DecimalConfig] = Type.of[DecimalConfig]
-    val String: Type[String] = Type.of[String]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Double: Type[Double] = Type.of[Double]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Any: Type[Any] = Type.of[Any]
-    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
-    val ArrayByte: Type[Array[Byte]] = Type.of[Array[Byte]]
-    val FieldName: Type[fieldName] = Type.of[fieldName]
-    val TransientField: Type[transientField] = Type.of[transientField]
-    val AvroFixed: Type[avroFixed] = Type.of[avroFixed]
-    val AvroAlias: Type[avroAlias] = Type.of[avroAlias]
-    val ListString: Type[List[String]] = Type.of[List[String]]
+    val Schema: Type.Lazy[Schema] = Type.Lazy(Type.of[Schema])
+    val AvroConfig: Type.Lazy[AvroConfig] = Type.Lazy(Type.of[AvroConfig])
+    val DecimalConfig: Type.Lazy[DecimalConfig] = Type.Lazy(Type.of[DecimalConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val ArrayAny: Type.Lazy[Array[Any]] = Type.Lazy(Type.of[Array[Any]])
+    val ArrayByte: Type.Lazy[Array[Byte]] = Type.Lazy(Type.of[Array[Byte]])
+    val FieldName: Type.Lazy[fieldName] = Type.Lazy(Type.of[fieldName])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
+    val AvroFixed: Type.Lazy[avroFixed] = Type.Lazy(Type.of[avroFixed])
+    val AvroAlias: Type.Lazy[avroAlias] = Type.Lazy(Type.of[avroAlias])
+    val ListString: Type.Lazy[List[String]] = Type.Lazy(Type.of[List[String]])
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -428,15 +428,15 @@ trait EncoderMacrosImpl
     def AvroEncoder: Type.Ctor1[AvroEncoder] = Type.Ctor1.of[AvroEncoder]
     val EncoderLogDerivation: Type[hearth.kindlings.avroderivation.AvroEncoder.LogDerivation] =
       Type.of[hearth.kindlings.avroderivation.AvroEncoder.LogDerivation]
-    val Schema: Type[Schema] = Type.of[Schema]
-    val AvroConfig: Type[AvroConfig] = Type.of[AvroConfig]
-    val DecimalConfig: Type[DecimalConfig] = Type.of[DecimalConfig]
-    val String: Type[String] = Type.of[String]
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val Product: Type[Product] = Type.of[Product]
-    val FieldName: Type[fieldName] = Type.of[fieldName]
-    val TransientField: Type[transientField] = Type.of[transientField]
-    val AvroFixed: Type[avroFixed] = Type.of[avroFixed]
+    val Schema: Type.Lazy[Schema] = Type.Lazy(Type.of[Schema])
+    val AvroConfig: Type.Lazy[AvroConfig] = Type.Lazy(Type.of[AvroConfig])
+    val DecimalConfig: Type.Lazy[DecimalConfig] = Type.Lazy(Type.of[DecimalConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Product: Type.Lazy[Product] = Type.Lazy(Type.of[Product])
+    val FieldName: Type.Lazy[fieldName] = Type.Lazy(Type.of[fieldName])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
+    val AvroFixed: Type.Lazy[avroFixed] = Type.Lazy(Type.of[avroFixed])
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/SchemaForMacrosImpl.scala
@@ -421,25 +421,25 @@ trait SchemaForMacrosImpl
     def AvroSchemaFor: Type.Ctor1[AvroSchemaFor] = Type.Ctor1.of[AvroSchemaFor]
     val SchemaForLogDerivation: Type[hearth.kindlings.avroderivation.AvroSchemaFor.LogDerivation] =
       Type.of[hearth.kindlings.avroderivation.AvroSchemaFor.LogDerivation]
-    val Schema: Type[Schema] = Type.of[Schema]
-    val AvroConfig: Type[AvroConfig] = Type.of[AvroConfig]
-    val DecimalConfig: Type[DecimalConfig] = Type.of[DecimalConfig]
-    val String: Type[String] = Type.of[String]
-    val FieldName: Type[fieldName] = Type.of[fieldName]
-    val TransientField: Type[transientField] = Type.of[transientField]
-    val AvroDoc: Type[avroDoc] = Type.of[avroDoc]
-    val AvroNamespace: Type[avroNamespace] = Type.of[avroNamespace]
-    val AvroDefault: Type[avroDefault] = Type.of[avroDefault]
-    val AvroFixed: Type[avroFixed] = Type.of[avroFixed]
-    val AvroError: Type[avroError] = Type.of[avroError]
-    val AvroProp: Type[avroProp] = Type.of[avroProp]
-    val AvroAlias: Type[avroAlias] = Type.of[avroAlias]
-    val AvroSortPriority: Type[avroSortPriority] = Type.of[avroSortPriority]
-    val AvroNoDefault: Type[avroNoDefault] = Type.of[avroNoDefault]
-    val AvroEnumDefault: Type[avroEnumDefault] = Type.of[avroEnumDefault]
-    val AvroErasedName: Type[avroErasedName] = Type.of[avroErasedName]
-    val AvroFqnParamNames: Type[avroFqnParamNames] = Type.of[avroFqnParamNames]
-    val AvroName: Type[avroName] = Type.of[avroName]
-    val AvroScalePrecision: Type[avroScalePrecision] = Type.of[avroScalePrecision]
+    val Schema: Type.Lazy[Schema] = Type.Lazy(Type.of[Schema])
+    val AvroConfig: Type.Lazy[AvroConfig] = Type.Lazy(Type.of[AvroConfig])
+    val DecimalConfig: Type.Lazy[DecimalConfig] = Type.Lazy(Type.of[DecimalConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val FieldName: Type.Lazy[fieldName] = Type.Lazy(Type.of[fieldName])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
+    val AvroDoc: Type.Lazy[avroDoc] = Type.Lazy(Type.of[avroDoc])
+    val AvroNamespace: Type.Lazy[avroNamespace] = Type.Lazy(Type.of[avroNamespace])
+    val AvroDefault: Type.Lazy[avroDefault] = Type.Lazy(Type.of[avroDefault])
+    val AvroFixed: Type.Lazy[avroFixed] = Type.Lazy(Type.of[avroFixed])
+    val AvroError: Type.Lazy[avroError] = Type.Lazy(Type.of[avroError])
+    val AvroProp: Type.Lazy[avroProp] = Type.Lazy(Type.of[avroProp])
+    val AvroAlias: Type.Lazy[avroAlias] = Type.Lazy(Type.of[avroAlias])
+    val AvroSortPriority: Type.Lazy[avroSortPriority] = Type.Lazy(Type.of[avroSortPriority])
+    val AvroNoDefault: Type.Lazy[avroNoDefault] = Type.Lazy(Type.of[avroNoDefault])
+    val AvroEnumDefault: Type.Lazy[avroEnumDefault] = Type.Lazy(Type.of[avroEnumDefault])
+    val AvroErasedName: Type.Lazy[avroErasedName] = Type.Lazy(Type.of[avroErasedName])
+    val AvroFqnParamNames: Type.Lazy[avroFqnParamNames] = Type.Lazy(Type.of[avroFqnParamNames])
+    val AvroName: Type.Lazy[avroName] = Type.Lazy(Type.of[avroName])
+    val AvroScalePrecision: Type.Lazy[avroScalePrecision] = Type.Lazy(Type.of[avroScalePrecision])
   }
 }

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCaseClassRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderHandleAsCaseClassRule.scala
@@ -144,7 +144,7 @@ trait AvroDecoderHandleAsCaseClassRuleImpl {
                       (fName, decodedExpr)
                     }
                   case (_, Some((_, scale))) =>
-                    val bigDecimalType: Type[BigDecimal] = Type.of[BigDecimal]
+                    val bigDecimalType: Type.Lazy[BigDecimal] = Type.Lazy(Type.of[BigDecimal])
                     MIO.pure {
                       implicit val BigDecimalT: Type[BigDecimal] = bigDecimalType
                       val decodedExpr: Expr_?? = Expr.quote {

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderUseImplicitWhenAvailableRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroDecoderUseImplicitWhenAvailableRule.scala
@@ -21,7 +21,7 @@ trait AvroDecoderUseImplicitWhenAvailableRuleImpl {
       * must be added here.
       */
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[AvroDecoder.type].methods.collect {
+      Type.of[AvroDecoder.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderUseImplicitWhenAvailableRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroEncoderUseImplicitWhenAvailableRule.scala
@@ -17,7 +17,7 @@ trait AvroEncoderUseImplicitWhenAvailableRuleImpl {
       * excluded.
       */
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[AvroEncoder.type].methods.collect {
+      Type.of[AvroEncoder.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForUseImplicitWhenAvailableRule.scala
+++ b/avro-derivation/src/main/scala/hearth/kindlings/avroderivation/internal/compiletime/rules/AvroSchemaForUseImplicitWhenAvailableRule.scala
@@ -18,7 +18,7 @@ trait AvroSchemaForUseImplicitWhenAvailableRuleImpl {
       * excluded.
       */
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[AvroSchemaFor.type].methods.collect {
+      Type.of[AvroSchemaFor.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/build.sbt
+++ b/build.sbt
@@ -75,6 +75,7 @@ val settings = Seq(
       "-feature",
       "-no-indent",
       "-language:postfixOps", // "for >>"
+      "-language:implicitConversions", // hearth Type.Lazy[A] => Type[A] unwrapping at use-sites
       "-Wconf:msg=Unreachable case:s", // suppress fake (?) errors in internal.compiletime
       "-Wconf:msg=Missing symbol position:s", // suppress warning https://github.com/scala/scala3/issues/21672
       "-Werror",
@@ -99,6 +100,7 @@ val settings = Seq(
       "-explaintypes",
       "-feature",
       "-language:higherKinds",
+      "-language:implicitConversions", // hearth Type.Lazy[A] => Type[A] unwrapping at use-sites
       "-Wconf:cat=scala3-migration:s", // silence mainly issues with -Xsource:3 and private case class constructors
       "-Wconf:cat=deprecation&origin=hearth.*:s", // we want to be able to deprecate APIs and test them while they're deprecated
       "-Wconf:msg=The outer reference in this type test cannot be checked at run time:s", // suppress fake(?) errors in internal.compiletime (adding origin breaks this suppression)

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AlternativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/AlternativeMacrosImpl.scala
@@ -353,9 +353,9 @@ trait AlternativeMacrosImpl extends CatsDerivationTimeout with CatsDerivationErr
   }
 
   protected object AltTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def Semigroup: Type.Ctor1[cats.kernel.Semigroup] = Type.Ctor1.of[cats.kernel.Semigroup]
     def Monoid: Type.Ctor1[cats.kernel.Monoid] = Type.Ctor1.of[cats.kernel.Monoid]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplicativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplicativeMacrosImpl.scala
@@ -252,9 +252,9 @@ trait ApplicativeMacrosImpl
   }
 
   protected object ApplicativeTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def Semigroup: Type.Ctor1[cats.kernel.Semigroup] = Type.Ctor1.of[cats.kernel.Semigroup]
     def Monoid: Type.Ctor1[cats.kernel.Monoid] = Type.Ctor1.of[cats.kernel.Monoid]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplyMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ApplyMacrosImpl.scala
@@ -211,9 +211,9 @@ trait ApplyMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupp
   }
 
   protected object ApplyTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def Semigroup: Type.Ctor1[cats.kernel.Semigroup] = Type.Ctor1.of[cats.kernel.Semigroup]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BifoldableMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BifoldableMacrosImpl.scala
@@ -328,9 +328,9 @@ trait BifoldableMacrosImpl extends CatsDerivationTimeout with CatsDerivationErro
   }
 
   protected object BifoldableTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def EvalCtor: Type.Ctor1[cats.Eval] = Type.Ctor1.of[cats.Eval]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BifunctorMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BifunctorMacrosImpl.scala
@@ -291,9 +291,9 @@ trait BifunctorMacrosImpl
   }
 
   protected object BifunctorTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BitraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/BitraverseMacrosImpl.scala
@@ -675,13 +675,13 @@ trait BitraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivationErro
   }
 
   protected object BitraverseTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val ListAny: Type[List[Any]] = Type.of[List[Any]]
-    val ListBoolean: Type[List[Boolean]] = Type.of[List[Boolean]]
-    val EvalAny: Type[cats.Eval[Any]] = Type.of[cats.Eval[Any]]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val ListAny: Type.Lazy[List[Any]] = Type.Lazy(Type.of[List[Any]])
+    val ListBoolean: Type.Lazy[List[Boolean]] = Type.Lazy(Type.of[List[Boolean]])
+    val EvalAny: Type.Lazy[cats.Eval[Any]] = Type.Lazy(Type.of[cats.Eval[Any]])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ConsKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ConsKMacrosImpl.scala
@@ -206,9 +206,9 @@ trait ConsKMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSupp
   }
 
   protected object ConsKTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ContravariantMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ContravariantMacrosImpl.scala
@@ -212,8 +212,8 @@ trait ContravariantMacrosImpl extends CatsDerivationTimeout with CatsDerivationE
     }
 
   protected object ContravariantTypes {
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyKMacrosImpl.scala
@@ -97,7 +97,7 @@ trait EmptyKMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSup
   }
 
   protected object EmptyKTypes {
-    val Any: Type[Any] = Type.of[Any]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
     def Empty: Type.Ctor1[alleycats.Empty] = Type.Ctor1.of[alleycats.Empty]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EmptyMacrosImpl.scala
@@ -122,15 +122,15 @@ trait EmptyMacrosImpl
 
   protected object EmptyTypes {
     def Empty: Type.Ctor1[alleycats.Empty] = Type.Ctor1.of[alleycats.Empty]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Byte: Type[Byte] = Type.of[Byte]
-    val Short: Type[Short] = Type.of[Short]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Float: Type[Float] = Type.of[Float]
-    val Double: Type[Double] = Type.of[Double]
-    val Char: Type[Char] = Type.of[Char]
-    val String: Type[String] = Type.of[String]
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Byte: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val Short: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Float: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Char: Type.Lazy[Char] = Type.Lazy(Type.of[Char])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EqMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/EqMacrosImpl.scala
@@ -136,15 +136,15 @@ trait EqMacrosImpl
 
   protected object EqTypes {
     def Eq: Type.Ctor1[cats.kernel.Eq] = Type.Ctor1.of[cats.kernel.Eq]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Byte: Type[Byte] = Type.of[Byte]
-    val Short: Type[Short] = Type.of[Short]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Float: Type[Float] = Type.of[Float]
-    val Double: Type[Double] = Type.of[Double]
-    val Char: Type[Char] = Type.of[Char]
-    val String: Type[String] = Type.of[String]
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Byte: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val Short: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Float: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Char: Type.Lazy[Char] = Type.Lazy(Type.of[Char])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FoldableMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FoldableMacrosImpl.scala
@@ -229,9 +229,9 @@ trait FoldableMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorS
   }
 
   protected object FoldableTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def EvalCtor: Type.Ctor1[cats.Eval] = Type.Ctor1.of[cats.Eval]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/FunctorMacrosImpl.scala
@@ -498,9 +498,9 @@ trait FunctorMacrosImpl
   protected lazy val CatsFunctorCtor: Type.CtorK1[cats.Functor] = Type.CtorK1.of[cats.Functor]
 
   protected object FunctorTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/HashMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/HashMacrosImpl.scala
@@ -233,7 +233,7 @@ trait HashMacrosImpl
 
   protected object HashTypes {
     def Hash: Type.Ctor1[cats.kernel.Hash] = Type.Ctor1.of[cats.kernel.Hash]
-    val Int: Type[Int] = Type.of[Int]
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
   }
 }
 

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/InvariantMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/InvariantMacrosImpl.scala
@@ -250,8 +250,8 @@ trait InvariantMacrosImpl extends CatsDerivationTimeout with CatsDerivationError
     }
 
   protected object InvariantTypes {
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/MonoidKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/MonoidKMacrosImpl.scala
@@ -156,7 +156,7 @@ trait MonoidKMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSu
   }
 
   protected object MonoidKTypes {
-    val Any: Type[Any] = Type.of[Any]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
     def Monoid: Type.Ctor1[cats.kernel.Monoid] = Type.Ctor1.of[cats.kernel.Monoid]
     def Semigroup: Type.Ctor1[cats.kernel.Semigroup] = Type.Ctor1.of[cats.kernel.Semigroup]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyAlternativeMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyAlternativeMacrosImpl.scala
@@ -314,9 +314,9 @@ trait NonEmptyAlternativeMacrosImpl extends CatsDerivationTimeout with CatsDeriv
   }
 
   protected object NEATypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def Semigroup: Type.Ctor1[cats.kernel.Semigroup] = Type.Ctor1.of[cats.kernel.Semigroup]
     def Monoid: Type.Ctor1[cats.kernel.Monoid] = Type.Ctor1.of[cats.kernel.Monoid]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyTraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/NonEmptyTraverseMacrosImpl.scala
@@ -399,9 +399,9 @@ trait NonEmptyTraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivati
   }
 
   protected object NETTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def EvalAny: Type[cats.Eval[Any]] = Type.of[cats.Eval[Any]]
     def ListAny: Type[List[Any]] = Type.of[List[Any]]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/OrderMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/OrderMacrosImpl.scala
@@ -125,15 +125,15 @@ trait OrderMacrosImpl
 
   protected object OrderTypes {
     def Order: Type.Ctor1[cats.kernel.Order] = Type.Ctor1.of[cats.kernel.Order]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Byte: Type[Byte] = Type.of[Byte]
-    val Short: Type[Short] = Type.of[Short]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Float: Type[Float] = Type.of[Float]
-    val Double: Type[Double] = Type.of[Double]
-    val Char: Type[Char] = Type.of[Char]
-    val String: Type[String] = Type.of[String]
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Byte: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val Short: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Float: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Char: Type.Lazy[Char] = Type.Lazy(Type.of[Char])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/PartialOrderMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/PartialOrderMacrosImpl.scala
@@ -32,6 +32,6 @@ trait PartialOrderMacrosImpl extends OrderMacrosImpl { this: MacroCommons & StdE
 
   protected object PartialOrderTypes {
     def PartialOrder: Type.Ctor1[cats.kernel.PartialOrder] = Type.Ctor1.of[cats.kernel.PartialOrder]
-    val Double: Type[Double] = Type.of[Double]
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
   }
 }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/PureMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/PureMacrosImpl.scala
@@ -143,9 +143,9 @@ trait PureMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorSuppo
   }
 
   protected object PureTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ReducibleMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ReducibleMacrosImpl.scala
@@ -233,9 +233,9 @@ trait ReducibleMacrosImpl extends CatsDerivationTimeout with CatsDerivationError
   }
 
   protected object ReducibleTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def EvalCtor: Type.Ctor1[cats.Eval] = Type.Ctor1.of[cats.Eval]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupKMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupKMacrosImpl.scala
@@ -114,7 +114,7 @@ trait SemigroupKMacrosImpl extends CatsDerivationTimeout with CatsDerivationErro
   }
 
   protected object SemigroupKTypes {
-    val Any: Type[Any] = Type.of[Any]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
     def Semigroup: Type.Ctor1[cats.kernel.Semigroup] = Type.Ctor1.of[cats.kernel.Semigroup]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/SemigroupMacrosImpl.scala
@@ -126,13 +126,13 @@ trait SemigroupMacrosImpl
 
   protected object SemigroupTypes {
     def Semigroup: Type.Ctor1[cats.kernel.Semigroup] = Type.Ctor1.of[cats.kernel.Semigroup]
-    val Byte: Type[Byte] = Type.of[Byte]
-    val Short: Type[Short] = Type.of[Short]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Float: Type[Float] = Type.of[Float]
-    val Double: Type[Double] = Type.of[Double]
-    val String: Type[String] = Type.of[String]
+    val Byte: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val Short: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Float: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =
       Type.of[hearth.kindlings.catsderivation.LogDerivation]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ShowMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/ShowMacrosImpl.scala
@@ -147,17 +147,17 @@ trait ShowMacrosImpl
 
   protected object ShowTypes {
     def Show: Type.Ctor1[cats.Show] = Type.Ctor1.of[cats.Show]
-    val LogDerivation: Type[LogDerivation] = Type.of[LogDerivation]
+    val LogDerivation: Type.Lazy[LogDerivation] = Type.Lazy(Type.of[LogDerivation])
     // StrictDerivation type managed by StrictDerivationSupport trait
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Byte: Type[Byte] = Type.of[Byte]
-    val Short: Type[Short] = Type.of[Short]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Float: Type[Float] = Type.of[Float]
-    val Double: Type[Double] = Type.of[Double]
-    val Char: Type[Char] = Type.of[Char]
-    val String: Type[String] = Type.of[String]
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Byte: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val Short: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Float: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Char: Type.Lazy[Char] = Type.Lazy(Type.of[Char])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     val SensitiveData: Type[hearth.kindlings.catsderivation.annotations.sensitiveData] =
       Type.of[hearth.kindlings.catsderivation.annotations.sensitiveData]
   }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/TraverseMacrosImpl.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/TraverseMacrosImpl.scala
@@ -837,9 +837,9 @@ trait TraverseMacrosImpl extends CatsDerivationTimeout with CatsDerivationErrorS
   }
 
   protected object TraverseTypes {
-    val Any: Type[Any] = Type.of[Any]
-    val Int: Type[Int] = Type.of[Int]
-    val String: Type[String] = Type.of[String]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
     def EvalAny: Type[cats.Eval[Any]] = Type.of[cats.Eval[Any]]
     def ListAny: Type[List[Any]] = Type.of[List[Any]]
     val LogDerivation: Type[hearth.kindlings.catsderivation.LogDerivation] =

--- a/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/CatsCollectionAndMapProviders.scala
+++ b/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/CatsCollectionAndMapProviders.scala
@@ -18,10 +18,12 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
   override def extend(ctx: MacroCommons & StdExtensions): Unit = {
     import ctx.*
 
-    val ListType = Type.Ctor1.of[List]
-    val BuilderType = Type.Ctor2.of[scala.collection.mutable.Builder]
-    val OrderCtor = Type.Ctor1.of[cats.kernel.Order]
-    val Tuple2Ctor = Type.Ctor2.of[Tuple2]
+    // Lazy so the type-constructor introspection is only paid when a provider actually matches (via the mkNE*
+    // helpers below), not on every macro expansion that loads this extension. See the Hearth provider-laziness sweep.
+    lazy val ListType = Type.Ctor1.of[List]
+    lazy val BuilderType = Type.Ctor2.of[scala.collection.mutable.Builder]
+    lazy val OrderCtor = Type.Ctor1.of[cats.kernel.Order]
+    lazy val Tuple2Ctor = Type.Ctor2.of[Tuple2]
 
     // --- Helper methods with regular type parameters (safe for cross-quotes on Scala 2) ---
 

--- a/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/CatsCollectionAndMapProviders.scala
+++ b/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/CatsCollectionAndMapProviders.scala
@@ -329,11 +329,16 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
         Type.Ctor1.fromUntyped[cats.data.NonEmptyList](impl.asUntyped)
       }
 
+      // Cheap sound negative gate (hearth#347 pattern): NonEmptyList is class-headed, so a
+      // class-headed scrutinee can only match when the constructor appears among its base classes.
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(NELCtor.asUntyped))
+
       @scala.annotation.nowarn("msg=is never used")
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] =
         NELCtor.unapply(tpe) match {
           case Some(elem) => ProviderResult.Matched(mkNEL(tpe, elem.Underlying))
-          case None       => skipped(s"${tpe.prettyPrint} is not a NonEmptyList")
+          case None       => skippedLazily(s"${tpe.prettyPrint} is not a NonEmptyList")
         }
     })
 
@@ -346,11 +351,16 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
         Type.Ctor1.fromUntyped[cats.data.NonEmptyVector](impl.asUntyped)
       }
 
+      // Cheap sound negative gate (hearth#347 pattern): NonEmptyVector is class-headed, so a
+      // class-headed scrutinee can only match when the constructor appears among its base classes.
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(NEVCtor.asUntyped))
+
       @scala.annotation.nowarn("msg=is never used")
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] =
         NEVCtor.unapply(tpe) match {
           case Some(elem) => ProviderResult.Matched(mkNEV(tpe, elem.Underlying))
-          case None       => skipped(s"${tpe.prettyPrint} is not a NonEmptyVector")
+          case None       => skippedLazily(s"${tpe.prettyPrint} is not a NonEmptyVector")
         }
     })
 
@@ -363,15 +373,23 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
         Type.Ctor1.fromUntyped[cats.data.NonEmptySeq](impl.asUntyped)
       }
 
+      // Cheap sound negative gate (hearth#347 pattern): NonEmptySeq is class-headed, so a
+      // class-headed scrutinee can only match when the constructor appears among its base classes.
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(NESeqCtor.asUntyped))
+
       @scala.annotation.nowarn("msg=is never used")
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] =
         NESeqCtor.unapply(tpe) match {
           case Some(elem) => ProviderResult.Matched(mkNESeq(tpe, elem.Underlying))
-          case None       => skipped(s"${tpe.prettyPrint} is not a NonEmptySeq")
+          case None       => skippedLazily(s"${tpe.prettyPrint} is not a NonEmptySeq")
         }
     })
 
     // --- NonEmptyLazyList ---
+    // NOTE: no `mightMatch` gate here nor on NonEmptyChain/NonEmptyMap/NonEmptySet below - these are cats NEWTYPES
+    // (dealiasing to abstract types, not classes), so the base-classes check used for the class-headed providers
+    // above would falsely reject them. They keep the default always-attempt behavior.
     IsCollection.registerProvider(new IsCollection.Provider {
       override def name: String = s"${loader.getClass.getName}#NonEmptyLazyList"
 
@@ -384,7 +402,7 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] =
         NELLCtor.unapply(tpe) match {
           case Some(elem) => ProviderResult.Matched(mkNELL(tpe, elem.Underlying))
-          case None       => skipped(s"${tpe.prettyPrint} is not a NonEmptyLazyList")
+          case None       => skippedLazily(s"${tpe.prettyPrint} is not a NonEmptyLazyList")
         }
     })
 
@@ -401,7 +419,7 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] =
         NECCtor.unapply(tpe) match {
           case Some(elem) => ProviderResult.Matched(mkNEC(tpe, elem.Underlying))
-          case None       => skipped(s"${tpe.prettyPrint} is not a NonEmptyChain")
+          case None       => skippedLazily(s"${tpe.prettyPrint} is not a NonEmptyChain")
         }
     })
 
@@ -414,11 +432,16 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
         Type.Ctor1.fromUntyped[cats.data.Chain](impl.asUntyped)
       }
 
+      // Cheap sound negative gate (hearth#347 pattern): Chain is class-headed, so a
+      // class-headed scrutinee can only match when the constructor appears among its base classes.
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(ChainCtor.asUntyped))
+
       @scala.annotation.nowarn("msg=is never used")
       override def parse[A](tpe: Type[A]): ProviderResult[IsCollection[A]] =
         ChainCtor.unapply(tpe) match {
           case Some(elem) => ProviderResult.Matched(mkChain(tpe, elem.Underlying))
-          case None       => skipped(s"${tpe.prettyPrint} is not a Chain")
+          case None       => skippedLazily(s"${tpe.prettyPrint} is not a Chain")
         }
     })
 
@@ -442,14 +465,14 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
             val orderK = Expr.summonImplicit[cats.kernel.Order[K]].toOption match {
               case Some(o) => o
               case None    =>
-                return skipped(
+                return skippedLazily(
                   s"${tpe.prettyPrint} is a NonEmptyMap but Order[${keyType.Underlying.prettyPrint}] not found"
                 )
             }
 
             ProviderResult.Matched(mkNEM(tpe, keyType.Underlying, valueType.Underlying, orderK))
 
-          case None => skipped(s"${tpe.prettyPrint} is not a NonEmptyMap")
+          case None => skippedLazily(s"${tpe.prettyPrint} is not a NonEmptyMap")
         }
     })
 
@@ -472,14 +495,14 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
             val orderElem = Expr.summonImplicit[cats.kernel.Order[Elem]].toOption match {
               case Some(o) => o
               case None    =>
-                return skipped(
+                return skippedLazily(
                   s"${tpe.prettyPrint} is a NonEmptySet but Order[${elem.Underlying.prettyPrint}] not found"
                 )
             }
 
             ProviderResult.Matched(mkNES(tpe, elem.Underlying, orderElem))
 
-          case None => skipped(s"${tpe.prettyPrint} is not a NonEmptySet")
+          case None => skippedLazily(s"${tpe.prettyPrint} is not a NonEmptySet")
         }
     })
   }

--- a/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/IsEitherProviderForValidated.scala
+++ b/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/IsEitherProviderForValidated.scala
@@ -26,6 +26,11 @@ final class IsEitherProviderForValidated extends StandardMacroExtension { loader
         Type.Ctor2.fromUntyped[cats.data.Validated](impl.asUntyped)
       }
 
+      // Cheap sound negative gate (hearth#347 pattern): Validated is class-headed, so a class-headed scrutinee can
+      // only match when the constructor appears among its base classes.
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(ValidatedCtor.asUntyped))
+
       @scala.annotation.nowarn("msg=is never used")
       private def mkIsEither[A, E0, A0](
           tpe: Type[A],
@@ -90,7 +95,7 @@ final class IsEitherProviderForValidated extends StandardMacroExtension { loader
         ValidatedCtor.unapply(tpe) match {
           case Some((errType, valType)) =>
             ProviderResult.Matched(mkIsEither(tpe, errType.Underlying, valType.Underlying))
-          case None => skipped(s"${tpe.prettyPrint} is not a Validated type")
+          case None => skippedLazily(s"${tpe.prettyPrint} is not a Validated type")
         }
     })
   }

--- a/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/IsValueTypeProviderForConst.scala
+++ b/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/IsValueTypeProviderForConst.scala
@@ -24,6 +24,11 @@ final class IsValueTypeProviderForConst extends StandardMacroExtension { loader 
         Type.Ctor2.fromUntyped[cats.data.Const](impl.asUntyped)
       }
 
+      // Cheap sound negative gate (hearth#347 pattern): Const is class-headed, so a class-headed scrutinee can only
+      // match when the constructor appears among its base classes.
+      override def mightMatch[A](tpe: Type[A]): Boolean =
+        tpe.asUntyped.baseClasses.exists(_.sameTypeConstructorAs(ConstCtor.asUntyped))
+
       @scala.annotation.nowarn("msg=is never used")
       override def parse[A](tpe: Type[A]): ProviderResult[IsValueType[A]] =
         ConstCtor.unapply(tpe) match {
@@ -56,7 +61,7 @@ final class IsValueTypeProviderForConst extends StandardMacroExtension { loader 
               )
             )
 
-          case None => skipped(s"${tpe.prettyPrint} is not a Const type")
+          case None => skippedLazily(s"${tpe.prettyPrint} is not a Const type")
         }
     })
   }

--- a/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/InvariantKMacrosImpl.scala
+++ b/cats-tagless-derivation/src/main/scala/hearth/kindlings/catstaglessderivation/internal/compiletime/InvariantKMacrosImpl.scala
@@ -328,7 +328,7 @@ trait InvariantKMacrosImpl
   // --- Types ---
 
   protected object InvariantKTypes {
-    val Any: Type[Any] = Type.of[Any]
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
     val LogDerivation: Type[hearth.kindlings.catstaglessderivation.LogDerivation] =
       Type.of[hearth.kindlings.catstaglessderivation.LogDerivation]
   }

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -476,27 +476,27 @@ trait DecoderMacrosImpl
     def KindlingsDecoder: Type.Ctor1[KindlingsDecoder] = Type.Ctor1.of[KindlingsDecoder]
     val DecoderLogDerivation: Type[hearth.kindlings.circederivation.KindlingsDecoder.LogDerivation] =
       Type.of[hearth.kindlings.circederivation.KindlingsDecoder.LogDerivation]
-    val Json: Type[Json] = Type.of[Json]
-    val HCursor: Type[HCursor] = Type.of[HCursor]
-    val DecodingFailure: Type[DecodingFailure] = Type.of[DecodingFailure]
-    val Configuration: Type[Configuration] = Type.of[Configuration]
-    val String: Type[String] = Type.of[String]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Double: Type[Double] = Type.of[Double]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Any: Type[Any] = Type.of[Any]
-    val Unit: Type[Unit] = Type.of[Unit]
-    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
-    val EitherDFAny: Type[Either[DecodingFailure, Any]] = Type.of[Either[DecodingFailure, Any]]
-    val EitherDFUnit: Type[Either[DecodingFailure, Unit]] = Type.of[Either[DecodingFailure, Unit]]
+    val Json: Type.Lazy[Json] = Type.Lazy(Type.of[Json])
+    val HCursor: Type.Lazy[HCursor] = Type.Lazy(Type.of[HCursor])
+    val DecodingFailure: Type.Lazy[DecodingFailure] = Type.Lazy(Type.of[DecodingFailure])
+    val Configuration: Type.Lazy[Configuration] = Type.Lazy(Type.of[Configuration])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Unit: Type.Lazy[Unit] = Type.Lazy(Type.of[Unit])
+    val ArrayAny: Type.Lazy[Array[Any]] = Type.Lazy(Type.of[Array[Any]])
+    val EitherDFAny: Type.Lazy[Either[DecodingFailure, Any]] = Type.Lazy(Type.of[Either[DecodingFailure, Any]])
+    val EitherDFUnit: Type.Lazy[Either[DecodingFailure, Unit]] = Type.Lazy(Type.of[Either[DecodingFailure, Unit]])
     val ListEitherDFAny: Type[List[Either[DecodingFailure, Any]]] =
       Type.of[List[Either[DecodingFailure, Any]]]
-    val ListString: Type[List[String]] = Type.of[List[String]]
-    val SetString: Type[Set[String]] = Type.of[Set[String]]
-    val StringHCursorTuple: Type[(String, HCursor)] = Type.of[(String, HCursor)]
-    val FieldName: Type[fieldName] = Type.of[fieldName]
-    val TransientField: Type[transientField] = Type.of[transientField]
+    val ListString: Type.Lazy[List[String]] = Type.Lazy(Type.of[List[String]])
+    val SetString: Type.Lazy[Set[String]] = Type.Lazy(Type.of[Set[String]])
+    val StringHCursorTuple: Type.Lazy[(String, HCursor)] = Type.Lazy(Type.of[(String, HCursor)])
+    val FieldName: Type.Lazy[fieldName] = Type.Lazy(Type.of[fieldName])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
 
     def DecoderResult[A: Type]: Type[Either[DecodingFailure, A]] =
       Type.of[Either[DecodingFailure, A]]

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -348,13 +348,13 @@ trait EncoderMacrosImpl
     def KindlingsEncoderAsObject: Type.Ctor1[KindlingsEncoderAsObject] = Type.Ctor1.of[KindlingsEncoderAsObject]
     val EncoderLogDerivation: Type[hearth.kindlings.circederivation.KindlingsEncoder.LogDerivation] =
       Type.of[hearth.kindlings.circederivation.KindlingsEncoder.LogDerivation]
-    val Json: Type[Json] = Type.of[Json]
-    val JsonObject: Type[JsonObject] = Type.of[JsonObject]
-    val Configuration: Type[Configuration] = Type.of[Configuration]
-    val String: Type[String] = Type.of[String]
-    val FieldName: Type[fieldName] = Type.of[fieldName]
-    val TransientField: Type[transientField] = Type.of[transientField]
-    val Int: Type[Int] = Type.of[Int]
-    val Product: Type[Product] = Type.of[Product]
+    val Json: Type.Lazy[Json] = Type.Lazy(Type.of[Json])
+    val JsonObject: Type.Lazy[JsonObject] = Type.Lazy(Type.of[JsonObject])
+    val Configuration: Type.Lazy[Configuration] = Type.Lazy(Type.of[Configuration])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val FieldName: Type.Lazy[fieldName] = Type.Lazy(Type.of[fieldName])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Product: Type.Lazy[Product] = Type.Lazy(Type.of[Product])
   }
 }

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderUseImplicitWhenAvailableRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/DecoderUseImplicitWhenAvailableRule.scala
@@ -14,11 +14,11 @@ trait DecoderUseImplicitWhenAvailableRuleImpl {
   object DecoderUseImplicitWhenAvailableRule extends DecoderDerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsDecoder.type].methods.collect {
+      Type.of[KindlingsDecoder.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[KindlingsCodecAsObject.type].methods.collect {
+      } ++ Type.of[KindlingsCodecAsObject.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[Decoder.type].methods.collect {
+      } ++ Type.of[Decoder.type].unsortedMethods.collect {
         case method if method.name == "derived" || method.name.startsWith("decodeLiteral") =>
           method.asUntyped
       }

--- a/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/EncoderUseImplicitWhenAvailableRule.scala
+++ b/circe-derivation/src/main/scala/hearth/kindlings/circederivation/internal/compiletime/rules/EncoderUseImplicitWhenAvailableRule.scala
@@ -17,11 +17,11 @@ trait EncoderUseImplicitWhenAvailableRuleImpl {
     // For circe's own companions, only ignore specific auto-derivation methods (not built-in
     // instances like encodeInt, encodeString, etc.).
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsEncoder.type].methods.collect {
+      Type.of[KindlingsEncoder.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[KindlingsCodecAsObject.type].methods.collect {
+      } ++ Type.of[KindlingsCodecAsObject.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[Encoder.type].methods.collect {
+      } ++ Type.of[Encoder.type].unsortedMethods.collect {
         case method if method.name == "derived" || method.name.startsWith("encodeLiteral") =>
           method.asUntyped
       }

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DiffMacrosImpl.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/DiffMacrosImpl.scala
@@ -33,18 +33,18 @@ trait DiffMacrosImpl
   protected object DiffTypes {
     def DiffCtor: Type.Ctor1[Diff] = Type.Ctor1.of[Diff]
     def Diff[A: Type]: Type[Diff[A]] = DiffCtor.apply[A]
-    val DiffResultType: Type[DiffResult] = Type.of[DiffResult]
-    val StringType: Type[String] = Type.of[String]
-    val BooleanType: Type[Boolean] = Type.of[Boolean]
-    val IntType: Type[Int] = Type.of[Int]
-    val ByteType: Type[Byte] = Type.of[Byte]
-    val ShortType: Type[Short] = Type.of[Short]
-    val LongType: Type[Long] = Type.of[Long]
-    val FloatType: Type[Float] = Type.of[Float]
-    val DoubleType: Type[Double] = Type.of[Double]
-    val CharType: Type[Char] = Type.of[Char]
-    val BigDecimalType: Type[BigDecimal] = Type.of[BigDecimal]
-    val BigIntType: Type[BigInt] = Type.of[BigInt]
+    val DiffResultType: Type.Lazy[DiffResult] = Type.Lazy(Type.of[DiffResult])
+    val StringType: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val BooleanType: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val IntType: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val ByteType: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val ShortType: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val LongType: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val FloatType: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val DoubleType: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val CharType: Type.Lazy[Char] = Type.Lazy(Type.of[Char])
+    val BigDecimalType: Type.Lazy[BigDecimal] = Type.Lazy(Type.of[BigDecimal])
+    val BigIntType: Type.Lazy[BigInt] = Type.Lazy(Type.of[BigInt])
   }
 
   // ── Diff derivation (two values → DiffResult) ────────────

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacrosImpl.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/FastShowPrettyMacrosImpl.scala
@@ -295,19 +295,19 @@ trait FastShowPrettyMacrosImpl
       Type.of[hearth.kindlings.fastshowpretty.FastShowPretty.LogDerivation]
     val AllowDerivation: Type[hearth.kindlings.fastshowpretty.FastShowPretty.AllowDerivation] =
       Type.of[hearth.kindlings.fastshowpretty.FastShowPretty.AllowDerivation]
-    val StringBuilder: Type[StringBuilder] = Type.of[StringBuilder]
-    val RenderConfig: Type[RenderConfig] = Type.of[RenderConfig]
+    val StringBuilder: Type.Lazy[StringBuilder] = Type.Lazy(Type.of[StringBuilder])
+    val RenderConfig: Type.Lazy[RenderConfig] = Type.Lazy(Type.of[RenderConfig])
 
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Byte: Type[Byte] = Type.of[Byte]
-    val Short: Type[Short] = Type.of[Short]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Float: Type[Float] = Type.of[Float]
-    val Double: Type[Double] = Type.of[Double]
-    val Char: Type[Char] = Type.of[Char]
-    val String: Type[String] = Type.of[String]
-    val Product: Type[Product] = Type.of[Product]
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Byte: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val Short: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Float: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Char: Type.Lazy[Char] = Type.Lazy(Type.of[Char])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Product: Type.Lazy[Product] = Type.Lazy(Type.of[Product])
     val SensitiveData: Type[hearth.kindlings.fastshowpretty.annotations.sensitiveData] =
       Type.of[hearth.kindlings.fastshowpretty.annotations.sensitiveData]
   }

--- a/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/rules/FastShowPrettyUseImplicitWhenAvailableRule.scala
+++ b/fast-show-pretty/src/main/scala/hearth/kindlings/fastshowpretty/internal/compiletime/rules/FastShowPrettyUseImplicitWhenAvailableRule.scala
@@ -12,7 +12,7 @@ trait FastShowPrettyUseImplicitWhenAvailableRuleImpl { this: FastShowPrettyMacro
   object FastShowPrettyUseImplicitWhenAvailableRule extends DerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[FastShowPretty.type].methods.collect {
+      Type.of[FastShowPretty.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/iron-integration/src/main/scala/hearth/kindlings/ironintegration/internal/compiletime/IsValueTypeProviderForIron.scala
+++ b/iron-integration/src/main/scala/hearth/kindlings/ironintegration/internal/compiletime/IsValueTypeProviderForIron.scala
@@ -43,7 +43,7 @@ final class IsValueTypeProviderForIron extends StandardMacroExtension { loader =
             // skip reason instead of an exception crashing the compiler.
             Expr.summonImplicit(using runtimeConstraintType).toOption match {
               case None =>
-                skipped(
+                skippedLazily(
                   s"${tpe.prettyPrint} is an Iron type, but no RuntimeConstraint instance was found for IronType[${Type[Inner].prettyPrint}, ${Type[Constr].prettyPrint}] — cannot generate validation"
                 )
 
@@ -77,7 +77,7 @@ final class IsValueTypeProviderForIron extends StandardMacroExtension { loader =
                 )
             }
 
-          case None => skipped(s"${tpe.prettyPrint} is not an Iron type")
+          case None => skippedLazily(s"${tpe.prettyPrint} is not an Iron type")
         }
     })
   }

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -1040,9 +1040,9 @@ trait CodecMacrosImpl
   // Shared ignored implicits for summonExprIgnoring — prevents infinite macro expansion
   // when summoning finds library auto-derivation methods (e.g., KindlingsJsonCodec.derived).
   private[compiletime] lazy val codecIgnoredImplicits: Seq[UntypedMethod] =
-    Type.of[KindlingsJsonValueCodec.type].methods.collect {
+    Type.of[KindlingsJsonValueCodec.type].unsortedMethods.collect {
       case method if method.isImplicit => method.asUntyped
-    } ++ Type.of[KindlingsJsonCodec.type].methods.collect {
+    } ++ Type.of[KindlingsJsonCodec.type].unsortedMethods.collect {
       case method if method.isImplicit => method.asUntyped
     }
 

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -67,58 +67,59 @@ trait CodecMacrosImpl
       Type.Ctor1.of[KindlingsJsonValueCodec]
     val CodecLogDerivation: Type[hearth.kindlings.jsoniterderivation.KindlingsJsonValueCodec.LogDerivation] =
       Type.of[hearth.kindlings.jsoniterderivation.KindlingsJsonValueCodec.LogDerivation]
-    val JsoniterConfig: Type[JsoniterConfig] = Type.of[JsoniterConfig]
-    val JsonReader: Type[JsonReader] = Type.of[JsonReader]
-    val JsonWriter: Type[JsonWriter] = Type.of[JsonWriter]
-    val String: Type[String] = Type.of[String]
-    val Unit: Type[Unit] = Type.of[Unit]
-    val Any: Type[Any] = Type.of[Any]
-    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
-    val ListString: Type[List[String]] = Type.of[List[String]]
-    val JsonReaderException: Type[JsonReaderException] = Type.of[JsonReaderException]
+    val JsoniterConfig: Type.Lazy[JsoniterConfig] = Type.Lazy(Type.of[JsoniterConfig])
+    val JsonReader: Type.Lazy[JsonReader] = Type.Lazy(Type.of[JsonReader])
+    val JsonWriter: Type.Lazy[JsonWriter] = Type.Lazy(Type.of[JsonWriter])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Unit: Type.Lazy[Unit] = Type.Lazy(Type.of[Unit])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val ArrayAny: Type.Lazy[Array[Any]] = Type.Lazy(Type.of[Array[Any]])
+    val ListString: Type.Lazy[List[String]] = Type.Lazy(Type.of[List[String]])
+    val JsonReaderException: Type.Lazy[JsonReaderException] = Type.Lazy(Type.of[JsonReaderException])
     def EitherJsonReaderException[A: Type]: Type[Either[JsonReaderException, A]] =
       Type.of[Either[JsonReaderException, A]]
-    val FieldName: Type[annotations.fieldName] = Type.of[annotations.fieldName]
-    val TransientField: Type[annotations.transientField] = Type.of[annotations.transientField]
-    val Stringified: Type[annotations.stringified] = Type.of[annotations.stringified]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Double: Type[Double] = Type.of[Double]
-    val Float: Type[Float] = Type.of[Float]
-    val Short: Type[Short] = Type.of[Short]
-    val Byte: Type[Byte] = Type.of[Byte]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val BigDecimal: Type[BigDecimal] = Type.of[BigDecimal]
-    val BigInt: Type[BigInt] = Type.of[BigInt]
-    val Product: Type[Product] = Type.of[Product]
-    val Instant: Type[java.time.Instant] = Type.of[java.time.Instant]
-    val LocalDate: Type[java.time.LocalDate] = Type.of[java.time.LocalDate]
-    val LocalTime: Type[java.time.LocalTime] = Type.of[java.time.LocalTime]
-    val LocalDateTime: Type[java.time.LocalDateTime] = Type.of[java.time.LocalDateTime]
-    val OffsetDateTime: Type[java.time.OffsetDateTime] = Type.of[java.time.OffsetDateTime]
-    val ZonedDateTime: Type[java.time.ZonedDateTime] = Type.of[java.time.ZonedDateTime]
-    val Duration: Type[java.time.Duration] = Type.of[java.time.Duration]
-    val MonthDay: Type[java.time.MonthDay] = Type.of[java.time.MonthDay]
-    val OffsetTime: Type[java.time.OffsetTime] = Type.of[java.time.OffsetTime]
-    val Period: Type[java.time.Period] = Type.of[java.time.Period]
-    val Year: Type[java.time.Year] = Type.of[java.time.Year]
-    val YearMonth: Type[java.time.YearMonth] = Type.of[java.time.YearMonth]
-    val ZoneId: Type[java.time.ZoneId] = Type.of[java.time.ZoneId]
-    val ZoneOffset: Type[java.time.ZoneOffset] = Type.of[java.time.ZoneOffset]
-    val UUID: Type[java.util.UUID] = Type.of[java.util.UUID]
+    val FieldName: Type.Lazy[annotations.fieldName] = Type.Lazy(Type.of[annotations.fieldName])
+    val TransientField: Type.Lazy[annotations.transientField] = Type.Lazy(Type.of[annotations.transientField])
+    val Stringified: Type.Lazy[annotations.stringified] = Type.Lazy(Type.of[annotations.stringified])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Float: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val Short: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val Byte: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val BigDecimal: Type.Lazy[BigDecimal] = Type.Lazy(Type.of[BigDecimal])
+    val BigInt: Type.Lazy[BigInt] = Type.Lazy(Type.of[BigInt])
+    val Product: Type.Lazy[Product] = Type.Lazy(Type.of[Product])
+    val Instant: Type.Lazy[java.time.Instant] = Type.Lazy(Type.of[java.time.Instant])
+    val LocalDate: Type.Lazy[java.time.LocalDate] = Type.Lazy(Type.of[java.time.LocalDate])
+    val LocalTime: Type.Lazy[java.time.LocalTime] = Type.Lazy(Type.of[java.time.LocalTime])
+    val LocalDateTime: Type.Lazy[java.time.LocalDateTime] = Type.Lazy(Type.of[java.time.LocalDateTime])
+    val OffsetDateTime: Type.Lazy[java.time.OffsetDateTime] = Type.Lazy(Type.of[java.time.OffsetDateTime])
+    val ZonedDateTime: Type.Lazy[java.time.ZonedDateTime] = Type.Lazy(Type.of[java.time.ZonedDateTime])
+    val Duration: Type.Lazy[java.time.Duration] = Type.Lazy(Type.of[java.time.Duration])
+    val MonthDay: Type.Lazy[java.time.MonthDay] = Type.Lazy(Type.of[java.time.MonthDay])
+    val OffsetTime: Type.Lazy[java.time.OffsetTime] = Type.Lazy(Type.of[java.time.OffsetTime])
+    val Period: Type.Lazy[java.time.Period] = Type.Lazy(Type.of[java.time.Period])
+    val Year: Type.Lazy[java.time.Year] = Type.Lazy(Type.of[java.time.Year])
+    val YearMonth: Type.Lazy[java.time.YearMonth] = Type.Lazy(Type.of[java.time.YearMonth])
+    val ZoneId: Type.Lazy[java.time.ZoneId] = Type.Lazy(Type.of[java.time.ZoneId])
+    val ZoneOffset: Type.Lazy[java.time.ZoneOffset] = Type.Lazy(Type.of[java.time.ZoneOffset])
+    val UUID: Type.Lazy[java.util.UUID] = Type.Lazy(Type.of[java.util.UUID])
     // Java boxed primitives
-    val JavaByte: Type[java.lang.Byte] = Type.of[java.lang.Byte]
-    val JavaShort: Type[java.lang.Short] = Type.of[java.lang.Short]
-    val JavaInteger: Type[java.lang.Integer] = Type.of[java.lang.Integer]
-    val JavaLong: Type[java.lang.Long] = Type.of[java.lang.Long]
-    val JavaFloat: Type[java.lang.Float] = Type.of[java.lang.Float]
-    val JavaDouble: Type[java.lang.Double] = Type.of[java.lang.Double]
-    val JavaBoolean: Type[java.lang.Boolean] = Type.of[java.lang.Boolean]
-    val JavaCharacter: Type[java.lang.Character] = Type.of[java.lang.Character]
+    val JavaByte: Type.Lazy[java.lang.Byte] = Type.Lazy(Type.of[java.lang.Byte])
+    val JavaShort: Type.Lazy[java.lang.Short] = Type.Lazy(Type.of[java.lang.Short])
+    val JavaInteger: Type.Lazy[java.lang.Integer] = Type.Lazy(Type.of[java.lang.Integer])
+    val JavaLong: Type.Lazy[java.lang.Long] = Type.Lazy(Type.of[java.lang.Long])
+    val JavaFloat: Type.Lazy[java.lang.Float] = Type.Lazy(Type.of[java.lang.Float])
+    val JavaDouble: Type.Lazy[java.lang.Double] = Type.Lazy(Type.of[java.lang.Double])
+    val JavaBoolean: Type.Lazy[java.lang.Boolean] = Type.Lazy(Type.of[java.lang.Boolean])
+    val JavaCharacter: Type.Lazy[java.lang.Character] = Type.Lazy(Type.of[java.lang.Character])
     // BitSet types
-    val ImmutableBitSet: Type[scala.collection.immutable.BitSet] = Type.of[scala.collection.immutable.BitSet]
-    val MutableBitSet: Type[scala.collection.mutable.BitSet] = Type.of[scala.collection.mutable.BitSet]
-    val CollectionBitSet: Type[scala.collection.BitSet] = Type.of[scala.collection.BitSet]
+    val ImmutableBitSet: Type.Lazy[scala.collection.immutable.BitSet] =
+      Type.Lazy(Type.of[scala.collection.immutable.BitSet])
+    val MutableBitSet: Type.Lazy[scala.collection.mutable.BitSet] = Type.Lazy(Type.of[scala.collection.mutable.BitSet])
+    val CollectionBitSet: Type.Lazy[scala.collection.BitSet] = Type.Lazy(Type.of[scala.collection.BitSet])
   }
 
   // Entrypoints

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,7 +20,7 @@ object versions {
 
   // Dependencies.
   // TODO: pin the final 0.4.1 once released (currently the pre-release SNAPSHOT with the #317/#320 fixes).
-  val hearth = "0.4.0-30-gf0bb8c3-SNAPSHOT"
+  val hearth = "0.4.0-52-gaaf7e1a-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,7 +20,7 @@ object versions {
 
   // Dependencies.
   // TODO: pin the final 0.4.1 once released (currently the pre-release SNAPSHOT with the #317/#320 fixes).
-  val hearth = "0.4.1-perf13-SNAPSHOT"
+  val hearth = "0.4.0-53-gd593898-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,7 +20,7 @@ object versions {
 
   // Dependencies.
   // TODO: pin the final 0.4.1 once released (currently the pre-release SNAPSHOT with the #317/#320 fixes).
-  val hearth = "0.4.0-27-g71200e3-SNAPSHOT"
+  val hearth = "0.4.0-30-gf0bb8c3-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,7 +20,7 @@ object versions {
 
   // Dependencies.
   // TODO: pin the final 0.4.1 once released (currently the pre-release SNAPSHOT with the #317/#320 fixes).
-  val hearth = "0.4.0-52-gaaf7e1a-SNAPSHOT"
+  val hearth = "0.4.1-perf13-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -296,27 +296,28 @@ trait ReaderMacrosImpl
     def KindlingsConfigReader: Type.Ctor1[KindlingsConfigReader] = Type.Ctor1.of[KindlingsConfigReader]
     val ReaderLogDerivation: Type[hearth.kindlings.pureconfigderivation.KindlingsConfigReader.LogDerivation] =
       Type.of[hearth.kindlings.pureconfigderivation.KindlingsConfigReader.LogDerivation]
-    val ConfigCursor: Type[ConfigCursor] = Type.of[ConfigCursor]
-    val ConfigObjectCursor: Type[pureconfig.ConfigObjectCursor] = Type.of[pureconfig.ConfigObjectCursor]
-    val ConfigListCursor: Type[pureconfig.ConfigListCursor] = Type.of[pureconfig.ConfigListCursor]
-    val ConfigReaderFailures: Type[ConfigReaderFailures] = Type.of[ConfigReaderFailures]
-    val PureConfig: Type[PureConfig] = Type.of[PureConfig]
-    val String: Type[String] = Type.of[String]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Double: Type[Double] = Type.of[Double]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Any: Type[Any] = Type.of[Any]
-    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
-    val EitherFailuresAny: Type[Either[ConfigReaderFailures, Any]] = Type.of[Either[ConfigReaderFailures, Any]]
+    val ConfigCursor: Type.Lazy[ConfigCursor] = Type.Lazy(Type.of[ConfigCursor])
+    val ConfigObjectCursor: Type.Lazy[pureconfig.ConfigObjectCursor] = Type.Lazy(Type.of[pureconfig.ConfigObjectCursor])
+    val ConfigListCursor: Type.Lazy[pureconfig.ConfigListCursor] = Type.Lazy(Type.of[pureconfig.ConfigListCursor])
+    val ConfigReaderFailures: Type.Lazy[ConfigReaderFailures] = Type.Lazy(Type.of[ConfigReaderFailures])
+    val PureConfig: Type.Lazy[PureConfig] = Type.Lazy(Type.of[PureConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val ArrayAny: Type.Lazy[Array[Any]] = Type.Lazy(Type.of[Array[Any]])
+    val EitherFailuresAny: Type.Lazy[Either[ConfigReaderFailures, Any]] =
+      Type.Lazy(Type.of[Either[ConfigReaderFailures, Any]])
     val ListEitherFailuresAny: Type[List[Either[ConfigReaderFailures, Any]]] =
       Type.of[List[Either[ConfigReaderFailures, Any]]]
-    val ListString: Type[List[String]] = Type.of[List[String]]
-    val SetString: Type[Set[String]] = Type.of[Set[String]]
-    val OptionString: Type[Option[String]] = Type.of[Option[String]]
-    val StringToString: Type[String => String] = Type.of[String => String]
-    val ConfigKey: Type[configKey] = Type.of[configKey]
-    val TransientField: Type[transientField] = Type.of[transientField]
+    val ListString: Type.Lazy[List[String]] = Type.Lazy(Type.of[List[String]])
+    val SetString: Type.Lazy[Set[String]] = Type.Lazy(Type.of[Set[String]])
+    val OptionString: Type.Lazy[Option[String]] = Type.Lazy(Type.of[Option[String]])
+    val StringToString: Type.Lazy[String => String] = Type.Lazy(Type.of[String => String])
+    val ConfigKey: Type.Lazy[configKey] = Type.Lazy(Type.of[configKey])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
 
     def ReaderResult[A: Type]: Type[Either[ConfigReaderFailures, A]] =
       Type.of[Either[ConfigReaderFailures, A]]

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/WriterMacrosImpl.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/WriterMacrosImpl.scala
@@ -288,15 +288,15 @@ trait WriterMacrosImpl
     def KindlingsConfigWriter: Type.Ctor1[KindlingsConfigWriter] = Type.Ctor1.of[KindlingsConfigWriter]
     val WriterLogDerivation: Type[hearth.kindlings.pureconfigderivation.KindlingsConfigWriter.LogDerivation] =
       Type.of[hearth.kindlings.pureconfigderivation.KindlingsConfigWriter.LogDerivation]
-    val ConfigValue: Type[ConfigValue] = Type.of[ConfigValue]
-    val PureConfig: Type[PureConfig] = Type.of[PureConfig]
-    val String: Type[String] = Type.of[String]
-    val StringToString: Type[String => String] = Type.of[String => String]
-    val OptionString: Type[Option[String]] = Type.of[Option[String]]
-    val ConfigKey: Type[configKey] = Type.of[configKey]
-    val TransientField: Type[transientField] = Type.of[transientField]
-    val Int: Type[Int] = Type.of[Int]
-    val Product: Type[Product] = Type.of[Product]
+    val ConfigValue: Type.Lazy[ConfigValue] = Type.Lazy(Type.of[ConfigValue])
+    val PureConfig: Type.Lazy[PureConfig] = Type.Lazy(Type.of[PureConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val StringToString: Type.Lazy[String => String] = Type.Lazy(Type.of[String => String])
+    val OptionString: Type.Lazy[Option[String]] = Type.Lazy(Type.of[Option[String]])
+    val ConfigKey: Type.Lazy[configKey] = Type.Lazy(Type.of[configKey])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Product: Type.Lazy[Product] = Type.Lazy(Type.of[Product])
 
     def kindlingsProductHintType[A: Type]: Type[KindlingsProductHint[A]] =
       Type.of[KindlingsProductHint[A]]

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderUseImplicitWhenAvailableRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/ReaderUseImplicitWhenAvailableRule.scala
@@ -28,9 +28,9 @@ trait ReaderUseImplicitWhenAvailableRuleImpl {
       * annotations / config knobs.
       */
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsConfigReader.type].methods.collect {
+      Type.of[KindlingsConfigReader.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[KindlingsConfigConvert.type].methods.collect {
+      } ++ Type.of[KindlingsConfigConvert.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/WriterUseImplicitWhenAvailableRule.scala
+++ b/pureconfig-derivation/src/main/scala/hearth/kindlings/pureconfigderivation/internal/compiletime/rules/WriterUseImplicitWhenAvailableRule.scala
@@ -18,9 +18,9 @@ trait WriterUseImplicitWhenAvailableRuleImpl {
       * are filtered.
       */
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsConfigWriter.type].methods.collect {
+      Type.of[KindlingsConfigWriter.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[KindlingsConfigConvert.type].methods.collect {
+      } ++ Type.of[KindlingsConfigConvert.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/refined-integration/src/main/scala/hearth/kindlings/refinedintegration/internal/compiletime/IsValueTypeProviderForRefined.scala
+++ b/refined-integration/src/main/scala/hearth/kindlings/refinedintegration/internal/compiletime/IsValueTypeProviderForRefined.scala
@@ -44,7 +44,7 @@ final class IsValueTypeProviderForRefined extends StandardMacroExtension { loade
             // aggregated skip reason instead of an exception crashing the compiler.
             Expr.summonImplicit(using validateType).toOption match {
               case None =>
-                skipped(
+                skippedLazily(
                   s"${tpe.prettyPrint} is a Refined type, but no Validate instance was found for Refined[${Type[Inner].prettyPrint}, ${Type[Pred].prettyPrint}] — cannot generate validation"
                 )
 
@@ -86,7 +86,7 @@ final class IsValueTypeProviderForRefined extends StandardMacroExtension { loade
                 )
             }
 
-          case None => skipped(s"${tpe.prettyPrint} is not a Refined type")
+          case None => skippedLazily(s"${tpe.prettyPrint} is not a Refined type")
         }
     })
   }

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ArbitraryMacrosImpl.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ArbitraryMacrosImpl.scala
@@ -173,10 +173,10 @@ trait ArbitraryMacrosImpl
   protected object ArbitraryTypes {
     def Arbitrary: Type.Ctor1[org.scalacheck.Arbitrary] = Type.Ctor1.of[org.scalacheck.Arbitrary]
     def Gen: Type.Ctor1[org.scalacheck.Gen] = Type.Ctor1.of[org.scalacheck.Gen]
-    val Unit: Type[Unit] = Type.of[Unit]
-    val Any: Type[Any] = Type.of[Any]
-    val ListAny: Type[List[Any]] = Type.of[List[Any]]
-    val ListGenAny: Type[List[org.scalacheck.Gen[Any]]] = Type.of[List[org.scalacheck.Gen[Any]]]
+    val Unit: Type.Lazy[Unit] = Type.Lazy(Type.of[Unit])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val ListAny: Type.Lazy[List[Any]] = Type.Lazy(Type.of[List[Any]])
+    val ListGenAny: Type.Lazy[List[org.scalacheck.Gen[Any]]] = Type.Lazy(Type.of[List[org.scalacheck.Gen[Any]]])
     val LogDerivation: Type[hearth.kindlings.scalacheckderivation.LogDerivation] =
       Type.of[hearth.kindlings.scalacheckderivation.LogDerivation]
   }

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/CogenMacrosImpl.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/CogenMacrosImpl.scala
@@ -147,10 +147,10 @@ trait CogenMacrosImpl
 
   protected object CogenTypes {
     def Cogen: Type.Ctor1[org.scalacheck.Cogen] = Type.Ctor1.of[org.scalacheck.Cogen]
-    val Seed: Type[org.scalacheck.rng.Seed] = Type.of[org.scalacheck.rng.Seed]
-    val Unit: Type[Unit] = Type.of[Unit]
-    val Any: Type[Any] = Type.of[Any]
-    val Long: Type[Long] = Type.of[Long]
+    val Seed: Type.Lazy[org.scalacheck.rng.Seed] = Type.Lazy(Type.of[org.scalacheck.rng.Seed])
+    val Unit: Type.Lazy[Unit] = Type.Lazy(Type.of[Unit])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
     val LogDerivation: Type[hearth.kindlings.scalacheckderivation.LogDerivation] =
       Type.of[hearth.kindlings.scalacheckderivation.LogDerivation]
   }

--- a/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ShrinkMacrosImpl.scala
+++ b/scalacheck-derivation/src/main/scala/hearth/kindlings/scalacheckderivation/internal/compiletime/ShrinkMacrosImpl.scala
@@ -164,9 +164,9 @@ trait ShrinkMacrosImpl
 
   protected object ShrinkTypes {
     def Shrink: Type.Ctor1[org.scalacheck.Shrink] = Type.Ctor1.of[org.scalacheck.Shrink]
-    val Unit: Type[Unit] = Type.of[Unit]
-    val Any: Type[Any] = Type.of[Any]
-    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
+    val Unit: Type.Lazy[Unit] = Type.Lazy(Type.of[Unit])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val ArrayAny: Type.Lazy[Array[Any]] = Type.Lazy(Type.of[Array[Any]])
     val LogDerivation: Type[hearth.kindlings.scalacheckderivation.LogDerivation] =
       Type.of[hearth.kindlings.scalacheckderivation.LogDerivation]
   }

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/ReaderMacrosImpl.scala
@@ -278,25 +278,26 @@ trait ReaderMacrosImpl
     def ConfigReader: Type.Ctor1[ConfigReader] = Type.Ctor1.of[ConfigReader]
     val ReaderLogDerivation: Type[hearth.kindlings.sconfigderivation.ConfigReader.LogDerivation] =
       Type.of[hearth.kindlings.sconfigderivation.ConfigReader.LogDerivation]
-    val ConfigValue: Type[ConfigValue] = Type.of[ConfigValue]
-    val ConfigDecodingError: Type[ConfigDecodingError] = Type.of[ConfigDecodingError]
-    val SConfig: Type[SConfig] = Type.of[SConfig]
-    val String: Type[String] = Type.of[String]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Double: Type[Double] = Type.of[Double]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Any: Type[Any] = Type.of[Any]
-    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
-    val EitherErrorAny: Type[Either[ConfigDecodingError, Any]] = Type.of[Either[ConfigDecodingError, Any]]
+    val ConfigValue: Type.Lazy[ConfigValue] = Type.Lazy(Type.of[ConfigValue])
+    val ConfigDecodingError: Type.Lazy[ConfigDecodingError] = Type.Lazy(Type.of[ConfigDecodingError])
+    val SConfig: Type.Lazy[SConfig] = Type.Lazy(Type.of[SConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val ArrayAny: Type.Lazy[Array[Any]] = Type.Lazy(Type.of[Array[Any]])
+    val EitherErrorAny: Type.Lazy[Either[ConfigDecodingError, Any]] =
+      Type.Lazy(Type.of[Either[ConfigDecodingError, Any]])
     val ListEitherErrorAny: Type[List[Either[ConfigDecodingError, Any]]] =
       Type.of[List[Either[ConfigDecodingError, Any]]]
-    val ListString: Type[List[String]] = Type.of[List[String]]
-    val SetString: Type[Set[String]] = Type.of[Set[String]]
-    val OptionString: Type[Option[String]] = Type.of[Option[String]]
-    val StringToString: Type[String => String] = Type.of[String => String]
-    val ConfigKey: Type[configKey] = Type.of[configKey]
-    val TransientField: Type[transientField] = Type.of[transientField]
+    val ListString: Type.Lazy[List[String]] = Type.Lazy(Type.of[List[String]])
+    val SetString: Type.Lazy[Set[String]] = Type.Lazy(Type.of[Set[String]])
+    val OptionString: Type.Lazy[Option[String]] = Type.Lazy(Type.of[Option[String]])
+    val StringToString: Type.Lazy[String => String] = Type.Lazy(Type.of[String => String])
+    val ConfigKey: Type.Lazy[configKey] = Type.Lazy(Type.of[configKey])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
 
     def ReaderResult[A: Type]: Type[Either[ConfigDecodingError, A]] =
       Type.of[Either[ConfigDecodingError, A]]

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/WriterMacrosImpl.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/WriterMacrosImpl.scala
@@ -272,15 +272,15 @@ trait WriterMacrosImpl
     def ConfigWriter: Type.Ctor1[ConfigWriter] = Type.Ctor1.of[ConfigWriter]
     val WriterLogDerivation: Type[hearth.kindlings.sconfigderivation.ConfigWriter.LogDerivation] =
       Type.of[hearth.kindlings.sconfigderivation.ConfigWriter.LogDerivation]
-    val ConfigValue: Type[ConfigValue] = Type.of[ConfigValue]
-    val SConfig: Type[SConfig] = Type.of[SConfig]
-    val String: Type[String] = Type.of[String]
-    val StringToString: Type[String => String] = Type.of[String => String]
-    val OptionString: Type[Option[String]] = Type.of[Option[String]]
-    val ConfigKey: Type[configKey] = Type.of[configKey]
-    val TransientField: Type[transientField] = Type.of[transientField]
-    val Int: Type[Int] = Type.of[Int]
-    val Product: Type[Product] = Type.of[Product]
+    val ConfigValue: Type.Lazy[ConfigValue] = Type.Lazy(Type.of[ConfigValue])
+    val SConfig: Type.Lazy[SConfig] = Type.Lazy(Type.of[SConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val StringToString: Type.Lazy[String => String] = Type.Lazy(Type.of[String => String])
+    val OptionString: Type.Lazy[Option[String]] = Type.Lazy(Type.of[Option[String]])
+    val ConfigKey: Type.Lazy[configKey] = Type.Lazy(Type.of[configKey])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Product: Type.Lazy[Product] = Type.Lazy(Type.of[Product])
 
     def productHintType[A: Type]: Type[ProductHint[A]] =
       Type.of[ProductHint[A]]

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderUseImplicitWhenAvailableRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/ReaderUseImplicitWhenAvailableRule.scala
@@ -20,9 +20,9 @@ trait ReaderUseImplicitWhenAvailableRuleImpl {
       * helper or one of the built-in instances.
       */
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[ConfigReader.type].methods.collect {
+      Type.of[ConfigReader.type].unsortedMethods.collect {
         case method if method.isImplicit && method.name == "derived" => method.asUntyped
-      } ++ Type.of[ConfigCodec.type].methods.collect {
+      } ++ Type.of[ConfigCodec.type].unsortedMethods.collect {
         case method if method.isImplicit && method.name == "derived" => method.asUntyped
       }
 

--- a/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/WriterUseImplicitWhenAvailableRule.scala
+++ b/sconfig-derivation/src/main/scala/hearth/kindlings/sconfigderivation/internal/compiletime/rules/WriterUseImplicitWhenAvailableRule.scala
@@ -15,9 +15,9 @@ trait WriterUseImplicitWhenAvailableRuleImpl {
 
     /** See [[ReaderUseImplicitWhenAvailableRule.ignoredImplicits]] for the rationale. */
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[ConfigWriter.type].methods.collect {
+      Type.of[ConfigWriter.type].unsortedMethods.collect {
         case method if method.name == "derived" => method.asUntyped
-      } ++ Type.of[ConfigCodec.type].methods.collect {
+      } ++ Type.of[ConfigCodec.type].unsortedMethods.collect {
         case method if method.name == "derived" => method.asUntyped
       }
 

--- a/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/SchemaMacrosImpl.scala
+++ b/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/SchemaMacrosImpl.scala
@@ -50,10 +50,10 @@ trait SchemaMacrosImpl
   // Methods to ignore during implicit search — prevents triggering expensive auto-derivation
 
   protected lazy val ignoredImplicits: Seq[UntypedMethod] = {
-    val ours = Type.of[KindlingsSchema.type].methods.collect {
+    val ours = Type.of[KindlingsSchema.type].unsortedMethods.collect {
       case method if method.name == "derived" => method.asUntyped
     }
-    val tapirSchema = Type.of[Schema.type].methods.collect {
+    val tapirSchema = Type.of[Schema.type].unsortedMethods.collect {
       case method if method.name == "derivedSchema" => method.asUntyped
     }
     ours ++ tapirSchema

--- a/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/rules/SchemaUseImplicitWhenAvailableRule.scala
+++ b/tapir-schema-derivation/src/main/scala/hearth/kindlings/tapirschemaderivation/internal/compiletime/rules/SchemaUseImplicitWhenAvailableRule.scala
@@ -15,9 +15,9 @@ trait SchemaUseImplicitWhenAvailableRuleImpl {
   object SchemaUseImplicitWhenAvailableRule extends SchemaDerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsSchema.type].methods.collect {
+      Type.of[KindlingsSchema.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[Schema.type].methods.collect {
+      } ++ Type.of[Schema.type].unsortedMethods.collect {
         // For tapir's own Schema companion, only ignore the auto-derivation method,
         // not built-in schemas for primitive types (schemaForString, schemaForInt, etc.).
         case method if method.name == "derivedSchema" => method.asUntyped

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/CodecMacrosImpl.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/CodecMacrosImpl.scala
@@ -503,25 +503,25 @@ trait CodecMacrosImpl
     def UBJsonValueCodec: Type.Ctor1[UBJsonValueCodec] = Type.Ctor1.of[UBJsonValueCodec]
     val CodecLogDerivation: Type[hearth.kindlings.ubjsonderivation.UBJsonValueCodec.LogDerivation] =
       Type.of[hearth.kindlings.ubjsonderivation.UBJsonValueCodec.LogDerivation]
-    val UBJsonConfig: Type[UBJsonConfig] = Type.of[UBJsonConfig]
-    val UBJsonReader: Type[UBJsonReader] = Type.of[UBJsonReader]
-    val UBJsonWriter: Type[UBJsonWriter] = Type.of[UBJsonWriter]
-    val String: Type[String] = Type.of[String]
-    val Unit: Type[Unit] = Type.of[Unit]
-    val Any: Type[Any] = Type.of[Any]
-    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
-    val ListString: Type[List[String]] = Type.of[List[String]]
-    val FieldName: Type[fieldNameAnn] = Type.of[fieldNameAnn]
-    val TransientField: Type[transientField] = Type.of[transientField]
-    val Stringified: Type[stringified] = Type.of[stringified]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Double: Type[Double] = Type.of[Double]
-    val Float: Type[Float] = Type.of[Float]
-    val Short: Type[Short] = Type.of[Short]
-    val Byte: Type[Byte] = Type.of[Byte]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val BigDecimal: Type[BigDecimal] = Type.of[BigDecimal]
-    val BigInt: Type[BigInt] = Type.of[BigInt]
+    val UBJsonConfig: Type.Lazy[UBJsonConfig] = Type.Lazy(Type.of[UBJsonConfig])
+    val UBJsonReader: Type.Lazy[UBJsonReader] = Type.Lazy(Type.of[UBJsonReader])
+    val UBJsonWriter: Type.Lazy[UBJsonWriter] = Type.Lazy(Type.of[UBJsonWriter])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Unit: Type.Lazy[Unit] = Type.Lazy(Type.of[Unit])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val ArrayAny: Type.Lazy[Array[Any]] = Type.Lazy(Type.of[Array[Any]])
+    val ListString: Type.Lazy[List[String]] = Type.Lazy(Type.of[List[String]])
+    val FieldName: Type.Lazy[fieldNameAnn] = Type.Lazy(Type.of[fieldNameAnn])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
+    val Stringified: Type.Lazy[stringified] = Type.Lazy(Type.of[stringified])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Float: Type.Lazy[Float] = Type.Lazy(Type.of[Float])
+    val Short: Type.Lazy[Short] = Type.Lazy(Type.of[Short])
+    val Byte: Type.Lazy[Byte] = Type.Lazy(Type.of[Byte])
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val BigDecimal: Type.Lazy[BigDecimal] = Type.Lazy(Type.of[BigDecimal])
+    val BigInt: Type.Lazy[BigInt] = Type.Lazy(Type.of[BigInt])
   }
 }

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/DecoderUseImplicitWhenAvailableRule.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/DecoderUseImplicitWhenAvailableRule.scala
@@ -13,7 +13,7 @@ trait DecoderUseImplicitWhenAvailableRuleImpl {
   object DecoderUseImplicitWhenAvailableRule extends DecoderDerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[UBJsonValueCodec.type].methods.collect {
+      Type.of[UBJsonValueCodec.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/EncoderUseImplicitWhenAvailableRule.scala
+++ b/ubjson-derivation/src/main/scala/hearth/kindlings/ubjsonderivation/internal/compiletime/rules/EncoderUseImplicitWhenAvailableRule.scala
@@ -13,7 +13,7 @@ trait EncoderUseImplicitWhenAvailableRuleImpl {
   object EncoderUseImplicitWhenAvailableRule extends EncoderDerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[UBJsonValueCodec.type].methods.collect {
+      Type.of[UBJsonValueCodec.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderUseImplicitWhenAvailableRule.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/DecoderUseImplicitWhenAvailableRule.scala
@@ -13,9 +13,9 @@ trait DecoderUseImplicitWhenAvailableRuleImpl {
   object DecoderUseImplicitWhenAvailableRule extends DecoderDerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsXmlDecoder.type].methods.collect {
+      Type.of[KindlingsXmlDecoder.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[KindlingsXmlCodec.type].methods.collect {
+      } ++ Type.of[KindlingsXmlCodec.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/EncoderUseImplicitWhenAvailableRule.scala
+++ b/xml-derivation/src/main/scala/hearth/kindlings/xmlderivation/internal/compiletime/rules/EncoderUseImplicitWhenAvailableRule.scala
@@ -13,9 +13,9 @@ trait EncoderUseImplicitWhenAvailableRuleImpl {
   object EncoderUseImplicitWhenAvailableRule extends EncoderDerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsXmlEncoder.type].methods.collect {
+      Type.of[KindlingsXmlEncoder.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[KindlingsXmlCodec.type].methods.collect {
+      } ++ Type.of[KindlingsXmlCodec.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/DecoderMacrosImpl.scala
@@ -373,23 +373,23 @@ trait DecoderMacrosImpl
     def KindlingsYamlDecoder: Type.Ctor1[KindlingsYamlDecoder] = Type.Ctor1.of[KindlingsYamlDecoder]
     val DecoderLogDerivation: Type[hearth.kindlings.yamlderivation.KindlingsYamlDecoder.LogDerivation] =
       Type.of[hearth.kindlings.yamlderivation.KindlingsYamlDecoder.LogDerivation]
-    val Node: Type[Node] = Type.of[Node]
-    val ConstructError: Type[ConstructError] = Type.of[ConstructError]
-    val YamlConfig: Type[YamlConfig] = Type.of[YamlConfig]
-    val String: Type[String] = Type.of[String]
-    val Int: Type[Int] = Type.of[Int]
-    val Long: Type[Long] = Type.of[Long]
-    val Double: Type[Double] = Type.of[Double]
-    val Boolean: Type[Boolean] = Type.of[Boolean]
-    val Any: Type[Any] = Type.of[Any]
-    val ArrayAny: Type[Array[Any]] = Type.of[Array[Any]]
-    val EitherCEAny: Type[Either[ConstructError, Any]] = Type.of[Either[ConstructError, Any]]
+    val Node: Type.Lazy[Node] = Type.Lazy(Type.of[Node])
+    val ConstructError: Type.Lazy[ConstructError] = Type.Lazy(Type.of[ConstructError])
+    val YamlConfig: Type.Lazy[YamlConfig] = Type.Lazy(Type.of[YamlConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Long: Type.Lazy[Long] = Type.Lazy(Type.of[Long])
+    val Double: Type.Lazy[Double] = Type.Lazy(Type.of[Double])
+    val Boolean: Type.Lazy[Boolean] = Type.Lazy(Type.of[Boolean])
+    val Any: Type.Lazy[Any] = Type.Lazy(Type.of[Any])
+    val ArrayAny: Type.Lazy[Array[Any]] = Type.Lazy(Type.of[Array[Any]])
+    val EitherCEAny: Type.Lazy[Either[ConstructError, Any]] = Type.Lazy(Type.of[Either[ConstructError, Any]])
     val ListEitherCEAny: Type[List[Either[ConstructError, Any]]] =
       Type.of[List[Either[ConstructError, Any]]]
-    val ListString: Type[List[String]] = Type.of[List[String]]
-    val StringNodeTuple: Type[(String, Node)] = Type.of[(String, Node)]
-    val FieldName: Type[fieldName] = Type.of[fieldName]
-    val TransientField: Type[transientField] = Type.of[transientField]
+    val ListString: Type.Lazy[List[String]] = Type.Lazy(Type.of[List[String]])
+    val StringNodeTuple: Type.Lazy[(String, Node)] = Type.Lazy(Type.of[(String, Node)])
+    val FieldName: Type.Lazy[fieldName] = Type.Lazy(Type.of[fieldName])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
 
     def DecoderResult[A: Type]: Type[Either[ConstructError, A]] =
       Type.of[Either[ConstructError, A]]

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/EncoderMacrosImpl.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/EncoderMacrosImpl.scala
@@ -319,12 +319,12 @@ trait EncoderMacrosImpl
     def KindlingsYamlEncoder: Type.Ctor1[KindlingsYamlEncoder] = Type.Ctor1.of[KindlingsYamlEncoder]
     val EncoderLogDerivation: Type[hearth.kindlings.yamlderivation.KindlingsYamlEncoder.LogDerivation] =
       Type.of[hearth.kindlings.yamlderivation.KindlingsYamlEncoder.LogDerivation]
-    val Node: Type[Node] = Type.of[Node]
-    val YamlConfig: Type[YamlConfig] = Type.of[YamlConfig]
-    val String: Type[String] = Type.of[String]
-    val FieldName: Type[fieldName] = Type.of[fieldName]
-    val TransientField: Type[transientField] = Type.of[transientField]
-    val Int: Type[Int] = Type.of[Int]
-    val Product: Type[Product] = Type.of[Product]
+    val Node: Type.Lazy[Node] = Type.Lazy(Type.of[Node])
+    val YamlConfig: Type.Lazy[YamlConfig] = Type.Lazy(Type.of[YamlConfig])
+    val String: Type.Lazy[String] = Type.Lazy(Type.of[String])
+    val FieldName: Type.Lazy[fieldName] = Type.Lazy(Type.of[fieldName])
+    val TransientField: Type.Lazy[transientField] = Type.Lazy(Type.of[transientField])
+    val Int: Type.Lazy[Int] = Type.Lazy(Type.of[Int])
+    val Product: Type.Lazy[Product] = Type.Lazy(Type.of[Product])
   }
 }

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderUseImplicitWhenAvailableRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/DecoderUseImplicitWhenAvailableRule.scala
@@ -14,9 +14,9 @@ trait DecoderUseImplicitWhenAvailableRuleImpl {
   object DecoderUseImplicitWhenAvailableRule extends DecoderDerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsYamlDecoder.type].methods.collect {
+      Type.of[KindlingsYamlDecoder.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[KindlingsYamlCodec.type].methods.collect {
+      } ++ Type.of[KindlingsYamlCodec.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 

--- a/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/EncoderUseImplicitWhenAvailableRule.scala
+++ b/yaml-derivation/src/main/scala/hearth/kindlings/yamlderivation/internal/compiletime/rules/EncoderUseImplicitWhenAvailableRule.scala
@@ -13,9 +13,9 @@ trait EncoderUseImplicitWhenAvailableRuleImpl {
   object EncoderUseImplicitWhenAvailableRule extends EncoderDerivationRule("use implicit when available") {
 
     lazy val ignoredImplicits: Seq[UntypedMethod] =
-      Type.of[KindlingsYamlEncoder.type].methods.collect {
+      Type.of[KindlingsYamlEncoder.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
-      } ++ Type.of[KindlingsYamlCodec.type].methods.collect {
+      } ++ Type.of[KindlingsYamlCodec.type].unsortedMethods.collect {
         case method if method.isImplicit => method.asUntyped
       }
 


### PR DESCRIPTION
Macro compile-time perf pass across Kindlings, applying the `hearth-macro-perf` checklist.

## Changes
- **Lazy provider registration** (cats-integration `CatsCollectionAndMapProviders`): the 4 shared `extend`-body `Type.Ctor.of[...]` vals are now `lazy val` — the type-constructor introspection is only paid when a provider actually matches, not on every macro expansion that loads the extension. (All per-provider ctors were already lazy.)
- **`unsortedMethods` on implicit ignore-sets** (19 files): every `*UseImplicitWhenAvailableRule` / codec macro builds an ignore-set via `Type.of[TC.type].methods.collect { by name }` and feeds it to `summonExprIgnoring`. That's an order-independent set, so it now uses `unsortedMethods` — skipping Hearth's source-position sort (`positionOf`, a real Scala 3 cost). Spans avro/circe/cats/diff/jsoniter/pureconfig/sconfig/tapir/ubjson/xml/yaml/fast-show-pretty.
- Hearth pin → `0.4.0-30-gf0bb8c3-SNAPSHOT` (for the `unsortedMethods` API).

## Verified
Representative modules (`catsIntegration`, `circeDerivation`, `diffDerivation`) compile on Scala 3 + 2.13; the audit confirmed all providers are otherwise already lazy and there are no O(n) collection idioms in macro-time code.

## Known follow-up (larger, not in this PR)
~170 `Log.namedScope(...)` sites build a by-value `prettyPrint` name on every (often per-field / per-recursion) derivation step, even when logging is disabled. Moving each into a cheap-labelled scope + by-name `Log.info(...) >> body` is the biggest remaining lever, but it's pervasive and per-site; deferred to a dedicated pass (the `hearth-macro-perf` skill documents the exact transform). The 3 `di` `Class[T].methods` sites (MEDIUM, order-uncertain for DI codegen) were also left for that pass.