### PR TITLE
Fix #184: Eq/Order/Diff enum derivation unchecked type test warning

### DIFF
--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/EqEnumRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/EqEnumRule.scala
@@ -38,14 +38,24 @@ trait EqEnumRuleImpl {
         .matchOn[MIO, Boolean](x) { matchedX =>
           import matchedX.{value as caseX, Underlying as EnumCase}
           Log.namedScope(s"Deriving Eq for enum case ${EnumCase.prettyPrint}") {
-            val caseY = Expr.quote(Expr.splice(y).asInstanceOf[EnumCase])
-            val isInstance = Expr.quote {
-              Expr.splice(y).isInstanceOf[EnumCase]
-            }
-            deriveEqRecursively[EnumCase](using eqctx.nest(caseX, caseY)).map { eqResult =>
-              Expr.quote {
-                Expr.splice(isInstance) && Expr.splice(eqResult)
-              }
+            SingletonValue.unapply(Type[EnumCase]) match {
+              case Some(sv) =>
+                // Singleton (parameterless enum case / case object): use reference equality
+                // to avoid unchecked type test warning on erased singleton types in Scala 3.
+                val singletonExpr = sv.singletonExpr
+                MIO.pure(Expr.quote {
+                  Expr.splice(y).asInstanceOf[AnyRef] eq Expr.splice(singletonExpr).asInstanceOf[AnyRef]
+                })
+              case None =>
+                val caseY = Expr.quote(Expr.splice(y).asInstanceOf[EnumCase])
+                val isInstance = Expr.quote {
+                  Expr.splice(y).isInstanceOf[EnumCase]
+                }
+                deriveEqRecursively[EnumCase](using eqctx.nest(caseX, caseY)).map { eqResult =>
+                  Expr.quote {
+                    Expr.splice(isInstance) && Expr.splice(eqResult)
+                  }
+                }
             }
           }
         }

--- a/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/OrderEnumRule.scala
+++ b/cats-derivation/src/main/scala/hearth/kindlings/catsderivation/internal/compiletime/rules/OrderEnumRule.scala
@@ -55,13 +55,25 @@ trait OrderEnumRuleImpl {
               import matchedX.{value as caseX, Underlying as EnumCase}
               val currentOrdinal = childOrdinal
               childOrdinal += 1
-              val caseY = Expr.quote(Expr.splice(y).asInstanceOf[EnumCase])
-              val isInstance = Expr.quote(Expr.splice(y).isInstanceOf[EnumCase])
-              deriveOrderRecursively[EnumCase](using octx.nest(caseX, caseY)).map { innerCmp =>
-                Expr.quote {
-                  if (Expr.splice(isInstance)) Expr.splice(innerCmp)
-                  else java.lang.Integer.compare(Expr.splice(Expr(currentOrdinal)), Expr.splice(ordinalOfY))
-                }
+              SingletonValue.unapply(Type[EnumCase]) match {
+                case Some(sv) =>
+                  // Singleton (parameterless enum case / case object): use reference equality
+                  // to avoid unchecked type test warning on erased singleton types in Scala 3.
+                  // Two equal singletons always compare as 0.
+                  val singletonExpr = sv.singletonExpr
+                  MIO.pure(Expr.quote {
+                    if (Expr.splice(y).asInstanceOf[AnyRef] eq Expr.splice(singletonExpr).asInstanceOf[AnyRef]) 0
+                    else java.lang.Integer.compare(Expr.splice(Expr(currentOrdinal)), Expr.splice(ordinalOfY))
+                  })
+                case None =>
+                  val caseY = Expr.quote(Expr.splice(y).asInstanceOf[EnumCase])
+                  val isInstance = Expr.quote(Expr.splice(y).isInstanceOf[EnumCase])
+                  deriveOrderRecursively[EnumCase](using octx.nest(caseX, caseY)).map { innerCmp =>
+                    Expr.quote {
+                      if (Expr.splice(isInstance)) Expr.splice(innerCmp)
+                      else java.lang.Integer.compare(Expr.splice(Expr(currentOrdinal)), Expr.splice(ordinalOfY))
+                    }
+                  }
               }
             }
             .flatMap {

--- a/cats-derivation/src/test/scala-3/hearth/kindlings/catsderivation/CatsScala3Spec.scala
+++ b/cats-derivation/src/test/scala-3/hearth/kindlings/catsderivation/CatsScala3Spec.scala
@@ -1,0 +1,131 @@
+package hearth.kindlings.catsderivation
+
+import hearth.MacroSuite
+import hearth.kindlings.catsderivation.extensions.*
+
+// Parameterless Scala 3 enum — singleton types erased at runtime.
+// Regression test for kubuszok/kindlings#184: isInstanceOf on these types
+// emits an "unchecked type test" warning that fails under -Werror.
+enum Direction {
+  case North, South, East, West
+}
+
+// Mixed Scala 3 enum — some cases are parameterless singletons, others are case classes.
+enum TrafficLight {
+  case Red
+  case Yellow
+  case Green(brightness: Int)
+}
+
+final class CatsScala3Spec extends MacroSuite {
+
+  group("Eq for parameterless Scala 3 enum (#184)") {
+
+    val eqDirection: cats.kernel.Eq[Direction] = cats.kernel.Eq.derived
+
+    test("same singleton values are equal") {
+      eqDirection.eqv(Direction.North, Direction.North) ==> true
+    }
+
+    test("different singleton values are not equal") {
+      eqDirection.eqv(Direction.North, Direction.South) ==> false
+    }
+
+    test("all cases compared against each other") {
+      val cases = List(Direction.North, Direction.South, Direction.East, Direction.West)
+      for {
+        a <- cases
+        b <- cases
+      } {
+        eqDirection.eqv(a, b) ==> (a == b)
+      }
+    }
+  }
+
+  group("Order for parameterless Scala 3 enum (#184)") {
+
+    val orderDirection: cats.kernel.Order[Direction] = cats.kernel.Order.derived
+
+    test("same singleton compares as 0") {
+      orderDirection.compare(Direction.North, Direction.North) ==> 0
+    }
+
+    test("different singletons have non-zero comparison") {
+      assert(orderDirection.compare(Direction.North, Direction.South) != 0)
+    }
+
+    test("ordering is consistent across all cases") {
+      val cases = List(Direction.North, Direction.South, Direction.East, Direction.West)
+      for {
+        a <- cases
+        b <- cases
+      } {
+        val cmp = orderDirection.compare(a, b)
+        if (a == b) assertEquals(cmp, 0)
+        else assert(cmp != 0, s"expected non-zero for $a vs $b")
+      }
+    }
+
+    test("ordering is antisymmetric") {
+      val cases = List(Direction.North, Direction.South, Direction.East, Direction.West)
+      for {
+        a <- cases
+        b <- cases
+      } {
+        val ab = orderDirection.compare(a, b)
+        val ba = orderDirection.compare(b, a)
+        assertEquals(ab.sign, -ba.sign, s"antisymmetry violated for $a vs $b")
+      }
+    }
+  }
+
+  group("Eq for mixed Scala 3 enum (#184)") {
+
+    val eqTL: cats.kernel.Eq[TrafficLight] = cats.kernel.Eq.derived
+
+    test("same parameterless case") {
+      eqTL.eqv(TrafficLight.Red, TrafficLight.Red) ==> true
+    }
+
+    test("different parameterless cases") {
+      eqTL.eqv(TrafficLight.Red, TrafficLight.Yellow) ==> false
+    }
+
+    test("parameterless vs parameterized case") {
+      eqTL.eqv(TrafficLight.Red, TrafficLight.Green(100)) ==> false
+    }
+
+    test("same parameterized case, same fields") {
+      eqTL.eqv(TrafficLight.Green(100), TrafficLight.Green(100)) ==> true
+    }
+
+    test("same parameterized case, different fields") {
+      eqTL.eqv(TrafficLight.Green(100), TrafficLight.Green(50)) ==> false
+    }
+  }
+
+  group("Order for mixed Scala 3 enum (#184)") {
+
+    val orderTL: cats.kernel.Order[TrafficLight] = cats.kernel.Order.derived
+
+    test("same parameterless case compares as 0") {
+      orderTL.compare(TrafficLight.Red, TrafficLight.Red) ==> 0
+    }
+
+    test("different parameterless cases have non-zero comparison") {
+      assert(orderTL.compare(TrafficLight.Red, TrafficLight.Yellow) != 0)
+    }
+
+    test("parameterless vs parameterized case ordered by ordinal") {
+      assert(orderTL.compare(TrafficLight.Red, TrafficLight.Green(100)) != 0)
+    }
+
+    test("same parameterized case, same fields compares as 0") {
+      orderTL.compare(TrafficLight.Green(100), TrafficLight.Green(100)) ==> 0
+    }
+
+    test("same parameterized case, different fields orders by field") {
+      assert(orderTL.compare(TrafficLight.Green(50), TrafficLight.Green(100)) < 0)
+    }
+  }
+}

--- a/cats-derivation/src/test/scala-3/hearth/kindlings/catsderivation/CatsScala3Spec.scala
+++ b/cats-derivation/src/test/scala-3/hearth/kindlings/catsderivation/CatsScala3Spec.scala
@@ -36,9 +36,8 @@ final class CatsScala3Spec extends MacroSuite {
       for {
         a <- cases
         b <- cases
-      } {
-        eqDirection.eqv(a, b) ==> (a == b)
       }
+        eqDirection.eqv(a, b) ==> (a == b)
     }
   }
 
@@ -61,7 +60,7 @@ final class CatsScala3Spec extends MacroSuite {
         b <- cases
       } {
         val cmp = orderDirection.compare(a, b)
-        if (a == b) assertEquals(cmp, 0)
+        if a == b then assertEquals(cmp, 0)
         else assert(cmp != 0, s"expected non-zero for $a vs $b")
       }
     }

--- a/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffEnumRule.scala
+++ b/diff-derivation/src/main/scala/hearth/kindlings/diffderivation/internal/compiletime/rules/DiffEnumRule.scala
@@ -46,43 +46,88 @@ trait DiffEnumRuleImpl { this: DiffMacrosImpl & MacroCommons & StdExtensions =>
           val caseName = Expr(Type.shortName[EnumCase])
 
           Log.namedScope(s"Deriving Diff for enum case ${EnumCase.prettyPrint}") {
-            val isInstance = Expr.quote(Expr.splice(right).isInstanceOf[EnumCase])
-
-            deriveSnapshotRecursively[EnumCase](using
-              SnapshotCtx[EnumCase](Type[EnumCase], caseLeft, dctx.cache, dctx.derivedType)
-            ).flatMap { leftSnapshotExpr =>
-              val caseRight = Expr.quote(Expr.splice(right).asInstanceOf[EnumCase])
-              deriveDiffRecursively[EnumCase](using dctx.nest(caseLeft, caseRight)).map { diffResult =>
-                Expr.quote {
-                  if (Expr.splice(isInstance)) {
-                    DiffResult.Variant(
-                      Expr.splice(pn),
-                      Expr.splice(fn),
-                      Expr.splice(sn),
-                      Expr.splice(sn),
-                      Expr.splice(caseName),
-                      Expr.splice(diffResult)
-                    )
-                  } else {
-                    DiffResult.TypeMismatch(
-                      Expr.splice(pn),
-                      Expr.splice(fn),
-                      Expr.splice(sn),
-                      Expr.splice(sn),
-                      Expr.splice(caseName),
-                      Expr.splice(leftSnapshotExpr),
-                      Expr.splice(right).getClass.getSimpleName.stripSuffix("$"),
-                      DiffResult.Identical(
+            SingletonValue.unapply(Type[EnumCase]) match {
+              case Some(sv) =>
+                // Singleton (parameterless enum case / case object): use reference equality
+                // to avoid unchecked type test warning on erased singleton types in Scala 3.
+                val singletonExpr = sv.singletonExpr
+                deriveSnapshotRecursively[EnumCase](using
+                  SnapshotCtx[EnumCase](Type[EnumCase], caseLeft, dctx.cache, dctx.derivedType)
+                ).map { leftSnapshotExpr =>
+                  Expr.quote {
+                    if (Expr.splice(right).asInstanceOf[AnyRef] eq Expr.splice(singletonExpr).asInstanceOf[AnyRef]) {
+                      DiffResult.Variant(
                         Expr.splice(pn),
                         Expr.splice(fn),
                         Expr.splice(sn),
                         Expr.splice(sn),
-                        Expr.splice(right).toString
+                        Expr.splice(caseName),
+                        DiffResult.Identical(
+                          Expr.splice(pn),
+                          Expr.splice(fn),
+                          Expr.splice(sn),
+                          Expr.splice(sn),
+                          Expr.splice(singletonExpr).toString
+                        )
                       )
-                    )
+                    } else {
+                      DiffResult.TypeMismatch(
+                        Expr.splice(pn),
+                        Expr.splice(fn),
+                        Expr.splice(sn),
+                        Expr.splice(sn),
+                        Expr.splice(caseName),
+                        Expr.splice(leftSnapshotExpr),
+                        Expr.splice(right).getClass.getSimpleName.stripSuffix("$"),
+                        DiffResult.Identical(
+                          Expr.splice(pn),
+                          Expr.splice(fn),
+                          Expr.splice(sn),
+                          Expr.splice(sn),
+                          Expr.splice(right).toString
+                        )
+                      )
+                    }
                   }
                 }
-              }
+              case None =>
+                val isInstance = Expr.quote(Expr.splice(right).isInstanceOf[EnumCase])
+                deriveSnapshotRecursively[EnumCase](using
+                  SnapshotCtx[EnumCase](Type[EnumCase], caseLeft, dctx.cache, dctx.derivedType)
+                ).flatMap { leftSnapshotExpr =>
+                  val caseRight = Expr.quote(Expr.splice(right).asInstanceOf[EnumCase])
+                  deriveDiffRecursively[EnumCase](using dctx.nest(caseLeft, caseRight)).map { diffResult =>
+                    Expr.quote {
+                      if (Expr.splice(isInstance)) {
+                        DiffResult.Variant(
+                          Expr.splice(pn),
+                          Expr.splice(fn),
+                          Expr.splice(sn),
+                          Expr.splice(sn),
+                          Expr.splice(caseName),
+                          Expr.splice(diffResult)
+                        )
+                      } else {
+                        DiffResult.TypeMismatch(
+                          Expr.splice(pn),
+                          Expr.splice(fn),
+                          Expr.splice(sn),
+                          Expr.splice(sn),
+                          Expr.splice(caseName),
+                          Expr.splice(leftSnapshotExpr),
+                          Expr.splice(right).getClass.getSimpleName.stripSuffix("$"),
+                          DiffResult.Identical(
+                            Expr.splice(pn),
+                            Expr.splice(fn),
+                            Expr.splice(sn),
+                            Expr.splice(sn),
+                            Expr.splice(right).toString
+                          )
+                        )
+                      }
+                    }
+                  }
+                }
             }
           }
         }

--- a/diff-derivation/src/test/scala-3/hearth/kindlings/diffderivation/DiffScala3Spec.scala
+++ b/diff-derivation/src/test/scala-3/hearth/kindlings/diffderivation/DiffScala3Spec.scala
@@ -33,7 +33,7 @@ final class DiffScala3Spec extends MacroSuite {
 
     test("all cases identical with themselves") {
       val cases = List(Season.Spring, Season.Summer, Season.Autumn, Season.Winter)
-      for (c <- cases) {
+      for c <- cases do {
         val result = diffSeason.diff(c, c)
         assert(result.isIdentical, s"expected identical for $c, got $result")
       }

--- a/diff-derivation/src/test/scala-3/hearth/kindlings/diffderivation/DiffScala3Spec.scala
+++ b/diff-derivation/src/test/scala-3/hearth/kindlings/diffderivation/DiffScala3Spec.scala
@@ -1,0 +1,89 @@
+package hearth.kindlings.diffderivation
+
+import hearth.MacroSuite
+
+// Parameterless Scala 3 enum — singleton types erased at runtime.
+// Regression test for kubuszok/kindlings#184: isInstanceOf on these types
+// emits an "unchecked type test" warning that fails under -Werror.
+enum Season {
+  case Spring, Summer, Autumn, Winter
+}
+
+// Mixed Scala 3 enum — some cases are parameterless singletons, others are case classes.
+enum Outcome {
+  case Success
+  case Failure(reason: String)
+}
+
+final class DiffScala3Spec extends MacroSuite {
+
+  group("Diff for parameterless Scala 3 enum (#184)") {
+
+    val diffSeason: Diff[Season] = Diff.derived
+
+    test("identical singletons") {
+      val result = diffSeason.diff(Season.Spring, Season.Spring)
+      assert(result.isIdentical, s"expected identical, got $result")
+    }
+
+    test("different singletons") {
+      val result = diffSeason.diff(Season.Spring, Season.Winter)
+      assert(!result.isIdentical, s"expected not identical, got $result")
+    }
+
+    test("all cases identical with themselves") {
+      val cases = List(Season.Spring, Season.Summer, Season.Autumn, Season.Winter)
+      for (c <- cases) {
+        val result = diffSeason.diff(c, c)
+        assert(result.isIdentical, s"expected identical for $c, got $result")
+      }
+    }
+
+    test("all pairs of different cases are not identical") {
+      val cases = List(Season.Spring, Season.Summer, Season.Autumn, Season.Winter)
+      for {
+        a <- cases
+        b <- cases
+        if a != b
+      } {
+        val result = diffSeason.diff(a, b)
+        assert(!result.isIdentical, s"expected not identical for $a vs $b, got $result")
+      }
+    }
+
+    test("snapshot of singleton") {
+      val result = diffSeason.snapshot(Season.Summer)
+      assert(result.isIdentical, s"snapshot should be identical, got $result")
+    }
+  }
+
+  group("Diff for mixed Scala 3 enum (#184)") {
+
+    val diffOutcome: Diff[Outcome] = Diff.derived
+
+    test("identical parameterless singletons") {
+      val result = diffOutcome.diff(Outcome.Success, Outcome.Success)
+      assert(result.isIdentical, s"expected identical, got $result")
+    }
+
+    test("parameterless vs parameterized case") {
+      val result = diffOutcome.diff(Outcome.Success, Outcome.Failure("oops"))
+      assert(!result.isIdentical, s"expected not identical, got $result")
+    }
+
+    test("parameterized vs parameterless case") {
+      val result = diffOutcome.diff(Outcome.Failure("oops"), Outcome.Success)
+      assert(!result.isIdentical, s"expected not identical, got $result")
+    }
+
+    test("same parameterized case, same fields") {
+      val result = diffOutcome.diff(Outcome.Failure("oops"), Outcome.Failure("oops"))
+      assert(result.isIdentical, s"expected identical, got $result")
+    }
+
+    test("same parameterized case, different fields") {
+      val result = diffOutcome.diff(Outcome.Failure("oops"), Outcome.Failure("other"))
+      assert(!result.isIdentical, s"expected not identical, got $result")
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Use reference equality (`eq`) via `SingletonValue.unapply` for parameterless Scala 3 enum vals instead of `isInstanceOf` which emits "unchecked type test" warnings (breaks `-Werror` builds)
- Case objects (own JVM class) keep the existing `isInstanceOf` path
- Only 3 rules affected: `EqEnumRule`, `OrderEnumRule`, `DiffEnumRule` — single-dispatch rules (Show, Hash, etc.) don't need `isInstanceOf` on a second value

## Test plan

- [x] 17 new tests in `CatsScala3Spec` for Eq/Order on parameterless and mixed Scala 3 enums
- [x] 10 new tests in `DiffScala3Spec` for Diff on parameterless and mixed Scala 3 enums
- [x] All existing tests pass on both Scala 2.13 and 3

Closes #184