### PR TITLE
Pin hearth to 0.4.0-54 (enum-order determinism fix)

### DIFF
--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -20,7 +20,7 @@ object versions {
 
   // Dependencies.
   // TODO: pin the final 0.4.1 once released (currently the pre-release SNAPSHOT with the #317/#320 fixes).
-  val hearth = "0.4.0-53-gd593898-SNAPSHOT"
+  val hearth = "0.4.0-54-gcad79ee-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.1"
   val avro4s213 = "4.1.2"


### PR DESCRIPTION
Bumps the hearth pin to `0.4.0-54-gcad79ee-SNAPSHOT`, carrying **hearth#357**.

## What it fixes

The intermittent `KindlingsSchemaSpec.derivedEnumeration` failure — `Color`'s enum values came back **alphabetical** (`List(Blue, Green, Red)`) instead of **declaration order** (`List(Red, Green, Blue)`) roughly 1 run in 4.

Root cause was in hearth's Scala 3 `directChildrenList`: it sorted the children **after** mapping each `case object` to its synthetic module class, whose source position is frequently absent during macro expansion — so the position-first ordering fell through to its alphabetical name fallback, and the result flipped between builds. hearth#357 sorts the **original** child symbol (which carries a real position) before mapping, restoring stable declaration order.

## Verification

- 3 cold `clean` + recompile cycles of the `derivedEnumeration` suite (each re-expands the macro) — all green.
- Full `tapirSchemaDerivation` 69/69 on both Scala 2.13 and 3.

Independent of #175 (filter-first perf) — different files, no conflict.