### PR TITLE
Test hearth snapshot with metaspace leak fix

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -187,7 +187,8 @@ val dependencies = Seq(
       compilerPlugin("org.typelevel" % "kind-projector" % versions.kindProjector cross CrossVersion.full)
     )
   ),
-  resolvers += Resolver.mavenLocal
+  resolvers += Resolver.mavenLocal,
+  resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
 )
 
 val publishSettings = Seq(
@@ -557,7 +558,8 @@ lazy val jsoniterJson = projectMatrix
         compilerPlugin("org.typelevel" % "kind-projector" % versions.kindProjector cross CrossVersion.full)
       )
     ),
-    resolvers += Resolver.mavenLocal
+    resolvers += Resolver.mavenLocal,
+    resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/"
   )
 
 lazy val ubjsonDerivation = projectMatrix
@@ -996,6 +998,7 @@ lazy val benchmarks = projectMatrix
     description := "JMH benchmarks comparing Kindlings derivation against original library derivation",
     scalacOptions --= Seq("-Werror", "-Xfatal-warnings", "-Xcheck-macros"),
     resolvers += Resolver.mavenLocal,
+    resolvers += "Sonatype Central Snapshots" at "https://central.sonatype.com/repository/maven-snapshots/",
     libraryDependencies ++= Seq(
       "io.circe" %% "circe-parser" % versions.circe,
       "io.circe" %% "circe-generic" % versions.circe,

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -19,7 +19,7 @@ object versions {
   val platforms = List(VirtualAxis.jvm, VirtualAxis.js, VirtualAxis.native)
 
   // Dependencies.
-  val hearth = "0.4.1"
+  val hearth = "0.4.1-17-g5febe81-SNAPSHOT"
   val kindProjector = "0.13.4"
   val avro = "1.12.2"
   val avro4s213 = "4.1.2"


### PR DESCRIPTION
## Summary

- Bumps hearth to `0.4.1-17-g5febe81-SNAPSHOT` which includes the fix for kubuszok/hearth#377 (WeakHashMap value→key retention in `platformSpecificServiceLoader` causing metaspace leak in persistent sbt sessions)
- Adds Sonatype Central Snapshots resolver to resolve the snapshot artifact

Ref: #199

## Test plan

- [x] CI builds and tests pass with the snapshot dependency