### PR TITLE
Perf: sizeHintForBuilder for O(1)-sized cats collections

### DIFF
--- a/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/CatsCollectionAndMapProviders.scala
+++ b/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/compiletime/CatsCollectionAndMapProviders.scala
@@ -37,6 +37,11 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
       Existential[IsCollectionOf[A, *], E](new IsCollectionOf[A, E] {
         override def asIterable(value: Expr[A]): Expr[Iterable[E]] =
           Expr.quote(Expr.splice(value).asInstanceOf[cats.data.NonEmptyList[E]].toList)
+        // NO sizeHintForBuilder override here (keeps the default `None`), and likewise for NonEmptySeq (arbitrary,
+        // possibly LinearSeq tail), NonEmptyChain / Chain (Chain#length folds the structure) and NonEmptyLazyList
+        // below: for all of them the element count is O(n) - and for NonEmptyLazyList reading the length would even
+        // FORCE the (possibly infinite) lazy list. A hint must be O(1), so these must not provide one - only the
+        // O(1)-sized NonEmptyVector / NonEmptyMap / NonEmptySet do. See the hearth `sizeHintForBuilder` contract.
         override type CtorResult = List[E]
         implicit override val CtorResult: Type[CtorResult] = listEType
         override def factory: Expr[scala.collection.Factory[E, CtorResult]] = Expr.quote {
@@ -70,6 +75,10 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
       Existential[IsCollectionOf[A, *], E](new IsCollectionOf[A, E] {
         override def asIterable(value: Expr[A]): Expr[Iterable[E]] =
           Expr.quote(Expr.splice(value).asInstanceOf[cats.data.NonEmptyVector[E]].toVector)
+        // O(1): NonEmptyVector is Vector-backed, so `.length` does not traverse - safe to pre-size the target builder.
+        override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+          Expr.splice(value).asInstanceOf[cats.data.NonEmptyVector[E]].length
+        })
         override type CtorResult = List[E]
         implicit override val CtorResult: Type[CtorResult] = listEType
         override def factory: Expr[scala.collection.Factory[E, CtorResult]] = Expr.quote {
@@ -241,6 +250,10 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
               .nonEmptyMapToIterable(Expr.splice(value))
               .asInstanceOf[Iterable[(K0, V0)]]
           }
+        // O(1): NonEmptyMap wraps an immutable SortedMap (TreeMap), whose `.size` reads the tree's stored node count.
+        override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+          hearth.kindlings.catsintegration.internal.runtime.CatsConversions.nonEmptyMapSize(Expr.splice(value))
+        })
         override type CtorResult = List[(K0, V0)]
         implicit override val CtorResult: Type[CtorResult] = listPairType
         override def factory: Expr[scala.collection.Factory[(K0, V0), CtorResult]] = Expr.quote {
@@ -294,6 +307,10 @@ final class CatsCollectionAndMapProviders extends StandardMacroExtension { loade
             hearth.kindlings.catsintegration.internal.runtime.CatsConversions
               .nonEmptySetToIterable[E0](Expr.splice(value))
           )
+        // O(1): NonEmptySet wraps an immutable SortedSet (TreeSet), whose `.size` reads the tree's stored node count.
+        override def sizeHintForBuilder(value: Expr[A]): Option[Expr[Int]] = Some(Expr.quote {
+          hearth.kindlings.catsintegration.internal.runtime.CatsConversions.nonEmptySetSize(Expr.splice(value))
+        })
         override type CtorResult = List[E0]
         implicit override val CtorResult: Type[CtorResult] = listElemType
         override def factory: Expr[scala.collection.Factory[E0, CtorResult]] = Expr.quote {

--- a/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/runtime/CatsConversions.scala
+++ b/cats-integration/src/main/scala/hearth/kindlings/catsintegration/internal/runtime/CatsConversions.scala
@@ -22,6 +22,14 @@ object CatsConversions {
   def nonEmptyMapToIterable(a: Any): Iterable[(Any, Any)] =
     a.asInstanceOf[cats.data.NonEmptyMap[Any, Any]].toSortedMap.toList
 
+  /** O(1) element count for a `NonEmptyMap` - the underlying immutable `SortedMap` (a `TreeMap`) keeps its size in the
+    * red-black tree's root node, so `.size` does not traverse. Used for builder pre-allocation via
+    * `sizeHintForBuilder`. A runtime helper (rather than an inline `.toSortedMap.size` in a quote) so the cats newtype
+    * alias never appears in a cross-quote body - see the type note at the top of this object.
+    */
+  def nonEmptyMapSize(a: Any): Int =
+    a.asInstanceOf[cats.data.NonEmptyMap[Any, Any]].toSortedMap.size
+
   def buildNonEmptyMap(pairs: List[(Any, Any)], ordering: Ordering[Any]): Either[String, Any] =
     pairs match {
       case head :: tail =>
@@ -42,6 +50,12 @@ object CatsConversions {
 
   def nonEmptySetToIterable[A](a: Any): Iterable[A] =
     a.asInstanceOf[cats.data.NonEmptySet[A]].toSortedSet.toList
+
+  /** O(1) element count for a `NonEmptySet` - the underlying immutable `SortedSet` (a `TreeSet`) keeps its size in the
+    * red-black tree's root node, so `.size` does not traverse. See [[nonEmptyMapSize]].
+    */
+  def nonEmptySetSize(a: Any): Int =
+    a.asInstanceOf[cats.data.NonEmptySet[Any]].toSortedSet.size
 
   def buildNonEmptySet(list: List[Any], ordering: Ordering[Any]): Either[String, Any] =
     list match {


### PR DESCRIPTION
Overrides Hearth's `IsCollectionOf.sizeHintForBuilder` (default `None`) for the cats collections whose element count is **O(1)**, so a consumer transforming one as a *source* can pre-allocate the target builder — the same lever Chimney adopted in scalalandio/chimney#907. Only safe (O(1)) sizes are provided; everything O(n) is deliberately left as `None`.

## Per-type decision (verified against cats 2.13.0 bytecode)

| Collection | Backing | `length`/`size` | Hint |
|---|---|---|---|
| **NonEmptyVector** | `Vector` | **O(1)** | ✅ `.length`, direct |
| **NonEmptyMap** | immutable `SortedMap` (TreeMap) | **O(1)** (RB-tree stored count) | ✅ via helper |
| **NonEmptySet** | immutable `SortedSet` (TreeSet) | **O(1)** | ✅ via helper |
| NonEmptyList | `List` | O(n) | ❌ `None` |
| NonEmptySeq | arbitrary `Seq` (may be `List`) | O(n) worst | ❌ `None` |
| NonEmptyChain / Chain | `Chain` (`length` folds) | O(n) | ❌ `None` |
| **NonEmptyLazyList** | `LazyList` | O(n) + **forces** (may be infinite) | ❌ `None` |

`NonEmptyMap`/`NonEmptySet` route through new `CatsConversions.nonEmptyMapSize` / `nonEmptySetSize` runtime helpers so the cats **newtype aliases never appear in a cross-quote body** — the same reason `asIterable` already uses helpers.

A size hint is non-authoritative (the builder grows as needed), so even an off-by-one would only affect pre-allocation, never correctness — but the counts are exact element counts by construction.

## Verification

- `cats-integration` compiles on Scala **2.13 + 3**.
- `integration-tests` `Cats*` round-trip suite (Circe / Jsoniter / Yaml / Xml / UBJson / Sconfig / Avro / FastShowPretty) — **80/80 on both versions**.