### PR TITLE
Fix #196: jsoniter singleton enum cases fail to decode in wrapper/discriminator modes

### DIFF
--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsEnumRule.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/compiletime/rules/DecoderHandleAsEnumRule.scala
@@ -279,7 +279,7 @@ trait DecoderHandleAsEnumRuleImpl {
           Expr.singletonOf[ChildType] match {
             case Some(singleton) =>
               Log.info(s"Using singleton for $childName") >>
-                MIO.pure { (typeNameExpr: Expr[String], _: Expr[JsonReader], elseExpr: Expr[A]) =>
+                MIO.pure { (typeNameExpr: Expr[String], readerExpr: Expr[JsonReader], elseExpr: Expr[A]) =>
                   Expr.quote {
                     if (
                       JsoniterDerivationUtils.mapEnumName(
@@ -288,9 +288,11 @@ trait DecoderHandleAsEnumRuleImpl {
                         Expr.splice(Expr(Type[A].isJavaEnum))
                       ) == Expr
                         .splice(typeNameExpr)
-                    )
+                    ) {
+                      // Consume the inner empty object {} written by EncoderHandleAsSingletonRule
+                      JsoniterDerivationUtils.readEmptyObject(Expr.splice(readerExpr))
                       Expr.splice(singleton).asInstanceOf[A]
-                    else
+                    } else
                       Expr.splice(elseExpr)
                   }
                 }
@@ -368,8 +370,32 @@ trait DecoderHandleAsEnumRuleImpl {
             }
 
         case None =>
-          // Not a case class (e.g., case object) — fall back to wrapper-style decoder
-          deriveChildDecoder[A, ChildType](childName)
+          // Not a case class — check if singleton for inline (discriminator) mode
+          Expr.singletonOf[ChildType] match {
+            case Some(singleton) =>
+              // Singleton in discriminator mode: the discriminator field has been read by readWithDiscriminator.
+              // Consume remaining fields (if any) and the closing } of the outer object.
+              Log.info(s"Using singleton for inline child $childName") >>
+                MIO.pure { (typeNameExpr: Expr[String], readerExpr: Expr[JsonReader], elseExpr: Expr[A]) =>
+                  Expr.quote {
+                    if (
+                      JsoniterDerivationUtils.mapEnumName(
+                        Expr.splice(dctx.config),
+                        Expr.splice(Expr(childName)),
+                        Expr.splice(Expr(Type[A].isJavaEnum))
+                      ) == Expr
+                        .splice(typeNameExpr)
+                    ) {
+                      JsoniterDerivationUtils.skipInlineObjectRemainder(Expr.splice(readerExpr))
+                      Expr.splice(singleton).asInstanceOf[A]
+                    } else
+                      Expr.splice(elseExpr)
+                  }
+                }
+            case None =>
+              // Non-singleton, non-case-class: fall back to wrapper-style decoder
+              deriveChildDecoder[A, ChildType](childName)
+          }
       }
     }
 

--- a/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/runtime/JsoniterDerivationUtils.scala
+++ b/jsoniter-derivation/src/main/scala/hearth/kindlings/jsoniterderivation/internal/runtime/JsoniterDerivationUtils.scala
@@ -177,6 +177,24 @@ object JsoniterDerivationUtils {
     if (!in.isNextToken('}'.toByte)) in.decodeError("expected '}'")
   }
 
+  /** Skip remaining fields and consume closing } of an already-opened inline object (e.g., after the discriminator
+    * field was consumed). For singletons in discriminator mode, there are no expected fields — any remaining fields are
+    * skipped.
+    */
+  @scala.annotation.nowarn("msg=unused value|discarded non-Unit")
+  def skipInlineObjectRemainder(in: JsonReader): Unit =
+    if (in.isNextToken(','.toByte)) {
+      in.readKeyAsString()
+      in.skip()
+      while (in.isNextToken(','.toByte)) {
+        in.readKeyAsString()
+        in.skip()
+      }
+      if (!in.isCurrentToken('}'.toByte)) in.decodeError("expected '}' or ','")
+    } else {
+      if (!in.isCurrentToken('}'.toByte)) in.decodeError("expected '}'")
+    }
+
   def readObject[A](
       in: JsonReader,
       fieldCount: Int,

--- a/jsoniter-derivation/src/test/scala-3/hearth/kindlings/jsoniterderivation/JsoniterScala3Spec.scala
+++ b/jsoniter-derivation/src/test/scala-3/hearth/kindlings/jsoniterderivation/JsoniterScala3Spec.scala
@@ -134,6 +134,20 @@ final class JsoniterScala3Spec extends MacroSuite {
       assert(json.contains("\"_type\""))
       readFromString[JsoniterVehicle](json)(codec) ==> car
     }
+
+    test("simple enum (case objects) wrapper-mode round-trip (#196)") {
+      val codec = KindlingsJsonValueCodec.derived[Color]
+      for c <- Color.values do {
+        val json = writeToString(c: Color)(codec)
+        readFromString[Color](json)(codec) ==> c
+      }
+    }
+
+    test("simple enum wrapper-mode produces correct JSON (#196)") {
+      val codec = KindlingsJsonValueCodec.derived[Color]
+      val json = writeToString(Color.Red: Color)(codec)
+      json ==> """{"Red":{}}"""
+    }
   }
 
   group("companion object given derivation") {

--- a/jsoniter-derivation/src/test/scala/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecSpec.scala
+++ b/jsoniter-derivation/src/test/scala/hearth/kindlings/jsoniterderivation/KindlingsJsonValueCodecSpec.scala
@@ -330,6 +330,58 @@ final class KindlingsJsonValueCodecSpec extends MacroSuite {
         val decoded = readFromString[Animal](json)(codec)
         decoded ==> value
       }
+
+      test("case-object-only sealed trait wrapper-mode round-trip (#196)") {
+        val codec = KindlingsJsonValueCodec.derived[CardinalDirection]
+        List[CardinalDirection](North, South, East, West).foreach { dir =>
+          val json = writeToString[CardinalDirection](dir)(codec)
+          val decoded = readFromString[CardinalDirection](json)(codec)
+          decoded ==> dir
+        }
+      }
+
+      test("case-object-only sealed trait wrapper-mode produces correct JSON (#196)") {
+        val codec = KindlingsJsonValueCodec.derived[CardinalDirection]
+        val json = writeToString[CardinalDirection](North)(codec)
+        json ==> """{"North":{}}"""
+      }
+
+      test("mixed enum wrapper-mode case object round-trip (#196)") {
+        val codec = KindlingsJsonValueCodec.derived[MixedEnum]
+        val pending: MixedEnum = Pending
+        val json = writeToString(pending)(codec)
+        json ==> """{"Pending":{}}"""
+        val decoded = readFromString[MixedEnum](json)(codec)
+        decoded ==> pending
+      }
+
+      test("mixed enum wrapper-mode case class round-trip") {
+        val codec = KindlingsJsonValueCodec.derived[MixedEnum]
+        val inProgress: MixedEnum = InProgress(75)
+        val json = writeToString(inProgress)(codec)
+        val decoded = readFromString[MixedEnum](json)(codec)
+        decoded ==> inProgress
+      }
+
+      test("mixed enum wrapper-mode all cases round-trip (#196)") {
+        val codec = KindlingsJsonValueCodec.derived[MixedEnum]
+        val cases: List[MixedEnum] = List(Pending, Done, InProgress(50))
+        cases.foreach { c =>
+          val json = writeToString(c)(codec)
+          val decoded = readFromString[MixedEnum](json)(codec)
+          decoded ==> c
+        }
+      }
+
+      test("case-object-only sealed trait discriminator-mode round-trip") {
+        implicit val config: JsoniterConfig = JsoniterConfig(discriminatorFieldName = Some("type"))
+        val codec = KindlingsJsonValueCodec.derived[CardinalDirection]
+        List[CardinalDirection](North, South, East, West).foreach { dir =>
+          val json = writeToString[CardinalDirection](dir)(codec)
+          val decoded = readFromString[CardinalDirection](json)(codec)
+          decoded ==> dir
+        }
+      }
     }
 
     group("string enum encoding (enumAsStrings)") {

--- a/ubjson-derivation/src/test/scala/hearth/kindlings/ubjsonderivation/UBJsonValueCodecSpec.scala
+++ b/ubjson-derivation/src/test/scala/hearth/kindlings/ubjsonderivation/UBJsonValueCodecSpec.scala
@@ -162,6 +162,29 @@ final class UBJsonValueCodecSpec extends MacroSuite {
         val inProgress: MixedEnum = InProgress(50)
         roundTrip(inProgress)(codec) ==> inProgress
       }
+
+      test("case-object-only sealed trait wrapper-mode all values round-trip (#196)") {
+        val codec = UBJsonValueCodec.derived[CardinalDirection]
+        List[CardinalDirection](North, South, East, West).foreach { dir =>
+          roundTrip(dir)(codec) ==> dir
+        }
+      }
+
+      test("mixed enum wrapper-mode all cases round-trip (#196)") {
+        val codec = UBJsonValueCodec.derived[MixedEnum]
+        val cases: List[MixedEnum] = List(Pending, Done, InProgress(50))
+        cases.foreach { c =>
+          roundTrip(c)(codec) ==> c
+        }
+      }
+
+      test("case-object-only sealed trait discriminator-mode round-trip") {
+        implicit val config: UBJsonConfig = UBJsonConfig().withDiscriminator("type")
+        val codec = UBJsonValueCodec.derived[CardinalDirection]
+        List[CardinalDirection](North, South, East, West).foreach { dir =>
+          roundTrip(dir)(codec) ==> dir
+        }
+      }
     }
 
     group("generic types") {


### PR DESCRIPTION
## Summary

- Encoder writes inner `{}` for singletons but decoder didn't consume it — added `readEmptyObject(reader)` in wrapper mode
- Fixed discriminator mode too — singletons now call `skipInlineObjectRemainder(reader)` instead of falling through to `deriveChildDecoder`
- Added `skipInlineObjectRemainder` runtime utility for consuming remaining fields of an already-opened inline object
- ubjson confirmed NOT affected (symmetric no-op on both sides)

## Test plan

- [x] 6 new round-trip tests in `KindlingsJsonValueCodecSpec` (wrapper + discriminator modes, pure case-object + mixed enums)
- [x] 2 new Scala 3 enum round-trip tests in `JsoniterScala3Spec`
- [x] 3 new ubjson regression tests in `UBJsonValueCodecSpec`
- [x] All existing tests pass on both Scala 2.13 and 3

Closes #196