### PR TITLE
Post-release 0.3.2: bump MiMa, Scala 3.9.0, pin 3.9.x

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -1,0 +1,14 @@
+# Scala 3 compiler/stdlib: pin to the 3.9.x line. Patch bumps (3.9.0 → 3.9.1) are welcome;
+# cross-minor bumps (3.9.x → 3.10.x) are not — those are managed manually.
+#
+# This pins the whole org.scala-lang group, which also blocks Scala 2.13 compiler PRs.
+# That is intentional: 2.13 bumps are managed by hand (same as hearth).
+#
+# NOTE: per-artifact pins leak (hearth#297) — suffixed artifacts like scala3-library_sjs1_3
+# slip past a pin on scala3-library_sjs1. Pinning the whole group avoids this.
+updates.pin = [
+  { groupId = "org.scala-lang", version = "3.9." }
+]
+pullRequests.grouping = [
+  { name = "scala-versions", title = "Scala compiler updates", filter = [{ group = "org.scala-lang" }, { group = "org.scoverage" }] }
+]

--- a/build.sbt
+++ b/build.sbt
@@ -116,6 +116,7 @@ val settings = Seq(
       "-language:implicitConversions", // hearth Type.Lazy[A] => Type[A] unwrapping at use-sites
       "-Wconf:msg=Unreachable case:s", // suppress fake (?) errors in internal.compiletime
       "-Wconf:msg=Missing symbol position:s", // suppress warning https://github.com/scala/scala3/issues/21672
+      "-Wconf:msg=Skipping coverage instrumentation:s", // Scala 3.9+ warns about large method bodies; not actionable for macro-generated code
       "-Werror",
       "-Wnonunit-statement",
       // "-Wunused:imports", // import x.Underlying as X is marked as unused even though it is! probably one of https://github.com/scala/scala3/issues/: #18564, #19252, #19657, #19912

--- a/build.sbt
+++ b/build.sbt
@@ -65,7 +65,7 @@ val nativeEvictionWarn = List(
 // macro providers/traits users mix into their bundles, so the same nested-vs-top-level rule as Hearth applies
 // (see docs/contributing/binary-compatibility-and-mixins.md in hearth): only members added inside a NESTED
 // scope may be filtered here, each with a justification. Bump this on every release.
-val mimaPreviousVersion = "0.3.1"
+val mimaPreviousVersion = "0.3.2"
 
 val mimaSettings = Seq(
   // Applied to every module via `settings`, but only PUBLISHED, JVM cells that already existed at 0.3.0 get a

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -12,7 +12,7 @@ import sbt.VirtualAxis
 object versions {
   // Versions we are publishing for.
   val scala213 = "2.13.18"
-  val scala3 = "3.8.4"
+  val scala3 = "3.9.0"
 
   // Which versions should be cross-compiled for publishing.
   val scalas = List(scala213, scala3)


### PR DESCRIPTION
## Summary

- Bump MiMa baseline from 0.3.1 to 0.3.2 (just released)
- Bump Scala 3 from 3.8.4 to 3.9.0
- Add `.scala-steward.conf` pinning `org.scala-lang` to 3.9.x — allows patch bumps (3.9.0 → 3.9.1), blocks cross-minor (3.9.x → 3.10.x); Scala 2.13 stays managed by hand